### PR TITLE
Add non-programming languages back into languages.csv

### DIFF
--- a/data/languages.csv
+++ b/data/languages.csv
@@ -223,8 +223,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 202,Tcl,programming,AU,2020,1
 197,sed,programming,AU,2020,1
 185,NSIS,programming,AU,2020,1
-159,Elixir,programming,AU,2020,1
 159,Clojure,programming,AU,2020,1
+159,Elixir,programming,AU,2020,1
 151,Cuda,programming,AU,2020,1
 140,Raku,programming,AU,2020,1
 139,Rebol,programming,AU,2020,1
@@ -237,8 +237,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,Prolog,programming,AU,2020,1
 124,Julia,programming,AU,2020,1
 123,Mako,programming,AU,2020,1
-122,VBScript,programming,AU,2020,1
 122,Processing,programming,AU,2020,1
+122,VBScript,programming,AU,2020,1
 119,Common Lisp,programming,AU,2020,1
 115,Puppet,programming,AU,2020,1
 113,FreeMarker,programming,AU,2020,1
@@ -350,17 +350,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 173,Dart,programming,BE,2020,1
 162,PLpgSQL,programming,BE,2020,1
 158,ShaderLab,programming,BE,2020,1
-145,Emacs Lisp,programming,BE,2020,1
 145,HLSL,programming,BE,2020,1
-132,HCL,programming,BE,2020,1
+145,Emacs Lisp,programming,BE,2020,1
 132,Awk,programming,BE,2020,1
+132,HCL,programming,BE,2020,1
 124,Tcl,programming,BE,2020,1
 123,Fortran,programming,BE,2020,1
 111,Pascal,programming,BE,2020,1
 110,PLSQL,programming,BE,2020,1
 105,Elixir,programming,BE,2020,1
-101,NSIS,programming,BE,2020,1
 101,Yacc,programming,BE,2020,1
+101,NSIS,programming,BE,2020,1
 4901,HTML,markup,BG,2020,1
 4151,CSS,markup,BG,2020,1
 325,Vue,markup,BG,2020,1
@@ -389,8 +389,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 164,PLpgSQL,programming,BG,2020,1
 153,Perl,programming,BG,2020,1
 152,Swift,programming,BG,2020,1
-146,Kotlin,programming,BG,2020,1
 146,Smarty,programming,BG,2020,1
+146,Kotlin,programming,BG,2020,1
 119,Assembly,programming,BG,2020,1
 106,XSLT,programming,BG,2020,1
 101,Lua,programming,BG,2020,1
@@ -447,8 +447,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1588,R,programming,BR,2020,1
 1533,Vim Script,programming,BR,2020,1
 1204,Perl,programming,BR,2020,1
-1123,Assembly,programming,BR,2020,1
 1123,Gherkin,programming,BR,2020,1
+1123,Assembly,programming,BR,2020,1
 963,CoffeeScript,programming,BR,2020,1
 906,Lua,programming,BR,2020,1
 882,ShaderLab,programming,BR,2020,1
@@ -504,8 +504,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,Verilog,programming,BR,2020,1
 133,Gnuplot,programming,BR,2020,1
 130,GDB,programming,BR,2020,1
-126,PureBasic,programming,BR,2020,1
 126,Rebol,programming,BR,2020,1
+126,PureBasic,programming,BR,2020,1
 125,Julia,programming,BR,2020,1
 117,SWIG,programming,BR,2020,1
 116,Standard ML,programming,BR,2020,1
@@ -645,8 +645,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 223,ANTLR,programming,CA,2020,1
 222,Visual Basic .NET,programming,CA,2020,1
 219,AppleScript,programming,CA,2020,1
-217,D,programming,CA,2020,1
 217,SWIG,programming,CA,2020,1
+217,D,programming,CA,2020,1
 217,Prolog,programming,CA,2020,1
 216,DIGITAL Command Language,programming,CA,2020,1
 210,Rebol,programming,CA,2020,1
@@ -746,9 +746,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 182,Nix,programming,CH,2020,1
 172,ShaderLab,programming,CH,2020,1
 166,Dart,programming,CH,2020,1
-159,GDB,programming,CH,2020,1
-159,M,programming,CH,2020,1
 159,HLSL,programming,CH,2020,1
+159,M,programming,CH,2020,1
+159,GDB,programming,CH,2020,1
 158,Scheme,programming,CH,2020,1
 157,VHDL,programming,CH,2020,1
 154,Mako,programming,CH,2020,1
@@ -890,8 +890,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 555,M,programming,CN,2020,1
 553,SmPL,programming,CN,2020,1
 504,Pawn,programming,CN,2020,1
-459,Haskell,programming,CN,2020,1
 459,UnrealScript,programming,CN,2020,1
+459,Haskell,programming,CN,2020,1
 433,PureBasic,programming,CN,2020,1
 427,HCL,programming,CN,2020,1
 424,DTrace,programming,CN,2020,1
@@ -933,8 +933,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 183,Metal,programming,CN,2020,1
 178,Elixir,programming,CN,2020,1
 175,WebAssembly,programming,CN,2020,1
-174,HiveQL,programming,CN,2020,1
 174,Brainfuck,programming,CN,2020,1
+174,HiveQL,programming,CN,2020,1
 166,Processing,programming,CN,2020,1
 160,Stata,programming,CN,2020,1
 158,NASL,programming,CN,2020,1
@@ -1032,8 +1032,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 372,JavaScript,programming,CY,2020,1
 231,Shell,programming,CY,2020,1
 212,Python,programming,CY,2020,1
-124,Java,programming,CY,2020,1
 124,Dockerfile,programming,CY,2020,1
+124,Java,programming,CY,2020,1
 112,PHP,programming,CY,2020,1
 109,Makefile,programming,CY,2020,1
 7374,HTML,markup,CZ,2020,1
@@ -1088,8 +1088,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 167,sed,programming,CZ,2020,1
 157,PLSQL,programming,CZ,2020,1
 146,Tcl,programming,CZ,2020,1
-145,Objective-C++,programming,CZ,2020,1
 145,HCL,programming,CZ,2020,1
+145,Objective-C++,programming,CZ,2020,1
 133,Pascal,programming,CZ,2020,1
 129,Smalltalk,programming,CZ,2020,1
 124,FreeMarker,programming,CZ,2020,1
@@ -1178,8 +1178,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 602,SWIG,programming,DE,2020,1
 597,Julia,programming,DE,2020,1
 592,Gnuplot,programming,DE,2020,1
-575,FreeMarker,programming,DE,2020,1
 575,Prolog,programming,DE,2020,1
+575,FreeMarker,programming,DE,2020,1
 573,GAP,programming,DE,2020,1
 570,Meson,programming,DE,2020,1
 556,Inno Setup,programming,DE,2020,1
@@ -1217,8 +1217,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 273,GDScript,programming,DE,2020,1
 252,NASL,programming,DE,2020,1
 246,VHDL,programming,DE,2020,1
-235,RenderScript,programming,DE,2020,1
 235,Xtend,programming,DE,2020,1
+235,RenderScript,programming,DE,2020,1
 227,SourcePawn,programming,DE,2020,1
 217,Elm,programming,DE,2020,1
 217,G-code,programming,DE,2020,1
@@ -1502,8 +1502,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 191,Processing,programming,ES,2020,1
 177,SQLPL,programming,ES,2020,1
 176,Elixir,programming,ES,2020,1
-172,Clojure,programming,ES,2020,1
 172,Visual Basic .NET,programming,ES,2020,1
+172,Clojure,programming,ES,2020,1
 171,Mako,programming,ES,2020,1
 160,ANTLR,programming,ES,2020,1
 156,SWIG,programming,ES,2020,1
@@ -1528,6 +1528,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 167,Go,programming,ET,2020,1
 143,C#,programming,ET,2020,1
 111,Shell,programming,ET,2020,1
+306614,HTML,markup,EU,2020,1
+258180,CSS,markup,EU,2020,1
+32950,Jupyter Notebook,markup,EU,2020,1
+21075,Vue,markup,EU,2020,1
+17314,TeX,markup,EU,2020,1
+15023,Roff,markup,EU,2020,1
+4064,Rich Text Format,markup,EU,2020,1
+1233,PostScript,markup,EU,2020,1
+1210,Vim Snippet,markup,EU,2020,1
+134,YASnippet,markup,EU,2020,1
+103,API Blueprint,markup,EU,2020,1
 264862,JavaScript,programming,EU,2020,1
 165365,Python,programming,EU,2020,1
 157258,Shell,programming,EU,2020,1
@@ -1590,8 +1601,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1960,SQLPL,programming,EU,2020,1
 1946,Elixir,programming,EU,2020,1
 1804,GDB,programming,EU,2020,1
-1780,Nix,programming,EU,2020,1
 1780,Raku,programming,EU,2020,1
+1780,Nix,programming,EU,2020,1
 1745,Prolog,programming,EU,2020,1
 1676,FreeMarker,programming,EU,2020,1
 1620,Processing,programming,EU,2020,1
@@ -1657,8 +1668,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 163,SaltStack,programming,EU,2020,1
 157,BitBake,programming,EU,2020,1
 155,Jsonnet,programming,EU,2020,1
-154,Jasmin,programming,EU,2020,1
 154,AutoHotkey,programming,EU,2020,1
+154,Jasmin,programming,EU,2020,1
 144,NewLisp,programming,EU,2020,1
 141,Vala,programming,EU,2020,1
 139,AGS Script,programming,EU,2020,1
@@ -1675,8 +1686,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,IDL,programming,EU,2020,1
 108,AspectJ,programming,EU,2020,1
 108,EmberScript,programming,EU,2020,1
-106,Nim,programming,EU,2020,1
 106,Brainfuck,programming,EU,2020,1
+106,Nim,programming,EU,2020,1
 102,SQF,programming,EU,2020,1
 101,Ragel,programming,EU,2020,1
 8156,HTML,markup,FI,2020,1
@@ -1808,8 +1819,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 445,SQLPL,programming,FR,2020,1
 426,Scheme,programming,FR,2020,1
 399,GAP,programming,FR,2020,1
-396,Mako,programming,FR,2020,1
 396,Mathematica,programming,FR,2020,1
+396,Mako,programming,FR,2020,1
 391,Nix,programming,FR,2020,1
 379,Inno Setup,programming,FR,2020,1
 371,Raku,programming,FR,2020,1
@@ -1843,12 +1854,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 188,Visual Basic .NET,programming,FR,2020,1
 181,GDScript,programming,FR,2020,1
 176,Scilab,programming,FR,2020,1
-175,DTrace,programming,FR,2020,1
 175,Verilog,programming,FR,2020,1
+175,DTrace,programming,FR,2020,1
 165,XS,programming,FR,2020,1
 164,Puppet,programming,FR,2020,1
-163,LLVM,programming,FR,2020,1
 163,PureBasic,programming,FR,2020,1
+163,LLVM,programming,FR,2020,1
 162,OpenSCAD,programming,FR,2020,1
 161,G-code,programming,FR,2020,1
 153,Xtend,programming,FR,2020,1
@@ -1861,8 +1872,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 129,RenderScript,programming,FR,2020,1
 123,Crystal,programming,FR,2020,1
 118,NASL,programming,FR,2020,1
-111,SourcePawn,programming,FR,2020,1
 111,ActionScript,programming,FR,2020,1
+111,SourcePawn,programming,FR,2020,1
 104,SAS,programming,FR,2020,1
 101,OpenEdge ABL,programming,FR,2020,1
 61798,HTML,markup,GB,2020,1
@@ -1937,8 +1948,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 614,Cuda,programming,GB,2020,1
 609,Raku,programming,GB,2020,1
 527,GDB,programming,GB,2020,1
-509,Nix,programming,GB,2020,1
 509,Mako,programming,GB,2020,1
+509,Nix,programming,GB,2020,1
 483,NSIS,programming,GB,2020,1
 480,Common Lisp,programming,GB,2020,1
 465,F#,programming,GB,2020,1
@@ -1957,8 +1968,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 354,AppleScript,programming,GB,2020,1
 353,Processing,programming,GB,2020,1
 350,Visual Basic .NET,programming,GB,2020,1
-349,Forth,programming,GB,2020,1
 349,GAP,programming,GB,2020,1
+349,Forth,programming,GB,2020,1
 342,Inno Setup,programming,GB,2020,1
 335,DTrace,programming,GB,2020,1
 328,VBScript,programming,GB,2020,1
@@ -1986,16 +1997,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,Thrift,programming,GB,2020,1
 164,Cycript,programming,GB,2020,1
 162,Ada,programming,GB,2020,1
-161,Jsonnet,programming,GB,2020,1
 161,OpenEdge ABL,programming,GB,2020,1
+161,Jsonnet,programming,GB,2020,1
 158,GDScript,programming,GB,2020,1
 156,VHDL,programming,GB,2020,1
 153,SourcePawn,programming,GB,2020,1
 152,Mercury,programming,GB,2020,1
 146,AMPL,programming,GB,2020,1
 145,Module Management System,programming,GB,2020,1
-143,PureBasic,programming,GB,2020,1
 143,SystemVerilog,programming,GB,2020,1
+143,PureBasic,programming,GB,2020,1
 141,VCL,programming,GB,2020,1
 138,ActionScript,programming,GB,2020,1
 135,G-code,programming,GB,2020,1
@@ -2006,10 +2017,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,SAS,programming,GB,2020,1
 116,AngelScript,programming,GB,2020,1
 115,AutoHotkey,programming,GB,2020,1
-110,Solidity,programming,GB,2020,1
 110,IDL,programming,GB,2020,1
-109,Apex,programming,GB,2020,1
+110,Solidity,programming,GB,2020,1
 109,Cool,programming,GB,2020,1
+109,Apex,programming,GB,2020,1
 107,PureScript,programming,GB,2020,1
 106,Arc,programming,GB,2020,1
 104,Max,programming,GB,2020,1
@@ -2079,8 +2090,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 146,Kotlin,programming,GR,2020,1
 134,Hack,programming,GR,2020,1
 109,GLSL,programming,GR,2020,1
-108,M4,programming,GR,2020,1
 108,Swift,programming,GR,2020,1
+108,M4,programming,GR,2020,1
 105,Lua,programming,GR,2020,1
 1395,HTML,markup,GT,2020,1
 1091,CSS,markup,GT,2020,1
@@ -2522,8 +2533,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 296,DIGITAL Command Language,programming,IN,2020,1
 286,F#,programming,IN,2020,1
 284,SWIG,programming,IN,2020,1
-282,VBScript,programming,IN,2020,1
 282,Scheme,programming,IN,2020,1
+282,VBScript,programming,IN,2020,1
 277,NSIS,programming,IN,2020,1
 276,M,programming,IN,2020,1
 266,GAP,programming,IN,2020,1
@@ -2554,8 +2565,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,Crystal,programming,IN,2020,1
 143,OpenEdge ABL,programming,IN,2020,1
 143,Nim,programming,IN,2020,1
-140,SystemVerilog,programming,IN,2020,1
 140,PureScript,programming,IN,2020,1
+140,SystemVerilog,programming,IN,2020,1
 138,Jsonnet,programming,IN,2020,1
 132,VHDL,programming,IN,2020,1
 131,HiveQL,programming,IN,2020,1
@@ -2607,8 +2618,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,Makefile,programming,IS,2020,1
 131,C#,programming,IS,2020,1
 129,C++,programming,IS,2020,1
-110,TypeScript,programming,IS,2020,1
 110,Dockerfile,programming,IS,2020,1
+110,TypeScript,programming,IS,2020,1
 14940,HTML,markup,IT,2020,1
 12705,CSS,markup,IT,2020,1
 1998,Jupyter Notebook,markup,IT,2020,1
@@ -2665,8 +2676,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 239,Objective-C++,programming,IT,2020,1
 235,Tcl,programming,IT,2020,1
 213,Gherkin,programming,IT,2020,1
-199,sed,programming,IT,2020,1
 199,Starlark,programming,IT,2020,1
+199,sed,programming,IT,2020,1
 198,Pascal,programming,IT,2020,1
 196,HCL,programming,IT,2020,1
 194,Cuda,programming,IT,2020,1
@@ -2680,9 +2691,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 150,FreeMarker,programming,IT,2020,1
 143,ANTLR,programming,IT,2020,1
 138,Clojure,programming,IT,2020,1
+137,Raku,programming,IT,2020,1
 137,Haskell,programming,IT,2020,1
 137,GDB,programming,IT,2020,1
-137,Raku,programming,IT,2020,1
 130,Scheme,programming,IT,2020,1
 122,VHDL,programming,IT,2020,1
 120,M,programming,IT,2020,1
@@ -2728,8 +2739,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 5343,Batchfile,programming,JP,2020,1
 4965,CoffeeScript,programming,JP,2020,1
 4843,Go,programming,JP,2020,1
-4041,Vim Script,programming,JP,2020,1
 4041,Objective-C,programming,JP,2020,1
+4041,Vim Script,programming,JP,2020,1
 3023,CMake,programming,JP,2020,1
 2992,Swift,programming,JP,2020,1
 2667,TSQL,programming,JP,2020,1
@@ -2788,11 +2799,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 199,Gnuplot,programming,JP,2020,1
 190,Pawn,programming,JP,2020,1
 181,XS,programming,JP,2020,1
-174,FreeMarker,programming,JP,2020,1
 174,Verilog,programming,JP,2020,1
+174,FreeMarker,programming,JP,2020,1
 173,Prolog,programming,JP,2020,1
-168,Mako,programming,JP,2020,1
 168,AppleScript,programming,JP,2020,1
+168,Mako,programming,JP,2020,1
 164,DIGITAL Command Language,programming,JP,2020,1
 162,DTrace,programming,JP,2020,1
 159,Erlang,programming,JP,2020,1
@@ -2802,8 +2813,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 146,Scilab,programming,JP,2020,1
 143,ANTLR,programming,JP,2020,1
 143,SQLPL,programming,JP,2020,1
-142,Standard ML,programming,JP,2020,1
 142,F#,programming,JP,2020,1
+142,Standard ML,programming,JP,2020,1
 141,AutoHotkey,programming,JP,2020,1
 130,LLVM,programming,JP,2020,1
 127,SystemVerilog,programming,JP,2020,1
@@ -3205,8 +3216,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,PLSQL,programming,MX,2020,1
 128,Gherkin,programming,MX,2020,1
 123,Elixir,programming,MX,2020,1
-119,Lua,programming,MX,2020,1
 119,Scala,programming,MX,2020,1
+119,Lua,programming,MX,2020,1
 115,Emacs Lisp,programming,MX,2020,1
 110,Rust,programming,MX,2020,1
 106,HCL,programming,MX,2020,1
@@ -3227,8 +3238,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 600,Dockerfile,programming,MY,2020,1
 584,C++,programming,MY,2020,1
 547,C#,programming,MY,2020,1
-463,Makefile,programming,MY,2020,1
 463,C,programming,MY,2020,1
+463,Makefile,programming,MY,2020,1
 437,Swift,programming,MY,2020,1
 386,Dart,programming,MY,2020,1
 371,TSQL,programming,MY,2020,1
@@ -3313,8 +3324,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1010,ShaderLab,programming,NL,2020,1
 950,HLSL,programming,NL,2020,1
 901,Lua,programming,NL,2020,1
-881,XSLT,programming,NL,2020,1
 881,Swift,programming,NL,2020,1
+881,XSLT,programming,NL,2020,1
 760,GLSL,programming,NL,2020,1
 739,Smarty,programming,NL,2020,1
 734,MATLAB,programming,NL,2020,1
@@ -3336,8 +3347,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 341,Processing,programming,NL,2020,1
 336,Dart,programming,NL,2020,1
 306,Starlark,programming,NL,2020,1
-303,Pascal,programming,NL,2020,1
 303,Fortran,programming,NL,2020,1
+303,Pascal,programming,NL,2020,1
 302,Lex,programming,NL,2020,1
 290,PLSQL,programming,NL,2020,1
 273,NSIS,programming,NL,2020,1
@@ -3349,13 +3360,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 222,SQLPL,programming,NL,2020,1
 206,Clojure,programming,NL,2020,1
 197,Elixir,programming,NL,2020,1
-190,FreeMarker,programming,NL,2020,1
 190,Raku,programming,NL,2020,1
+190,FreeMarker,programming,NL,2020,1
 184,GDB,programming,NL,2020,1
 181,ANTLR,programming,NL,2020,1
 177,Cuda,programming,NL,2020,1
-177,SWIG,programming,NL,2020,1
 177,QML,programming,NL,2020,1
+177,SWIG,programming,NL,2020,1
 167,Mako,programming,NL,2020,1
 164,Prolog,programming,NL,2020,1
 157,DIGITAL Command Language,programming,NL,2020,1
@@ -3365,8 +3376,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 145,Inno Setup,programming,NL,2020,1
 143,Julia,programming,NL,2020,1
 137,Pawn,programming,NL,2020,1
-132,GAP,programming,NL,2020,1
 132,Erlang,programming,NL,2020,1
+132,GAP,programming,NL,2020,1
 127,F#,programming,NL,2020,1
 125,VBScript,programming,NL,2020,1
 123,AppleScript,programming,NL,2020,1
@@ -3427,8 +3438,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 143,Scala,programming,NO,2020,1
 142,HLSL,programming,NO,2020,1
 136,PLpgSQL,programming,NO,2020,1
-127,Gherkin,programming,NO,2020,1
 127,Awk,programming,NO,2020,1
+127,Gherkin,programming,NO,2020,1
 126,CoffeeScript,programming,NO,2020,1
 124,Yacc,programming,NO,2020,1
 119,Tcl,programming,NO,2020,1
@@ -3654,8 +3665,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 656,GLSL,programming,PL,2020,1
 651,Scala,programming,PL,2020,1
 573,M4,programming,PL,2020,1
-566,XSLT,programming,PL,2020,1
 566,Rust,programming,PL,2020,1
+566,XSLT,programming,PL,2020,1
 553,PLpgSQL,programming,PL,2020,1
 544,Dart,programming,PL,2020,1
 543,Gherkin,programming,PL,2020,1
@@ -3677,8 +3688,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 238,Fortran,programming,PL,2020,1
 237,SQLPL,programming,PL,2020,1
 223,Elixir,programming,PL,2020,1
-218,Cuda,programming,PL,2020,1
 218,Prolog,programming,PL,2020,1
+218,Cuda,programming,PL,2020,1
 172,Erlang,programming,PL,2020,1
 164,Mako,programming,PL,2020,1
 162,Clojure,programming,PL,2020,1
@@ -3695,10 +3706,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,Julia,programming,PL,2020,1
 113,Rebol,programming,PL,2020,1
 112,Scheme,programming,PL,2020,1
-111,GAP,programming,PL,2020,1
 111,Inno Setup,programming,PL,2020,1
-107,GDScript,programming,PL,2020,1
+111,GAP,programming,PL,2020,1
 107,VBScript,programming,PL,2020,1
+107,GDScript,programming,PL,2020,1
 368,HTML,markup,PR,2020,1
 315,CSS,markup,PR,2020,1
 315,JavaScript,programming,PR,2020,1
@@ -3761,8 +3772,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,M4,programming,PT,2020,1
 116,Haskell,programming,PT,2020,1
 112,Lex,programming,PT,2020,1
-110,Awk,programming,PT,2020,1
 110,Gherkin,programming,PT,2020,1
+110,Awk,programming,PT,2020,1
 110,Yacc,programming,PT,2020,1
 105,PLSQL,programming,PT,2020,1
 104,Emacs Lisp,programming,PT,2020,1
@@ -3824,8 +3835,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 159,ShaderLab,programming,RO,2020,1
 157,Dart,programming,RO,2020,1
 152,Groovy,programming,RO,2020,1
-149,PLpgSQL,programming,RO,2020,1
 149,Tcl,programming,RO,2020,1
+149,PLpgSQL,programming,RO,2020,1
 147,PLSQL,programming,RO,2020,1
 141,Gherkin,programming,RO,2020,1
 135,Scala,programming,RO,2020,1
@@ -3928,8 +3939,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 623,MATLAB,programming,RU,2020,1
 577,Smalltalk,programming,RU,2020,1
 524,Tcl,programming,RU,2020,1
-523,HCL,programming,RU,2020,1
 523,Starlark,programming,RU,2020,1
+523,HCL,programming,RU,2020,1
 513,SQLPL,programming,RU,2020,1
 465,sed,programming,RU,2020,1
 459,FreeMarker,programming,RU,2020,1
@@ -3951,20 +3962,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 264,Scheme,programming,RU,2020,1
 250,Pawn,programming,RU,2020,1
 248,VBScript,programming,RU,2020,1
-237,XS,programming,RU,2020,1
 237,Mathematica,programming,RU,2020,1
+237,XS,programming,RU,2020,1
 221,D,programming,RU,2020,1
-218,Erlang,programming,RU,2020,1
 218,F#,programming,RU,2020,1
 218,DTrace,programming,RU,2020,1
+218,Erlang,programming,RU,2020,1
 214,SWIG,programming,RU,2020,1
 213,1C Enterprise,programming,RU,2020,1
 207,Nix,programming,RU,2020,1
 196,Visual Basic .NET,programming,RU,2020,1
 192,GAP,programming,RU,2020,1
 189,VBA,programming,RU,2020,1
-186,OCaml,programming,RU,2020,1
 186,Meson,programming,RU,2020,1
+186,OCaml,programming,RU,2020,1
 179,Forth,programming,RU,2020,1
 177,Gnuplot,programming,RU,2020,1
 173,SmPL,programming,RU,2020,1
@@ -3980,8 +3991,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,RenderScript,programming,RU,2020,1
 117,SAS,programming,RU,2020,1
 117,Standard ML,programming,RU,2020,1
-111,ActionScript,programming,RU,2020,1
 111,LLVM,programming,RU,2020,1
+111,ActionScript,programming,RU,2020,1
 106,GDScript,programming,RU,2020,1
 106,Ada,programming,RU,2020,1
 104,Julia,programming,RU,2020,1
@@ -4089,8 +4100,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,Pascal,programming,SE,2020,1
 150,PLSQL,programming,SE,2020,1
 139,F#,programming,SE,2020,1
-134,GDB,programming,SE,2020,1
 134,M,programming,SE,2020,1
+134,GDB,programming,SE,2020,1
 125,Scheme,programming,SE,2020,1
 121,Common Lisp,programming,SE,2020,1
 117,Julia,programming,SE,2020,1
@@ -4135,8 +4146,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 286,HCL,programming,SG,2020,1
 268,MATLAB,programming,SG,2020,1
 264,Groovy,programming,SG,2020,1
-252,XSLT,programming,SG,2020,1
 252,M4,programming,SG,2020,1
+252,XSLT,programming,SG,2020,1
 228,HLSL,programming,SG,2020,1
 227,ShaderLab,programming,SG,2020,1
 211,Hack,programming,SG,2020,1
@@ -4246,8 +4257,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 903,C,programming,TH,2020,1
 886,Hack,programming,TH,2020,1
 837,Kotlin,programming,TH,2020,1
-825,Makefile,programming,TH,2020,1
 825,TSQL,programming,TH,2020,1
+825,Makefile,programming,TH,2020,1
 594,Swift,programming,TH,2020,1
 593,Batchfile,programming,TH,2020,1
 542,Go,programming,TH,2020,1
@@ -4339,8 +4350,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Lex,programming,TR,2020,1
 117,Gherkin,programming,TR,2020,1
 110,Yacc,programming,TR,2020,1
-109,PLpgSQL,programming,TR,2020,1
 109,Objective-C++,programming,TR,2020,1
+109,PLpgSQL,programming,TR,2020,1
 102,Smalltalk,programming,TR,2020,1
 101,Pascal,programming,TR,2020,1
 168,HTML,markup,TT,2020,1
@@ -4665,8 +4676,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 344,ColdFusion,programming,US,2020,1
 343,PureScript,programming,US,2020,1
 343,VCL,programming,US,2020,1
-340,NCL,programming,US,2020,1
 340,Cap'n Proto,programming,US,2020,1
+340,NCL,programming,US,2020,1
 319,POV-Ray SDL,programming,US,2020,1
 317,BitBake,programming,US,2020,1
 313,Reason,programming,US,2020,1
@@ -4681,8 +4692,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 256,XQuery,programming,US,2020,1
 255,Open Policy Agent,programming,US,2020,1
 246,LabVIEW,programming,US,2020,1
-243,Io,programming,US,2020,1
 243,MAXScript,programming,US,2020,1
+243,Io,programming,US,2020,1
 226,Jasmin,programming,US,2020,1
 218,Nextflow,programming,US,2020,1
 209,AspectJ,programming,US,2020,1
@@ -4690,13 +4701,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 204,Objective-J,programming,US,2020,1
 196,nesC,programming,US,2020,1
 187,TLA,programming,US,2020,1
-183,Common Workflow Language,programming,US,2020,1
 183,eC,programming,US,2020,1
+183,Common Workflow Language,programming,US,2020,1
 175,LiveScript,programming,US,2020,1
 171,CartoCSS,programming,US,2020,1
 170,Clarion,programming,US,2020,1
-169,Harbour,programming,US,2020,1
 169,AutoIt,programming,US,2020,1
+169,Harbour,programming,US,2020,1
 168,E,programming,US,2020,1
 166,Slash,programming,US,2020,1
 157,CLIPS,programming,US,2020,1
@@ -4704,14 +4715,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,BlitzBasic,programming,US,2020,1
 144,Hy,programming,US,2020,1
 143,Isabelle,programming,US,2020,1
-142,Zig,programming,US,2020,1
 142,LilyPond,programming,US,2020,1
+142,Zig,programming,US,2020,1
 141,Rascal,programming,US,2020,1
 140,Ren'Py,programming,US,2020,1
 139,Modelica,programming,US,2020,1
 139,REXX,programming,US,2020,1
-137,Pike,programming,US,2020,1
 137,YARA,programming,US,2020,1
+137,Pike,programming,US,2020,1
 137,Zeek,programming,US,2020,1
 133,LSL,programming,US,2020,1
 132,Dhall,programming,US,2020,1
@@ -4719,19 +4730,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,NetLogo,programming,US,2020,1
 120,GCC Machine Description,programming,US,2020,1
 117,ObjectScript,programming,US,2020,1
-116,Xtend,programming,US,2020,1
 116,Agda,programming,US,2020,1
 116,mIRC Script,programming,US,2020,1
+116,Xtend,programming,US,2020,1
 114,Asymptote,programming,US,2020,1
-113,F*,programming,US,2020,1
 113,Clean,programming,US,2020,1
+113,F*,programming,US,2020,1
 111,Component Pascal,programming,US,2020,1
 110,FLUX,programming,US,2020,1
 109,Eiffel,programming,US,2020,1
 107,SQF,programming,US,2020,1
 106,J,programming,US,2020,1
-102,ChucK,programming,US,2020,1
 102,GAMS,programming,US,2020,1
+102,ChucK,programming,US,2020,1
 101,IGOR Pro,programming,US,2020,1
 1255,HTML,markup,UY,2020,1
 1063,CSS,markup,UY,2020,1
@@ -4747,8 +4758,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,Makefile,programming,UY,2020,1
 126,C++,programming,UY,2020,1
 125,TSQL,programming,UY,2020,1
-121,C,programming,UY,2020,1
 121,Objective-C,programming,UY,2020,1
+121,C,programming,UY,2020,1
 1502,HTML,markup,UZ,2020,1
 1254,CSS,markup,UZ,2020,1
 149,Vue,markup,UZ,2020,1
@@ -4809,8 +4820,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 732,Starlark,programming,VN,2020,1
 730,PowerShell,programming,VN,2020,1
 717,Dart,programming,VN,2020,1
-419,CMake,programming,VN,2020,1
 419,Perl,programming,VN,2020,1
+419,CMake,programming,VN,2020,1
 399,Assembly,programming,VN,2020,1
 377,Vim Script,programming,VN,2020,1
 366,CoffeeScript,programming,VN,2020,1
@@ -5129,8 +5140,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 172,Mathematica,programming,AU,2020,2
 169,Rebol,programming,AU,2020,2
 168,Clojure,programming,AU,2020,2
-164,F#,programming,AU,2020,2
 164,Elixir,programming,AU,2020,2
+164,F#,programming,AU,2020,2
 162,Processing,programming,AU,2020,2
 151,SQLPL,programming,AU,2020,2
 150,Inno Setup,programming,AU,2020,2
@@ -5141,8 +5152,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,FreeMarker,programming,AU,2020,2
 131,VBA,programming,AU,2020,2
 131,SWIG,programming,AU,2020,2
-122,M,programming,AU,2020,2
 122,Prolog,programming,AU,2020,2
+122,M,programming,AU,2020,2
 120,Common Lisp,programming,AU,2020,2
 119,ANTLR,programming,AU,2020,2
 112,DIGITAL Command Language,programming,AU,2020,2
@@ -5150,9 +5161,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Puppet,programming,AU,2020,2
 106,AppleScript,programming,AU,2020,2
 106,GAP,programming,AU,2020,2
-103,Elm,programming,AU,2020,2
-103,NASL,programming,AU,2020,2
 103,G-code,programming,AU,2020,2
+103,NASL,programming,AU,2020,2
+103,Elm,programming,AU,2020,2
 1405,HTML,markup,AZ,2020,2
 1118,CSS,markup,AZ,2020,2
 1036,JavaScript,programming,AZ,2020,2
@@ -5260,8 +5271,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,HLSL,programming,BE,2020,2
 156,Dart,programming,BE,2020,2
 155,ShaderLab,programming,BE,2020,2
-152,Emacs Lisp,programming,BE,2020,2
 152,Fortran,programming,BE,2020,2
+152,Emacs Lisp,programming,BE,2020,2
 141,Awk,programming,BE,2020,2
 140,Smalltalk,programming,BE,2020,2
 130,PLSQL,programming,BE,2020,2
@@ -5411,9 +5422,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 223,VHDL,programming,BR,2020,2
 222,FreeMarker,programming,BR,2020,2
 221,Raku,programming,BR,2020,2
-219,Visual Basic .NET,programming,BR,2020,2
-219,Cuda,programming,BR,2020,2
 219,Rebol,programming,BR,2020,2
+219,Cuda,programming,BR,2020,2
+219,Visual Basic .NET,programming,BR,2020,2
 216,Prolog,programming,BR,2020,2
 207,Scheme,programming,BR,2020,2
 203,NSIS,programming,BR,2020,2
@@ -5440,8 +5451,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 124,F#,programming,BR,2020,2
 119,NASL,programming,BR,2020,2
 118,Meson,programming,BR,2020,2
-113,SmPL,programming,BR,2020,2
 113,DIGITAL Command Language,programming,BR,2020,2
+113,SmPL,programming,BR,2020,2
 112,xBase,programming,BR,2020,2
 106,XS,programming,BR,2020,2
 104,AppleScript,programming,BR,2020,2
@@ -5477,11 +5488,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 237,Hack,programming,BY,2020,2
 204,QMake,programming,BY,2020,2
 190,Groovy,programming,BY,2020,2
-180,Perl,programming,BY,2020,2
 180,Smarty,programming,BY,2020,2
+180,Perl,programming,BY,2020,2
 167,XSLT,programming,BY,2020,2
-165,Lua,programming,BY,2020,2
 165,Gherkin,programming,BY,2020,2
+165,Lua,programming,BY,2020,2
 164,Pascal,programming,BY,2020,2
 163,Scala,programming,BY,2020,2
 154,Starlark,programming,BY,2020,2
@@ -5571,10 +5582,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 361,Processing,programming,CA,2020,2
 349,GDB,programming,CA,2020,2
 341,Julia,programming,CA,2020,2
-335,SQLPL,programming,CA,2020,2
 335,Common Lisp,programming,CA,2020,2
-306,Rebol,programming,CA,2020,2
+335,SQLPL,programming,CA,2020,2
 306,FreeMarker,programming,CA,2020,2
+306,Rebol,programming,CA,2020,2
 305,M,programming,CA,2020,2
 304,SWIG,programming,CA,2020,2
 294,Pawn,programming,CA,2020,2
@@ -5585,11 +5596,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 249,AppleScript,programming,CA,2020,2
 242,Verilog,programming,CA,2020,2
 241,ANTLR,programming,CA,2020,2
-228,Prolog,programming,CA,2020,2
 228,VBScript,programming,CA,2020,2
+228,Prolog,programming,CA,2020,2
+216,Meson,programming,CA,2020,2
 216,DTrace,programming,CA,2020,2
 216,D,programming,CA,2020,2
-216,Meson,programming,CA,2020,2
 208,Erlang,programming,CA,2020,2
 200,GDScript,programming,CA,2020,2
 195,OCaml,programming,CA,2020,2
@@ -5597,8 +5608,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,DIGITAL Command Language,programming,CA,2020,2
 176,Standard ML,programming,CA,2020,2
 171,Scilab,programming,CA,2020,2
-170,VHDL,programming,CA,2020,2
 170,LLVM,programming,CA,2020,2
+170,VHDL,programming,CA,2020,2
 168,QML,programming,CA,2020,2
 168,F#,programming,CA,2020,2
 163,Gnuplot,programming,CA,2020,2
@@ -5606,14 +5617,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,Logos,programming,CA,2020,2
 145,AutoHotkey,programming,CA,2020,2
 137,XS,programming,CA,2020,2
-134,SmPL,programming,CA,2020,2
 134,OpenSCAD,programming,CA,2020,2
+134,SmPL,programming,CA,2020,2
 133,Puppet,programming,CA,2020,2
 124,RenderScript,programming,CA,2020,2
 122,UnrealScript,programming,CA,2020,2
 121,G-code,programming,CA,2020,2
-119,Coq,programming,CA,2020,2
 119,Objective-J,programming,CA,2020,2
+119,Coq,programming,CA,2020,2
 117,SystemVerilog,programming,CA,2020,2
 116,Elm,programming,CA,2020,2
 115,Stata,programming,CA,2020,2
@@ -5621,11 +5632,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,SourcePawn,programming,CA,2020,2
 111,Jsonnet,programming,CA,2020,2
 109,AMPL,programming,CA,2020,2
-106,SAS,programming,CA,2020,2
 106,PureBasic,programming,CA,2020,2
+106,SAS,programming,CA,2020,2
 105,Solidity,programming,CA,2020,2
-104,Thrift,programming,CA,2020,2
 104,SuperCollider,programming,CA,2020,2
+104,Thrift,programming,CA,2020,2
 240,HTML,markup,CD,2020,2
 182,CSS,markup,CD,2020,2
 184,JavaScript,programming,CD,2020,2
@@ -5694,8 +5705,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 192,HLSL,programming,CH,2020,2
 176,GDB,programming,CH,2020,2
 168,SWIG,programming,CH,2020,2
-167,M,programming,CH,2020,2
 167,Dart,programming,CH,2020,2
+167,M,programming,CH,2020,2
 166,Gnuplot,programming,CH,2020,2
 156,Mako,programming,CH,2020,2
 154,SQLPL,programming,CH,2020,2
@@ -5712,8 +5723,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Julia,programming,CH,2020,2
 106,FreeMarker,programming,CH,2020,2
 103,Meson,programming,CH,2020,2
-101,Elixir,programming,CH,2020,2
 101,Forth,programming,CH,2020,2
+101,Elixir,programming,CH,2020,2
 569,HTML,markup,CI,2020,2
 404,CSS,markup,CI,2020,2
 367,JavaScript,programming,CI,2020,2
@@ -5820,8 +5831,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1877,Emacs Lisp,programming,CN,2020,2
 1661,CoffeeScript,programming,CN,2020,2
 1560,PLSQL,programming,CN,2020,2
-1259,sed,programming,CN,2020,2
 1259,ShaderLab,programming,CN,2020,2
+1259,sed,programming,CN,2020,2
 1241,Standard ML,programming,CN,2020,2
 1225,Thrift,programming,CN,2020,2
 1210,Ada,programming,CN,2020,2
@@ -5843,8 +5854,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 799,Clojure,programming,CN,2020,2
 776,DIGITAL Command Language,programming,CN,2020,2
 674,SmPL,programming,CN,2020,2
-666,Gherkin,programming,CN,2020,2
 666,NASL,programming,CN,2020,2
+666,Gherkin,programming,CN,2020,2
 663,M,programming,CN,2020,2
 661,VBScript,programming,CN,2020,2
 588,PureBasic,programming,CN,2020,2
@@ -5872,8 +5883,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 308,ActionScript,programming,CN,2020,2
 305,Prolog,programming,CN,2020,2
 299,Julia,programming,CN,2020,2
-294,D,programming,CN,2020,2
 294,Terra,programming,CN,2020,2
+294,D,programming,CN,2020,2
 291,RobotFramework,programming,CN,2020,2
 288,Coq,programming,CN,2020,2
 282,SystemVerilog,programming,CN,2020,2
@@ -5936,8 +5947,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1836,C++,programming,CO,2020,2
 1600,C,programming,CO,2020,2
 1179,Hack,programming,CO,2020,2
-1106,Objective-C,programming,CO,2020,2
 1106,Makefile,programming,CO,2020,2
+1106,Objective-C,programming,CO,2020,2
 1024,Kotlin,programming,CO,2020,2
 778,Batchfile,programming,CO,2020,2
 769,Swift,programming,CO,2020,2
@@ -5947,8 +5958,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 453,Assembly,programming,CO,2020,2
 435,Go,programming,CO,2020,2
 334,MATLAB,programming,CO,2020,2
-316,Gherkin,programming,CO,2020,2
 316,ShaderLab,programming,CO,2020,2
+316,Gherkin,programming,CO,2020,2
 289,HLSL,programming,CO,2020,2
 256,Rebol,programming,CO,2020,2
 222,CoffeeScript,programming,CO,2020,2
@@ -6207,13 +6218,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 188,Jasmin,programming,DE,2020,2
 186,OpenEdge ABL,programming,DE,2020,2
 183,AutoHotkey,programming,DE,2020,2
-181,Module Management System,programming,DE,2020,2
 181,SystemVerilog,programming,DE,2020,2
-177,Jsonnet,programming,DE,2020,2
+181,Module Management System,programming,DE,2020,2
 177,Thrift,programming,DE,2020,2
+177,Jsonnet,programming,DE,2020,2
 173,RobotFramework,programming,DE,2020,2
-170,AngelScript,programming,DE,2020,2
 170,SaltStack,programming,DE,2020,2
+170,AngelScript,programming,DE,2020,2
 168,SAS,programming,DE,2020,2
 163,Stata,programming,DE,2020,2
 161,BitBake,programming,DE,2020,2
@@ -6232,8 +6243,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,Isabelle,programming,DE,2020,2
 111,VCL,programming,DE,2020,2
 109,EmberScript,programming,DE,2020,2
-109,MLIR,programming,DE,2020,2
 109,ABAP,programming,DE,2020,2
+109,MLIR,programming,DE,2020,2
 102,IDL,programming,DE,2020,2
 101,Terra,programming,DE,2020,2
 8241,HTML,markup,DK,2020,2
@@ -6284,8 +6295,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 161,PLpgSQL,programming,DK,2020,2
 152,Groovy,programming,DK,2020,2
 125,Starlark,programming,DK,2020,2
-120,Awk,programming,DK,2020,2
 120,Tcl,programming,DK,2020,2
+120,Awk,programming,DK,2020,2
 120,Scala,programming,DK,2020,2
 114,Haskell,programming,DK,2020,2
 113,HCL,programming,DK,2020,2
@@ -6418,8 +6429,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,Perl,programming,EG,2020,2
 129,VHDL,programming,EG,2020,2
 127,Verilog,programming,EG,2020,2
-122,CoffeeScript,programming,EG,2020,2
 122,QMake,programming,EG,2020,2
+122,CoffeeScript,programming,EG,2020,2
 121,ShaderLab,programming,EG,2020,2
 109,HLSL,programming,EG,2020,2
 102,Yacc,programming,EG,2020,2
@@ -6513,18 +6524,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,M,programming,ES,2020,2
 124,VHDL,programming,ES,2020,2
 121,GDScript,programming,ES,2020,2
-119,D,programming,ES,2020,2
 119,Inno Setup,programming,ES,2020,2
-117,Erlang,programming,ES,2020,2
+119,D,programming,ES,2020,2
 117,DIGITAL Command Language,programming,ES,2020,2
-111,NASL,programming,ES,2020,2
+117,Erlang,programming,ES,2020,2
 111,QML,programming,ES,2020,2
+111,NASL,programming,ES,2020,2
 108,XS,programming,ES,2020,2
 106,Verilog,programming,ES,2020,2
 106,Forth,programming,ES,2020,2
-104,Nix,programming,ES,2020,2
-104,CLIPS,programming,ES,2020,2
 104,Papyrus,programming,ES,2020,2
+104,CLIPS,programming,ES,2020,2
+104,Nix,programming,ES,2020,2
 833,HTML,markup,ET,2020,2
 502,CSS,markup,ET,2020,2
 494,JavaScript,programming,ET,2020,2
@@ -6533,6 +6544,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 197,Python,programming,ET,2020,2
 191,Java,programming,ET,2020,2
 115,PHP,programming,ET,2020,2
+340227,HTML,markup,EU,2020,2
+275359,CSS,markup,EU,2020,2
+38634,Jupyter Notebook,markup,EU,2020,2
+23650,Vue,markup,EU,2020,2
+18440,TeX,markup,EU,2020,2
+16284,Roff,markup,EU,2020,2
+4058,Rich Text Format,markup,EU,2020,2
+1392,Vim Snippet,markup,EU,2020,2
+1386,PostScript,markup,EU,2020,2
+140,YASnippet,markup,EU,2020,2
+118,Liquid,markup,EU,2020,2
 284543,JavaScript,programming,EU,2020,2
 181212,Python,programming,EU,2020,2
 174936,Shell,programming,EU,2020,2
@@ -6678,11 +6700,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 123,RPC,programming,EU,2020,2
 118,SQF,programming,EU,2020,2
 113,Isabelle,programming,EU,2020,2
-109,EmberScript,programming,EU,2020,2
-109,MLIR,programming,EU,2020,2
 109,ABAP,programming,EU,2020,2
-104,Papyrus,programming,EU,2020,2
+109,MLIR,programming,EU,2020,2
+109,EmberScript,programming,EU,2020,2
 104,CLIPS,programming,EU,2020,2
+104,Papyrus,programming,EU,2020,2
 102,IDL,programming,EU,2020,2
 101,Terra,programming,EU,2020,2
 7943,HTML,markup,FI,2020,2
@@ -6821,27 +6843,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 401,SWIG,programming,FR,2020,2
 400,Mako,programming,FR,2020,2
 399,QML,programming,FR,2020,2
-378,Mathematica,programming,FR,2020,2
 378,Common Lisp,programming,FR,2020,2
+378,Mathematica,programming,FR,2020,2
 364,NASL,programming,FR,2020,2
 350,Processing,programming,FR,2020,2
 349,Elixir,programming,FR,2020,2
 338,Clojure,programming,FR,2020,2
 330,FreeMarker,programming,FR,2020,2
 329,GAP,programming,FR,2020,2
-328,Prolog,programming,FR,2020,2
 328,Standard ML,programming,FR,2020,2
+328,Prolog,programming,FR,2020,2
 324,Julia,programming,FR,2020,2
 312,M,programming,FR,2020,2
 308,Meson,programming,FR,2020,2
 278,Erlang,programming,FR,2020,2
-274,ANTLR,programming,FR,2020,2
 274,Pawn,programming,FR,2020,2
+274,ANTLR,programming,FR,2020,2
 269,DIGITAL Command Language,programming,FR,2020,2
 266,VBScript,programming,FR,2020,2
-265,D,programming,FR,2020,2
-265,VHDL,programming,FR,2020,2
 265,Forth,programming,FR,2020,2
+265,VHDL,programming,FR,2020,2
+265,D,programming,FR,2020,2
 249,Rebol,programming,FR,2020,2
 242,AppleScript,programming,FR,2020,2
 229,GDScript,programming,FR,2020,2
@@ -6869,8 +6891,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,G-code,programming,FR,2020,2
 129,Thrift,programming,FR,2020,2
 117,SourcePawn,programming,FR,2020,2
-116,SuperCollider,programming,FR,2020,2
 116,Haxe,programming,FR,2020,2
+116,SuperCollider,programming,FR,2020,2
 108,UnrealScript,programming,FR,2020,2
 104,Module Management System,programming,FR,2020,2
 103,Stata,programming,FR,2020,2
@@ -6954,8 +6976,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 535,Mako,programming,GB,2020,2
 510,Scheme,programming,GB,2020,2
 504,SWIG,programming,GB,2020,2
-492,M,programming,GB,2020,2
 492,Elixir,programming,GB,2020,2
+492,M,programming,GB,2020,2
 454,Julia,programming,GB,2020,2
 444,OCaml,programming,GB,2020,2
 437,F#,programming,GB,2020,2
@@ -6967,8 +6989,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 401,AppleScript,programming,GB,2020,2
 386,DIGITAL Command Language,programming,GB,2020,2
 379,Prolog,programming,GB,2020,2
-373,Gnuplot,programming,GB,2020,2
 373,VBScript,programming,GB,2020,2
+373,Gnuplot,programming,GB,2020,2
 367,Inno Setup,programming,GB,2020,2
 355,Processing,programming,GB,2020,2
 354,GAP,programming,GB,2020,2
@@ -7017,19 +7039,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,PureBasic,programming,GB,2020,2
 126,Module Management System,programming,GB,2020,2
 124,Apex,programming,GB,2020,2
-117,Cool,programming,GB,2020,2
 117,SAS,programming,GB,2020,2
+117,Cool,programming,GB,2020,2
 116,AngelScript,programming,GB,2020,2
 115,Stan,programming,GB,2020,2
-112,JSONiq,programming,GB,2020,2
 112,RobotFramework,programming,GB,2020,2
+112,JSONiq,programming,GB,2020,2
 111,DM,programming,GB,2020,2
 110,NewLisp,programming,GB,2020,2
 109,Nextflow,programming,GB,2020,2
 108,Arc,programming,GB,2020,2
 106,IDL,programming,GB,2020,2
-105,Racket,programming,GB,2020,2
 105,Haxe,programming,GB,2020,2
+105,Racket,programming,GB,2020,2
 102,Solidity,programming,GB,2020,2
 1456,HTML,markup,GE,2020,2
 1166,CSS,markup,GE,2020,2
@@ -7045,8 +7067,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Dockerfile,programming,GE,2020,2
 108,Kotlin,programming,GE,2020,2
 101,C,programming,GE,2020,2
-101,Hack,programming,GE,2020,2
 101,Makefile,programming,GE,2020,2
+101,Hack,programming,GE,2020,2
 2543,HTML,markup,GH,2020,2
 1723,CSS,markup,GH,2020,2
 192,Vue,markup,GH,2020,2
@@ -7117,8 +7139,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 488,Shell,programming,GT,2020,2
 407,TypeScript,programming,GT,2020,2
 401,TSQL,programming,GT,2020,2
-398,C#,programming,GT,2020,2
 398,PHP,programming,GT,2020,2
+398,C#,programming,GT,2020,2
 373,C++,programming,GT,2020,2
 253,Ruby,programming,GT,2020,2
 235,C,programming,GT,2020,2
@@ -7339,8 +7361,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 408,Smarty,programming,ID,2020,2
 351,R,programming,ID,2020,2
 330,Rust,programming,ID,2020,2
-307,Vim Script,programming,ID,2020,2
 307,CMake,programming,ID,2020,2
+307,Vim Script,programming,ID,2020,2
 305,ShaderLab,programming,ID,2020,2
 304,MATLAB,programming,ID,2020,2
 287,HLSL,programming,ID,2020,2
@@ -7571,15 +7593,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 400,ANTLR,programming,IN,2020,2
 395,M,programming,IN,2020,2
 392,RobotFramework,programming,IN,2020,2
-354,SWIG,programming,IN,2020,2
 354,Elixir,programming,IN,2020,2
+354,SWIG,programming,IN,2020,2
 349,RenderScript,programming,IN,2020,2
 334,DIGITAL Command Language,programming,IN,2020,2
 329,NSIS,programming,IN,2020,2
 311,Puppet,programming,IN,2020,2
 310,DTrace,programming,IN,2020,2
-306,GAP,programming,IN,2020,2
 306,NASL,programming,IN,2020,2
+306,GAP,programming,IN,2020,2
 305,F#,programming,IN,2020,2
 303,D,programming,IN,2020,2
 286,Pawn,programming,IN,2020,2
@@ -7590,8 +7612,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 260,LLVM,programming,IN,2020,2
 232,AngelScript,programming,IN,2020,2
 227,Mathematica,programming,IN,2020,2
-224,VBA,programming,IN,2020,2
 224,Solidity,programming,IN,2020,2
+224,VBA,programming,IN,2020,2
 223,Standard ML,programming,IN,2020,2
 215,OpenEdge ABL,programming,IN,2020,2
 211,AppleScript,programming,IN,2020,2
@@ -7617,8 +7639,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 139,HiveQL,programming,IN,2020,2
 136,PureScript,programming,IN,2020,2
 136,Meson,programming,IN,2020,2
-128,GDScript,programming,IN,2020,2
 128,Coq,programming,IN,2020,2
+128,GDScript,programming,IN,2020,2
 125,Logos,programming,IN,2020,2
 117,Smali,programming,IN,2020,2
 113,PigLatin,programming,IN,2020,2
@@ -7739,13 +7761,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 190,Raku,programming,IT,2020,2
 179,NSIS,programming,IT,2020,2
 174,Prolog,programming,IT,2020,2
-162,GDB,programming,IT,2020,2
 162,Processing,programming,IT,2020,2
+162,GDB,programming,IT,2020,2
 161,FreeMarker,programming,IT,2020,2
 160,Clojure,programming,IT,2020,2
 158,QML,programming,IT,2020,2
-157,SQLPL,programming,IT,2020,2
 157,Smalltalk,programming,IT,2020,2
+157,SQLPL,programming,IT,2020,2
 154,Gnuplot,programming,IT,2020,2
 152,Scheme,programming,IT,2020,2
 151,ANTLR,programming,IT,2020,2
@@ -7759,8 +7781,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,XS,programming,IT,2020,2
 108,Elixir,programming,IT,2020,2
 107,Mathematica,programming,IT,2020,2
-102,Common Lisp,programming,IT,2020,2
 102,NASL,programming,IT,2020,2
+102,Common Lisp,programming,IT,2020,2
 507,HTML,markup,JM,2020,2
 427,CSS,markup,JM,2020,2
 417,JavaScript,programming,JM,2020,2
@@ -7848,8 +7870,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 326,Elixir,programming,JP,2020,2
 324,Pascal,programming,JP,2020,2
 321,GDB,programming,JP,2020,2
-317,QMake,programming,JP,2020,2
 317,Scheme,programming,JP,2020,2
+317,QMake,programming,JP,2020,2
 307,Clojure,programming,JP,2020,2
 299,VBA,programming,JP,2020,2
 292,Processing,programming,JP,2020,2
@@ -7867,8 +7889,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 189,Prolog,programming,JP,2020,2
 189,Verilog,programming,JP,2020,2
 182,XS,programming,JP,2020,2
-181,AppleScript,programming,JP,2020,2
 181,Mako,programming,JP,2020,2
+181,AppleScript,programming,JP,2020,2
 180,F#,programming,JP,2020,2
 180,Pawn,programming,JP,2020,2
 179,Scilab,programming,JP,2020,2
@@ -8012,8 +8034,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 184,sed,programming,KR,2020,2
 170,NSIS,programming,KR,2020,2
 167,FreeMarker,programming,KR,2020,2
-152,Clojure,programming,KR,2020,2
 152,SQLPL,programming,KR,2020,2
+152,Clojure,programming,KR,2020,2
 148,GDB,programming,KR,2020,2
 145,Mathematica,programming,KR,2020,2
 138,SWIG,programming,KR,2020,2
@@ -8473,10 +8495,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 228,Processing,programming,NL,2020,2
 227,Raku,programming,NL,2020,2
 227,Mathematica,programming,NL,2020,2
-207,Cuda,programming,NL,2020,2
 207,Clojure,programming,NL,2020,2
-196,Elixir,programming,NL,2020,2
+207,Cuda,programming,NL,2020,2
 196,SQLPL,programming,NL,2020,2
+196,Elixir,programming,NL,2020,2
 190,SWIG,programming,NL,2020,2
 188,QML,programming,NL,2020,2
 183,GDB,programming,NL,2020,2
@@ -8708,8 +8730,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Assembly,programming,PH,2020,2
 115,CMake,programming,PH,2020,2
 110,Smarty,programming,PH,2020,2
-101,Lua,programming,PH,2020,2
 101,PLpgSQL,programming,PH,2020,2
+101,Lua,programming,PH,2020,2
 15492,HTML,markup,PK,2020,2
 12070,CSS,markup,PK,2020,2
 1742,Jupyter Notebook,markup,PK,2020,2
@@ -8840,14 +8862,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Mathematica,programming,PL,2020,2
 116,GAP,programming,PL,2020,2
 112,SWIG,programming,PL,2020,2
-112,Rebol,programming,PL,2020,2
 112,Gnuplot,programming,PL,2020,2
-111,Common Lisp,programming,PL,2020,2
+112,Rebol,programming,PL,2020,2
 111,GDScript,programming,PL,2020,2
 111,Processing,programming,PL,2020,2
+111,Common Lisp,programming,PL,2020,2
 107,PureBasic,programming,PL,2020,2
-105,OpenSCAD,programming,PL,2020,2
 105,OCaml,programming,PL,2020,2
+105,OpenSCAD,programming,PL,2020,2
 521,HTML,markup,PR,2020,2
 399,CSS,markup,PR,2020,2
 387,JavaScript,programming,PR,2020,2
@@ -8910,8 +8932,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,Rust,programming,PT,2020,2
 148,Scala,programming,PT,2020,2
 138,Lex,programming,PT,2020,2
-134,Yacc,programming,PT,2020,2
 134,Gherkin,programming,PT,2020,2
+134,Yacc,programming,PT,2020,2
 121,Haskell,programming,PT,2020,2
 115,Objective-C++,programming,PT,2020,2
 112,Awk,programming,PT,2020,2
@@ -8982,13 +9004,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 164,GLSL,programming,RO,2020,2
 164,Yacc,programming,RO,2020,2
 160,PLSQL,programming,RO,2020,2
-150,Lex,programming,RO,2020,2
 150,Haskell,programming,RO,2020,2
+150,Lex,programming,RO,2020,2
 143,HCL,programming,RO,2020,2
 138,Scala,programming,RO,2020,2
 134,Awk,programming,RO,2020,2
-133,R,programming,RO,2020,2
 133,Rust,programming,RO,2020,2
+133,R,programming,RO,2020,2
 125,Tcl,programming,RO,2020,2
 108,FreeMarker,programming,RO,2020,2
 107,QMake,programming,RO,2020,2
@@ -9086,8 +9108,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 594,Mako,programming,RU,2020,2
 560,QML,programming,RU,2020,2
 559,HCL,programming,RU,2020,2
-550,SQLPL,programming,RU,2020,2
 550,Fortran,programming,RU,2020,2
+550,SQLPL,programming,RU,2020,2
 524,Tcl,programming,RU,2020,2
 504,Cuda,programming,RU,2020,2
 481,Raku,programming,RU,2020,2
@@ -9112,15 +9134,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 257,Visual Basic .NET,programming,RU,2020,2
 255,Erlang,programming,RU,2020,2
 250,D,programming,RU,2020,2
-245,1C Enterprise,programming,RU,2020,2
 245,DTrace,programming,RU,2020,2
+245,1C Enterprise,programming,RU,2020,2
 238,NASL,programming,RU,2020,2
 236,Nix,programming,RU,2020,2
 235,XS,programming,RU,2020,2
 233,VBA,programming,RU,2020,2
 224,M,programming,RU,2020,2
-221,OCaml,programming,RU,2020,2
 221,Meson,programming,RU,2020,2
+221,OCaml,programming,RU,2020,2
 218,GAP,programming,RU,2020,2
 206,Forth,programming,RU,2020,2
 198,Gnuplot,programming,RU,2020,2
@@ -9131,8 +9153,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 172,DM,programming,RU,2020,2
 168,Logos,programming,RU,2020,2
 162,UnrealScript,programming,RU,2020,2
-156,Processing,programming,RU,2020,2
 156,Module Management System,programming,RU,2020,2
+156,Processing,programming,RU,2020,2
 154,LLVM,programming,RU,2020,2
 153,PureBasic,programming,RU,2020,2
 145,Julia,programming,RU,2020,2
@@ -9146,8 +9168,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,Ragel,programming,RU,2020,2
 113,SAS,programming,RU,2020,2
 111,Jsonnet,programming,RU,2020,2
-102,Thrift,programming,RU,2020,2
 102,AMPL,programming,RU,2020,2
+102,Thrift,programming,RU,2020,2
 679,HTML,markup,RW,2020,2
 546,CSS,markup,RW,2020,2
 572,JavaScript,programming,RW,2020,2
@@ -9213,8 +9235,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 936,Vim Script,programming,SE,2020,2
 920,Perl,programming,SE,2020,2
 775,Kotlin,programming,SE,2020,2
-751,R,programming,SE,2020,2
 751,Assembly,programming,SE,2020,2
+751,R,programming,SE,2020,2
 699,Lua,programming,SE,2020,2
 639,Rust,programming,SE,2020,2
 611,Swift,programming,SE,2020,2
@@ -9248,8 +9270,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,sed,programming,SE,2020,2
 169,Erlang,programming,SE,2020,2
 164,Tcl,programming,SE,2020,2
-147,Pascal,programming,SE,2020,2
 147,NSIS,programming,SE,2020,2
+147,Pascal,programming,SE,2020,2
 144,Fortran,programming,SE,2020,2
 144,Clojure,programming,SE,2020,2
 138,PLSQL,programming,SE,2020,2
@@ -9595,8 +9617,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 143,HCL,programming,TW,2020,2
 142,Smalltalk,programming,TW,2020,2
 138,Pascal,programming,TW,2020,2
-136,sed,programming,TW,2020,2
 136,GDB,programming,TW,2020,2
+136,sed,programming,TW,2020,2
 134,Fortran,programming,TW,2020,2
 124,Processing,programming,TW,2020,2
 121,PLpgSQL,programming,TW,2020,2
@@ -9811,8 +9833,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1325,Puppet,programming,US,2020,2
 1255,Stata,programming,US,2020,2
 1236,PureBasic,programming,US,2020,2
-1232,SystemVerilog,programming,US,2020,2
 1232,XS,programming,US,2020,2
+1232,SystemVerilog,programming,US,2020,2
 1204,GDScript,programming,US,2020,2
 1149,OpenSCAD,programming,US,2020,2
 1120,RenderScript,programming,US,2020,2
@@ -9856,8 +9878,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 457,RPC,programming,US,2020,2
 455,HiveQL,programming,US,2020,2
 437,Ragel,programming,US,2020,2
-424,Brainfuck,programming,US,2020,2
 424,PureScript,programming,US,2020,2
+424,Brainfuck,programming,US,2020,2
 419,Terra,programming,US,2020,2
 413,Max,programming,US,2020,2
 386,AGS Script,programming,US,2020,2
@@ -9867,8 +9889,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 373,V,programming,US,2020,2
 372,COBOL,programming,US,2020,2
 358,NCL,programming,US,2020,2
-357,q,programming,US,2020,2
 357,Reason,programming,US,2020,2
+357,q,programming,US,2020,2
 356,ColdFusion,programming,US,2020,2
 345,BitBake,programming,US,2020,2
 340,CodeQL,programming,US,2020,2
@@ -9888,16 +9910,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 249,Nextflow,programming,US,2020,2
 248,xBase,programming,US,2020,2
 214,Objective-J,programming,US,2020,2
-211,eC,programming,US,2020,2
 211,Dhall,programming,US,2020,2
+211,eC,programming,US,2020,2
 204,nesC,programming,US,2020,2
 203,TLA,programming,US,2020,2
 198,Common Workflow Language,programming,US,2020,2
 197,LiveScript,programming,US,2020,2
 195,CartoCSS,programming,US,2020,2
 187,Slash,programming,US,2020,2
-185,AspectJ,programming,US,2020,2
 185,BlitzBasic,programming,US,2020,2
+185,AspectJ,programming,US,2020,2
 182,AutoIt,programming,US,2020,2
 177,Harbour,programming,US,2020,2
 174,ZenScript,programming,US,2020,2
@@ -9909,8 +9931,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 158,E,programming,US,2020,2
 157,Clarion,programming,US,2020,2
 155,LSL,programming,US,2020,2
-154,DataWeave,programming,US,2020,2
 154,CWeb,programming,US,2020,2
+154,DataWeave,programming,US,2020,2
 151,Pike,programming,US,2020,2
 150,REXX,programming,US,2020,2
 149,Rascal,programming,US,2020,2
@@ -9930,16 +9952,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,Faust,programming,US,2020,2
 116,Eiffel,programming,US,2020,2
 114,XC,programming,US,2020,2
-112,Lean,programming,US,2020,2
 112,ObjectScript,programming,US,2020,2
+112,Lean,programming,US,2020,2
 112,SQF,programming,US,2020,2
 111,Asymptote,programming,US,2020,2
 109,F*,programming,US,2020,2
 104,Idris,programming,US,2020,2
 103,Red,programming,US,2020,2
 102,GCC Machine Description,programming,US,2020,2
-101,Component Pascal,programming,US,2020,2
 101,mIRC Script,programming,US,2020,2
+101,Component Pascal,programming,US,2020,2
 1663,HTML,markup,UY,2020,2
 1413,CSS,markup,UY,2020,2
 101,Jupyter Notebook,markup,UY,2020,2
@@ -10188,22 +10210,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 583,Go,programming,AR,2020,3
 516,Swift,programming,AR,2020,3
 483,CMake,programming,AR,2020,3
-470,PowerShell,programming,AR,2020,3
 470,R,programming,AR,2020,3
+470,PowerShell,programming,AR,2020,3
 445,Assembly,programming,AR,2020,3
 341,Perl,programming,AR,2020,3
 324,Dart,programming,AR,2020,3
 306,Vim Script,programming,AR,2020,3
 290,Starlark,programming,AR,2020,3
-282,HLSL,programming,AR,2020,3
 282,Smarty,programming,AR,2020,3
+282,HLSL,programming,AR,2020,3
 265,ShaderLab,programming,AR,2020,3
 232,ASP.NET,programming,AR,2020,3
 231,Gherkin,programming,AR,2020,3
 230,Smalltalk,programming,AR,2020,3
 222,Wollok,programming,AR,2020,3
-218,Lua,programming,AR,2020,3
 218,XSLT,programming,AR,2020,3
+218,Lua,programming,AR,2020,3
 210,MATLAB,programming,AR,2020,3
 209,Haskell,programming,AR,2020,3
 183,GLSL,programming,AR,2020,3
@@ -10215,8 +10237,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,Rust,programming,AR,2020,3
 155,HCL,programming,AR,2020,3
 135,PLpgSQL,programming,AR,2020,3
-116,Pascal,programming,AR,2020,3
 116,Solidity,programming,AR,2020,3
+116,Pascal,programming,AR,2020,3
 115,Prolog,programming,AR,2020,3
 113,M4,programming,AR,2020,3
 110,Visual Basic .NET,programming,AR,2020,3
@@ -10264,12 +10286,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 216,Hack,programming,AT,2020,3
 168,QMake,programming,AT,2020,3
 167,Awk,programming,AT,2020,3
-166,Emacs Lisp,programming,AT,2020,3
 166,MATLAB,programming,AT,2020,3
+166,Emacs Lisp,programming,AT,2020,3
 147,Dart,programming,AT,2020,3
 145,Gherkin,programming,AT,2020,3
-142,Yacc,programming,AT,2020,3
 142,Objective-C++,programming,AT,2020,3
+142,Yacc,programming,AT,2020,3
 141,Scala,programming,AT,2020,3
 140,PLpgSQL,programming,AT,2020,3
 119,Starlark,programming,AT,2020,3
@@ -10369,8 +10391,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,VBScript,programming,AU,2020,3
 131,FreeMarker,programming,AU,2020,3
 130,Visual Basic .NET,programming,AU,2020,3
-128,AutoHotkey,programming,AU,2020,3
 128,Gnuplot,programming,AU,2020,3
+128,AutoHotkey,programming,AU,2020,3
 125,M,programming,AU,2020,3
 123,Common Lisp,programming,AU,2020,3
 123,Prolog,programming,AU,2020,3
@@ -10381,10 +10403,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,SWIG,programming,AU,2020,3
 109,Elm,programming,AU,2020,3
 108,DIGITAL Command Language,programming,AU,2020,3
-107,OpenSCAD,programming,AU,2020,3
 107,Apex,programming,AU,2020,3
-105,NASL,programming,AU,2020,3
+107,OpenSCAD,programming,AU,2020,3
 105,G-code,programming,AU,2020,3
+105,NASL,programming,AU,2020,3
 1532,HTML,markup,AZ,2020,3
 1195,CSS,markup,AZ,2020,3
 194,SCSS,markup,AZ,2020,3
@@ -10502,12 +10524,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 157,HCL,programming,BE,2020,3
 146,Fortran,programming,BE,2020,3
 145,Dart,programming,BE,2020,3
+129,Emacs Lisp,programming,BE,2020,3
 129,Awk,programming,BE,2020,3
 129,PLpgSQL,programming,BE,2020,3
-129,Emacs Lisp,programming,BE,2020,3
 114,ShaderLab,programming,BE,2020,3
-113,HLSL,programming,BE,2020,3
 113,QMake,programming,BE,2020,3
+113,HLSL,programming,BE,2020,3
 108,NSIS,programming,BE,2020,3
 103,Yacc,programming,BE,2020,3
 101,PLSQL,programming,BE,2020,3
@@ -10655,15 +10677,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 335,VBA,programming,BR,2020,3
 333,Awk,programming,BR,2020,3
 301,sed,programming,BR,2020,3
-253,FreeMarker,programming,BR,2020,3
 253,Julia,programming,BR,2020,3
+253,FreeMarker,programming,BR,2020,3
 243,VHDL,programming,BR,2020,3
 238,GAP,programming,BR,2020,3
 236,Processing,programming,BR,2020,3
 232,Mathematica,programming,BR,2020,3
 224,Raku,programming,BR,2020,3
-214,Cuda,programming,BR,2020,3
 214,Visual Basic .NET,programming,BR,2020,3
+214,Cuda,programming,BR,2020,3
 212,VBScript,programming,BR,2020,3
 211,Scheme,programming,BR,2020,3
 202,Prolog,programming,BR,2020,3
@@ -10676,8 +10698,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,Standard ML,programming,BR,2020,3
 168,SQLPL,programming,BR,2020,3
 167,Forth,programming,BR,2020,3
-162,Verilog,programming,BR,2020,3
 162,Common Lisp,programming,BR,2020,3
+162,Verilog,programming,BR,2020,3
 160,NSIS,programming,BR,2020,3
 142,QML,programming,BR,2020,3
 142,Stata,programming,BR,2020,3
@@ -10840,10 +10862,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 222,Erlang,programming,CA,2020,3
 222,Prolog,programming,CA,2020,3
 219,Visual Basic .NET,programming,CA,2020,3
-218,ANTLR,programming,CA,2020,3
 218,DTrace,programming,CA,2020,3
-214,D,programming,CA,2020,3
+218,ANTLR,programming,CA,2020,3
 214,GAP,programming,CA,2020,3
+214,D,programming,CA,2020,3
 212,Verilog,programming,CA,2020,3
 210,OCaml,programming,CA,2020,3
 203,Inno Setup,programming,CA,2020,3
@@ -10868,8 +10890,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,AMPL,programming,CA,2020,3
 123,SuperCollider,programming,CA,2020,3
 122,Jsonnet,programming,CA,2020,3
-120,RenderScript,programming,CA,2020,3
 120,XS,programming,CA,2020,3
+120,RenderScript,programming,CA,2020,3
 118,Objective-J,programming,CA,2020,3
 115,Elm,programming,CA,2020,3
 112,SmPL,programming,CA,2020,3
@@ -11164,16 +11186,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 194,ASL,programming,CN,2020,3
 179,JSONiq,programming,CN,2020,3
 174,Jsonnet,programming,CN,2020,3
-169,HiveQL,programming,CN,2020,3
 169,RenderScript,programming,CN,2020,3
+169,HiveQL,programming,CN,2020,3
 153,Elixir,programming,CN,2020,3
 152,WebAssembly,programming,CN,2020,3
 150,SAS,programming,CN,2020,3
 145,q,programming,CN,2020,3
 144,Rebol,programming,CN,2020,3
 130,Processing,programming,CN,2020,3
-120,Mercury,programming,CN,2020,3
 120,NewLisp,programming,CN,2020,3
+120,Mercury,programming,CN,2020,3
 119,Nix,programming,CN,2020,3
 114,MLIR,programming,CN,2020,3
 112,EmberScript,programming,CN,2020,3
@@ -11302,8 +11324,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 653,Go,programming,CZ,2020,3
 560,PowerShell,programming,CZ,2020,3
 464,TSQL,programming,CZ,2020,3
-450,Assembly,programming,CZ,2020,3
 450,Kotlin,programming,CZ,2020,3
+450,Assembly,programming,CZ,2020,3
 434,M4,programming,CZ,2020,3
 421,XSLT,programming,CZ,2020,3
 403,Vim Script,programming,CZ,2020,3
@@ -11318,9 +11340,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 222,GLSL,programming,CZ,2020,3
 211,Yacc,programming,CZ,2020,3
 198,Lex,programming,CZ,2020,3
-188,Hack,programming,CZ,2020,3
-188,Gherkin,programming,CZ,2020,3
 188,QMake,programming,CZ,2020,3
+188,Gherkin,programming,CZ,2020,3
+188,Hack,programming,CZ,2020,3
 185,PLpgSQL,programming,CZ,2020,3
 172,MATLAB,programming,CZ,2020,3
 163,sed,programming,CZ,2020,3
@@ -11333,8 +11355,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,Starlark,programming,CZ,2020,3
 118,PLSQL,programming,CZ,2020,3
 113,Smalltalk,programming,CZ,2020,3
-112,Raku,programming,CZ,2020,3
 112,HLSL,programming,CZ,2020,3
+112,Raku,programming,CZ,2020,3
 111,Dart,programming,CZ,2020,3
 109,Mako,programming,CZ,2020,3
 102,CoffeeScript,programming,CZ,2020,3
@@ -11504,8 +11526,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,EmberScript,programming,DE,2020,3
 108,Apex,programming,DE,2020,3
 106,MLIR,programming,DE,2020,3
-105,Max,programming,DE,2020,3
 105,Brainfuck,programming,DE,2020,3
+105,Max,programming,DE,2020,3
 102,ABAP,programming,DE,2020,3
 101,VCL,programming,DE,2020,3
 6951,HTML,markup,DK,2020,3
@@ -11747,8 +11769,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 399,Rust,programming,ES,2020,3
 389,HCL,programming,ES,2020,3
 343,Starlark,programming,ES,2020,3
-342,Scala,programming,ES,2020,3
 342,Emacs Lisp,programming,ES,2020,3
+342,Scala,programming,ES,2020,3
 333,PLpgSQL,programming,ES,2020,3
 296,CoffeeScript,programming,ES,2020,3
 285,Objective-C++,programming,ES,2020,3
@@ -11756,8 +11778,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 266,Lex,programming,ES,2020,3
 255,Awk,programming,ES,2020,3
 245,NSIS,programming,ES,2020,3
-242,PLSQL,programming,ES,2020,3
 242,QMake,programming,ES,2020,3
+242,PLSQL,programming,ES,2020,3
 232,Fortran,programming,ES,2020,3
 223,Raku,programming,ES,2020,3
 219,Tcl,programming,ES,2020,3
@@ -11795,6 +11817,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 191,Ruby,programming,ET,2020,3
 179,Java,programming,ET,2020,3
 109,PHP,programming,ET,2020,3
+291984,HTML,markup,EU,2020,3
+225552,CSS,markup,EU,2020,3
+37743,SCSS,markup,EU,2020,3
+31929,Jupyter Notebook,markup,EU,2020,3
+20984,Vue,markup,EU,2020,3
+15824,TeX,markup,EU,2020,3
+14576,Roff,markup,EU,2020,3
+5496,Less,markup,EU,2020,3
+3310,Rich Text Format,markup,EU,2020,3
+3256,Twig,markup,EU,2020,3
+2705,Handlebars,markup,EU,2020,3
+2356,Blade,markup,EU,2020,3
+1609,Sass,markup,EU,2020,3
+1447,Pug,markup,EU,2020,3
+1263,Vim Snippet,markup,EU,2020,3
+855,PostScript,markup,EU,2020,3
+476,Stylus,markup,EU,2020,3
+304,Svelte,markup,EU,2020,3
+129,Liquid,markup,EU,2020,3
+122,YASnippet,markup,EU,2020,3
+116,Haml,markup,EU,2020,3
 248147,JavaScript,programming,EU,2020,3
 167361,Shell,programming,EU,2020,3
 155365,Python,programming,EU,2020,3
@@ -11979,8 +12022,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 269,M4,programming,FI,2020,3
 234,Rust,programming,FI,2020,3
 220,Swift,programming,FI,2020,3
-219,Emacs Lisp,programming,FI,2020,3
 219,GLSL,programming,FI,2020,3
+219,Emacs Lisp,programming,FI,2020,3
 214,XSLT,programming,FI,2020,3
 211,ShaderLab,programming,FI,2020,3
 200,HLSL,programming,FI,2020,3
@@ -12081,8 +12124,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 364,GDB,programming,FR,2020,3
 332,Gnuplot,programming,FR,2020,3
 328,Inno Setup,programming,FR,2020,3
-314,SWIG,programming,FR,2020,3
 314,Standard ML,programming,FR,2020,3
+314,SWIG,programming,FR,2020,3
 307,Common Lisp,programming,FR,2020,3
 302,FreeMarker,programming,FR,2020,3
 279,Clojure,programming,FR,2020,3
@@ -12108,8 +12151,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 187,GDScript,programming,FR,2020,3
 184,Visual Basic .NET,programming,FR,2020,3
 179,ASP.NET,programming,FR,2020,3
-177,Verilog,programming,FR,2020,3
 177,Coq,programming,FR,2020,3
+177,Verilog,programming,FR,2020,3
 176,AppleScript,programming,FR,2020,3
 166,F#,programming,FR,2020,3
 165,Ada,programming,FR,2020,3
@@ -12125,8 +12168,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 139,Logos,programming,FR,2020,3
 137,Elm,programming,FR,2020,3
 137,OpenSCAD,programming,FR,2020,3
-134,LLVM,programming,FR,2020,3
 134,VCL,programming,FR,2020,3
+134,LLVM,programming,FR,2020,3
 131,Crystal,programming,FR,2020,3
 130,ActionScript,programming,FR,2020,3
 129,Puppet,programming,FR,2020,3
@@ -12239,8 +12282,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 349,FreeMarker,programming,GB,2020,3
 340,VBScript,programming,GB,2020,3
 331,DTrace,programming,GB,2020,3
-330,Forth,programming,GB,2020,3
 330,Inno Setup,programming,GB,2020,3
+330,Forth,programming,GB,2020,3
 327,Erlang,programming,GB,2020,3
 319,Visual Basic .NET,programming,GB,2020,3
 314,Rebol,programming,GB,2020,3
@@ -12261,8 +12304,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 229,Scilab,programming,GB,2020,3
 225,Solidity,programming,GB,2020,3
 222,XS,programming,GB,2020,3
-220,Cycript,programming,GB,2020,3
 220,SuperCollider,programming,GB,2020,3
+220,Cycript,programming,GB,2020,3
 215,Verilog,programming,GB,2020,3
 215,GDScript,programming,GB,2020,3
 211,RenderScript,programming,GB,2020,3
@@ -12282,8 +12325,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Apex,programming,GB,2020,3
 139,VCL,programming,GB,2020,3
 134,VHDL,programming,GB,2020,3
-130,Mercury,programming,GB,2020,3
 130,UnrealScript,programming,GB,2020,3
+130,Mercury,programming,GB,2020,3
 129,Module Management System,programming,GB,2020,3
 128,ActionScript,programming,GB,2020,3
 126,DM,programming,GB,2020,3
@@ -12296,8 +12339,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,AngelScript,programming,GB,2020,3
 113,Cool,programming,GB,2020,3
 112,Open Policy Agent,programming,GB,2020,3
-108,RobotFramework,programming,GB,2020,3
 108,IDL,programming,GB,2020,3
+108,RobotFramework,programming,GB,2020,3
 107,Nextflow,programming,GB,2020,3
 106,JSONiq,programming,GB,2020,3
 1390,HTML,markup,GE,2020,3
@@ -12331,8 +12374,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 220,Objective-C,programming,GH,2020,3
 209,TypeScript,programming,GH,2020,3
 206,Kotlin,programming,GH,2020,3
-180,Dart,programming,GH,2020,3
 180,Dockerfile,programming,GH,2020,3
+180,Dart,programming,GH,2020,3
 170,Swift,programming,GH,2020,3
 146,Hack,programming,GH,2020,3
 114,C++,programming,GH,2020,3
@@ -12353,8 +12396,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 953,Makefile,programming,GR,2020,3
 921,C,programming,GR,2020,3
 869,Dockerfile,programming,GR,2020,3
-719,Ruby,programming,GR,2020,3
 719,PHP,programming,GR,2020,3
+719,Ruby,programming,GR,2020,3
 650,TypeScript,programming,GR,2020,3
 573,C#,programming,GR,2020,3
 446,Batchfile,programming,GR,2020,3
@@ -12478,8 +12521,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,PLSQL,programming,HK,2020,3
 154,GAP,programming,HK,2020,3
 145,Fortran,programming,HK,2020,3
-134,DIGITAL Command Language,programming,HK,2020,3
 134,SmPL,programming,HK,2020,3
+134,DIGITAL Command Language,programming,HK,2020,3
 133,NASL,programming,HK,2020,3
 129,Verilog,programming,HK,2020,3
 125,Smalltalk,programming,HK,2020,3
@@ -12554,16 +12597,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 424,CMake,programming,HU,2020,3
 366,Go,programming,HU,2020,3
 357,TSQL,programming,HU,2020,3
-326,Kotlin,programming,HU,2020,3
 326,Perl,programming,HU,2020,3
+326,Kotlin,programming,HU,2020,3
 273,PowerShell,programming,HU,2020,3
 246,Assembly,programming,HU,2020,3
 235,Swift,programming,HU,2020,3
 193,Vim Script,programming,HU,2020,3
 184,XSLT,programming,HU,2020,3
 179,R,programming,HU,2020,3
-176,Hack,programming,HU,2020,3
 176,Lua,programming,HU,2020,3
+176,Hack,programming,HU,2020,3
 176,M4,programming,HU,2020,3
 161,Smarty,programming,HU,2020,3
 161,Groovy,programming,HU,2020,3
@@ -12623,14 +12666,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 235,M4,programming,ID,2020,3
 233,ShaderLab,programming,ID,2020,3
 213,Lua,programming,ID,2020,3
-212,Groovy,programming,ID,2020,3
 212,HLSL,programming,ID,2020,3
+212,Groovy,programming,ID,2020,3
 188,Mako,programming,ID,2020,3
 178,Visual Basic .NET,programming,ID,2020,3
 167,Clojure,programming,ID,2020,3
 164,Yacc,programming,ID,2020,3
-162,Awk,programming,ID,2020,3
 162,MATLAB,programming,ID,2020,3
+162,Awk,programming,ID,2020,3
 160,XSLT,programming,ID,2020,3
 157,Raku,programming,ID,2020,3
 153,sed,programming,ID,2020,3
@@ -12642,8 +12685,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,Pascal,programming,ID,2020,3
 127,HCL,programming,ID,2020,3
 122,SmPL,programming,ID,2020,3
-120,PLSQL,programming,ID,2020,3
 120,UnrealScript,programming,ID,2020,3
+120,PLSQL,programming,ID,2020,3
 118,Forth,programming,ID,2020,3
 109,ASP.NET,programming,ID,2020,3
 105,RenderScript,programming,ID,2020,3
@@ -12682,20 +12725,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 240,Vim Script,programming,IE,2020,3
 205,Smarty,programming,IE,2020,3
 202,Rust,programming,IE,2020,3
-181,Lua,programming,IE,2020,3
 181,Groovy,programming,IE,2020,3
+181,Lua,programming,IE,2020,3
 179,M4,programming,IE,2020,3
 171,Starlark,programming,IE,2020,3
 167,Scala,programming,IE,2020,3
 136,HCL,programming,IE,2020,3
-132,MATLAB,programming,IE,2020,3
 132,HLSL,programming,IE,2020,3
-127,XSLT,programming,IE,2020,3
+132,MATLAB,programming,IE,2020,3
 127,Emacs Lisp,programming,IE,2020,3
+127,XSLT,programming,IE,2020,3
 126,ShaderLab,programming,IE,2020,3
+124,Awk,programming,IE,2020,3
 124,Hack,programming,IE,2020,3
 124,GLSL,programming,IE,2020,3
-124,Awk,programming,IE,2020,3
 121,Gherkin,programming,IE,2020,3
 103,Objective-C++,programming,IE,2020,3
 12881,HTML,markup,IL,2020,3
@@ -12747,13 +12790,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 219,HLSL,programming,IL,2020,3
 202,Hack,programming,IL,2020,3
 176,PLpgSQL,programming,IL,2020,3
-175,Awk,programming,IL,2020,3
 175,Emacs Lisp,programming,IL,2020,3
+175,Awk,programming,IL,2020,3
 173,Lex,programming,IL,2020,3
 163,Yacc,programming,IL,2020,3
 154,ASP.NET,programming,IL,2020,3
-151,Tcl,programming,IL,2020,3
 151,Objective-C++,programming,IL,2020,3
+151,Tcl,programming,IL,2020,3
 146,GLSL,programming,IL,2020,3
 144,Gherkin,programming,IL,2020,3
 131,Fortran,programming,IL,2020,3
@@ -12902,8 +12945,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 175,QML,programming,IN,2020,3
 174,OpenEdge ABL,programming,IN,2020,3
 173,Racket,programming,IN,2020,3
-171,Crystal,programming,IN,2020,3
 171,Coq,programming,IN,2020,3
+171,Crystal,programming,IN,2020,3
 163,Classic ASP,programming,IN,2020,3
 151,Meson,programming,IN,2020,3
 144,NewLisp,programming,IN,2020,3
@@ -12917,8 +12960,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 115,SAS,programming,IN,2020,3
 115,PigLatin,programming,IN,2020,3
 113,Limbo,programming,IN,2020,3
-110,q,programming,IN,2020,3
 110,AutoHotkey,programming,IN,2020,3
+110,q,programming,IN,2020,3
 107,Reason,programming,IN,2020,3
 792,HTML,markup,IQ,2020,3
 494,CSS,markup,IQ,2020,3
@@ -12929,8 +12972,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,PHP,programming,IQ,2020,3
 114,Objective-C,programming,IQ,2020,3
 108,Lua,programming,IQ,2020,3
-102,Java,programming,IQ,2020,3
 102,Dart,programming,IQ,2020,3
+102,Java,programming,IQ,2020,3
 101,Swift,programming,IQ,2020,3
 5102,HTML,markup,IR,2020,3
 3635,CSS,markup,IR,2020,3
@@ -12961,8 +13004,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 176,CMake,programming,IR,2020,3
 171,Hack,programming,IR,2020,3
 153,MATLAB,programming,IR,2020,3
-145,Assembly,programming,IR,2020,3
 145,Dart,programming,IR,2020,3
+145,Assembly,programming,IR,2020,3
 117,Perl,programming,IR,2020,3
 624,HTML,markup,IS,2020,3
 518,CSS,markup,IS,2020,3
@@ -13041,14 +13084,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 207,HCL,programming,IT,2020,3
 198,Prolog,programming,IT,2020,3
 193,CoffeeScript,programming,IT,2020,3
-188,Pascal,programming,IT,2020,3
 188,PLSQL,programming,IT,2020,3
+188,Pascal,programming,IT,2020,3
 172,Raku,programming,IT,2020,3
 171,NSIS,programming,IT,2020,3
 165,SWIG,programming,IT,2020,3
 159,Haskell,programming,IT,2020,3
-155,GDB,programming,IT,2020,3
 155,Clojure,programming,IT,2020,3
+155,GDB,programming,IT,2020,3
 146,FreeMarker,programming,IT,2020,3
 145,QML,programming,IT,2020,3
 142,Gnuplot,programming,IT,2020,3
@@ -13166,8 +13209,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 345,QMake,programming,JP,2020,3
 341,Pascal,programming,JP,2020,3
 335,AutoHotkey,programming,JP,2020,3
-327,Processing,programming,JP,2020,3
 327,Clojure,programming,JP,2020,3
+327,Processing,programming,JP,2020,3
 320,Gherkin,programming,JP,2020,3
 306,VBA,programming,JP,2020,3
 300,Elixir,programming,JP,2020,3
@@ -13178,8 +13221,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 232,D,programming,JP,2020,3
 227,NSIS,programming,JP,2020,3
 209,SWIG,programming,JP,2020,3
-207,Mako,programming,JP,2020,3
 207,XS,programming,JP,2020,3
+207,Mako,programming,JP,2020,3
 201,FreeMarker,programming,JP,2020,3
 196,Pawn,programming,JP,2020,3
 195,Gnuplot,programming,JP,2020,3
@@ -13199,14 +13242,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 148,Logos,programming,JP,2020,3
 144,Ada,programming,JP,2020,3
 139,ANTLR,programming,JP,2020,3
-137,Nim,programming,JP,2020,3
 137,Solidity,programming,JP,2020,3
+137,Nim,programming,JP,2020,3
 133,LLVM,programming,JP,2020,3
 130,SmPL,programming,JP,2020,3
 128,ASP.NET,programming,JP,2020,3
 124,SystemVerilog,programming,JP,2020,3
-119,Jsonnet,programming,JP,2020,3
 119,Coq,programming,JP,2020,3
+119,Jsonnet,programming,JP,2020,3
 115,Inno Setup,programming,JP,2020,3
 112,Ragel,programming,JP,2020,3
 107,RenderScript,programming,JP,2020,3
@@ -13297,8 +13340,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 4888,TypeScript,programming,KR,2020,3
 4361,C#,programming,KR,2020,3
 4309,PHP,programming,KR,2020,3
-3959,Batchfile,programming,KR,2020,3
 3959,Objective-C,programming,KR,2020,3
+3959,Batchfile,programming,KR,2020,3
 3725,Kotlin,programming,KR,2020,3
 2689,Swift,programming,KR,2020,3
 2325,CMake,programming,KR,2020,3
@@ -13358,8 +13401,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,QML,programming,KR,2020,3
 118,OCaml,programming,KR,2020,3
 117,PureBasic,programming,KR,2020,3
-114,XS,programming,KR,2020,3
 114,Forth,programming,KR,2020,3
+114,XS,programming,KR,2020,3
 112,DIGITAL Command Language,programming,KR,2020,3
 109,M,programming,KR,2020,3
 106,Pawn,programming,KR,2020,3
@@ -13374,8 +13417,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Ruby,programming,KW,2020,3
 3369,HTML,markup,KZ,2020,3
 2422,CSS,markup,KZ,2020,3
-332,SCSS,markup,KZ,2020,3
 332,Vue,markup,KZ,2020,3
+332,SCSS,markup,KZ,2020,3
 260,Jupyter Notebook,markup,KZ,2020,3
 105,Blade,markup,KZ,2020,3
 2361,JavaScript,programming,KZ,2020,3
@@ -13440,8 +13483,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 278,Makefile,programming,LK,2020,3
 252,Scala,programming,LK,2020,3
 202,XSLT,programming,LK,2020,3
-194,Starlark,programming,LK,2020,3
 194,PowerShell,programming,LK,2020,3
+194,Starlark,programming,LK,2020,3
 164,Ballerina,programming,LK,2020,3
 156,PLSQL,programming,LK,2020,3
 142,Go,programming,LK,2020,3
@@ -13820,8 +13863,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 240,Fortran,programming,NL,2020,3
 236,Tcl,programming,NL,2020,3
 235,Raku,programming,NL,2020,3
-234,CoffeeScript,programming,NL,2020,3
 234,Nix,programming,NL,2020,3
+234,CoffeeScript,programming,NL,2020,3
 229,Scheme,programming,NL,2020,3
 225,Smalltalk,programming,NL,2020,3
 222,NSIS,programming,NL,2020,3
@@ -13832,8 +13875,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 175,SWIG,programming,NL,2020,3
 172,ANTLR,programming,NL,2020,3
 171,Elixir,programming,NL,2020,3
-168,Prolog,programming,NL,2020,3
 168,GDB,programming,NL,2020,3
+168,Prolog,programming,NL,2020,3
 165,FreeMarker,programming,NL,2020,3
 157,QML,programming,NL,2020,3
 149,Processing,programming,NL,2020,3
@@ -13844,17 +13887,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,NASL,programming,NL,2020,3
 131,Pawn,programming,NL,2020,3
 129,ASP.NET,programming,NL,2020,3
-129,Rebol,programming,NL,2020,3
 129,Julia,programming,NL,2020,3
-127,Inno Setup,programming,NL,2020,3
+129,Rebol,programming,NL,2020,3
 127,Mako,programming,NL,2020,3
+127,Inno Setup,programming,NL,2020,3
+122,Erlang,programming,NL,2020,3
 122,M,programming,NL,2020,3
 122,D,programming,NL,2020,3
-122,Erlang,programming,NL,2020,3
 121,F#,programming,NL,2020,3
 118,Standard ML,programming,NL,2020,3
-117,OpenSCAD,programming,NL,2020,3
 117,VBScript,programming,NL,2020,3
+117,OpenSCAD,programming,NL,2020,3
 114,OCaml,programming,NL,2020,3
 107,Gnuplot,programming,NL,2020,3
 7248,HTML,markup,NO,2020,3
@@ -14198,19 +14241,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 148,NSIS,programming,PL,2020,3
 133,Pawn,programming,PL,2020,3
 128,QML,programming,PL,2020,3
-126,SmPL,programming,PL,2020,3
 126,ANTLR,programming,PL,2020,3
+126,SmPL,programming,PL,2020,3
 125,ASP.NET,programming,PL,2020,3
 116,Scheme,programming,PL,2020,3
-114,FreeMarker,programming,PL,2020,3
 114,Meson,programming,PL,2020,3
+114,FreeMarker,programming,PL,2020,3
 113,GAP,programming,PL,2020,3
-109,Erlang,programming,PL,2020,3
 109,NASL,programming,PL,2020,3
+109,Erlang,programming,PL,2020,3
 105,F#,programming,PL,2020,3
 103,OCaml,programming,PL,2020,3
-102,GDScript,programming,PL,2020,3
 102,Mathematica,programming,PL,2020,3
+102,GDScript,programming,PL,2020,3
 101,Inno Setup,programming,PL,2020,3
 101,SQLPL,programming,PL,2020,3
 529,HTML,markup,PR,2020,3
@@ -14281,8 +14324,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 124,PLpgSQL,programming,PT,2020,3
 124,HCL,programming,PT,2020,3
 122,Yacc,programming,PT,2020,3
-117,Lex,programming,PT,2020,3
 117,Prolog,programming,PT,2020,3
+117,Lex,programming,PT,2020,3
 113,Haskell,programming,PT,2020,3
 102,Emacs Lisp,programming,PT,2020,3
 777,HTML,markup,PY,2020,3
@@ -14500,12 +14543,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,AppleScript,programming,RU,2020,3
 161,Verilog,programming,RU,2020,3
 160,UnrealScript,programming,RU,2020,3
-155,M,programming,RU,2020,3
 155,Gnuplot,programming,RU,2020,3
+155,M,programming,RU,2020,3
 145,Logos,programming,RU,2020,3
 143,DM,programming,RU,2020,3
-142,Module Management System,programming,RU,2020,3
 142,Julia,programming,RU,2020,3
+142,Module Management System,programming,RU,2020,3
 137,Jsonnet,programming,RU,2020,3
 133,GDScript,programming,RU,2020,3
 130,Processing,programming,RU,2020,3
@@ -14514,8 +14557,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Rebol,programming,RU,2020,3
 112,AMPL,programming,RU,2020,3
 111,RenderScript,programming,RU,2020,3
-102,Thrift,programming,RU,2020,3
 102,SAS,programming,RU,2020,3
+102,Thrift,programming,RU,2020,3
 101,Metal,programming,RU,2020,3
 101,SystemVerilog,programming,RU,2020,3
 809,HTML,markup,RW,2020,3
@@ -14604,8 +14647,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 353,ShaderLab,programming,SE,2020,3
 306,Scala,programming,SE,2020,3
 302,Smarty,programming,SE,2020,3
-260,Haskell,programming,SE,2020,3
 260,Groovy,programming,SE,2020,3
+260,Haskell,programming,SE,2020,3
 253,Awk,programming,SE,2020,3
 251,Starlark,programming,SE,2020,3
 248,Objective-C++,programming,SE,2020,3
@@ -14976,8 +15019,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 202,Tcl,programming,TW,2020,3
 199,Objective-C++,programming,TW,2020,3
 198,Emacs Lisp,programming,TW,2020,3
-194,sed,programming,TW,2020,3
 194,ASP.NET,programming,TW,2020,3
+194,sed,programming,TW,2020,3
 183,QMake,programming,TW,2020,3
 175,Smalltalk,programming,TW,2020,3
 174,Verilog,programming,TW,2020,3
@@ -14992,8 +15035,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,PLSQL,programming,TW,2020,3
 124,Fortran,programming,TW,2020,3
 109,Haskell,programming,TW,2020,3
-101,Clojure,programming,TW,2020,3
 101,SmPL,programming,TW,2020,3
+101,Clojure,programming,TW,2020,3
 685,HTML,markup,TZ,2020,3
 546,CSS,markup,TZ,2020,3
 516,JavaScript,programming,TZ,2020,3
@@ -15074,8 +15117,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,Lex,programming,UA,2020,3
 139,Clojure,programming,UA,2020,3
 125,Raku,programming,UA,2020,3
-124,Haskell,programming,UA,2020,3
 124,QML,programming,UA,2020,3
+124,Haskell,programming,UA,2020,3
 111,VCL,programming,UA,2020,3
 102,Tcl,programming,UA,2020,3
 1384,HTML,markup,UG,2020,3
@@ -15242,8 +15285,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 761,UnrealScript,programming,US,2020,3
 760,Racket,programming,US,2020,3
 725,Elm,programming,US,2020,3
-671,MLIR,programming,US,2020,3
 671,ActionScript,programming,US,2020,3
+671,MLIR,programming,US,2020,3
 662,DM,programming,US,2020,3
 649,RobotFramework,programming,US,2020,3
 635,Metal,programming,US,2020,3
@@ -15264,8 +15307,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 422,RPC,programming,US,2020,3
 407,PureScript,programming,US,2020,3
 401,Brainfuck,programming,US,2020,3
-397,NCL,programming,US,2020,3
 397,q,programming,US,2020,3
+397,NCL,programming,US,2020,3
 382,Limbo,programming,US,2020,3
 378,Max,programming,US,2020,3
 375,AGS Script,programming,US,2020,3
@@ -15283,8 +15326,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 309,Jasmin,programming,US,2020,3
 299,POV-Ray SDL,programming,US,2020,3
 293,Cap'n Proto,programming,US,2020,3
-291,Classic ASP,programming,US,2020,3
 291,Open Policy Agent,programming,US,2020,3
+291,Classic ASP,programming,US,2020,3
 287,Sage,programming,US,2020,3
 286,CodeQL,programming,US,2020,3
 272,Vala,programming,US,2020,3
@@ -15324,15 +15367,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,AspectJ,programming,US,2020,3
 143,CartoCSS,programming,US,2020,3
 142,Nearley,programming,US,2020,3
-142,Harbour,programming,US,2020,3
 142,Slash,programming,US,2020,3
+142,Harbour,programming,US,2020,3
 131,Clean,programming,US,2020,3
 130,Pike,programming,US,2020,3
 124,NetLogo,programming,US,2020,3
 123,Qt Script,programming,US,2020,3
 121,Xtend,programming,US,2020,3
-119,LSL,programming,US,2020,3
 119,Agda,programming,US,2020,3
+119,LSL,programming,US,2020,3
 118,Lean,programming,US,2020,3
 117,mIRC Script,programming,US,2020,3
 114,Faust,programming,US,2020,3
@@ -15349,8 +15392,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,Ren'Py,programming,US,2020,3
 106,P4,programming,US,2020,3
 105,Isabelle,programming,US,2020,3
-104,Lasso,programming,US,2020,3
 104,Asymptote,programming,US,2020,3
+104,Lasso,programming,US,2020,3
 2169,HTML,markup,UY,2020,3
 1806,CSS,markup,UY,2020,3
 257,SCSS,markup,UY,2020,3
@@ -15371,8 +15414,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,Batchfile,programming,UY,2020,3
 2134,HTML,markup,UZ,2020,3
 1575,CSS,markup,UZ,2020,3
-218,SCSS,markup,UZ,2020,3
 218,Vue,markup,UZ,2020,3
+218,SCSS,markup,UZ,2020,3
 1469,JavaScript,programming,UZ,2020,3
 514,Shell,programming,UZ,2020,3
 478,Python,programming,UZ,2020,3
@@ -15629,8 +15672,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 326,ShaderLab,programming,AR,2020,4
 322,HLSL,programming,AR,2020,4
 311,Perl,programming,AR,2020,4
-299,Dart,programming,AR,2020,4
 299,Starlark,programming,AR,2020,4
+299,Dart,programming,AR,2020,4
 286,Yacc,programming,AR,2020,4
 273,Wollok,programming,AR,2020,4
 259,Lex,programming,AR,2020,4
@@ -15701,8 +15744,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 193,Scala,programming,AT,2020,4
 187,HLSL,programming,AT,2020,4
 187,Emacs Lisp,programming,AT,2020,4
-182,ShaderLab,programming,AT,2020,4
 182,MATLAB,programming,AT,2020,4
+182,ShaderLab,programming,AT,2020,4
 178,Awk,programming,AT,2020,4
 173,QMake,programming,AT,2020,4
 158,Haskell,programming,AT,2020,4
@@ -15711,8 +15754,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,Yacc,programming,AT,2020,4
 122,Lex,programming,AT,2020,4
 118,Tcl,programming,AT,2020,4
-117,sed,programming,AT,2020,4
 117,PLpgSQL,programming,AT,2020,4
+117,sed,programming,AT,2020,4
 114,Raku,programming,AT,2020,4
 110,NSIS,programming,AT,2020,4
 108,TSQL,programming,AT,2020,4
@@ -15813,8 +15856,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,M,programming,AU,2020,4
 135,Common Lisp,programming,AU,2020,4
 135,PLSQL,programming,AU,2020,4
-134,Elixir,programming,AU,2020,4
 134,VBA,programming,AU,2020,4
+134,Elixir,programming,AU,2020,4
 132,Prolog,programming,AU,2020,4
 123,DIGITAL Command Language,programming,AU,2020,4
 120,AutoHotkey,programming,AU,2020,4
@@ -15847,8 +15890,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 297,TypeScript,programming,BA,2020,4
 266,PHP,programming,BA,2020,4
 260,Python,programming,BA,2020,4
-183,Ruby,programming,BA,2020,4
 183,Dockerfile,programming,BA,2020,4
+183,Ruby,programming,BA,2020,4
 157,C++,programming,BA,2020,4
 114,C,programming,BA,2020,4
 16631,HTML,markup,BD,2020,4
@@ -16115,8 +16158,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 359,Visual Basic .NET,programming,BR,2020,4
 348,GDScript,programming,BR,2020,4
 342,VHDL,programming,BR,2020,4
-332,Processing,programming,BR,2020,4
 332,Rebol,programming,BR,2020,4
+332,Processing,programming,BR,2020,4
 329,VBA,programming,BR,2020,4
 320,sed,programming,BR,2020,4
 320,Objective-C++,programming,BR,2020,4
@@ -16156,8 +16199,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Inno Setup,programming,BR,2020,4
 134,Apex,programming,BR,2020,4
 133,Nix,programming,BR,2020,4
-130,Scilab,programming,BR,2020,4
 130,Gnuplot,programming,BR,2020,4
+130,Scilab,programming,BR,2020,4
 127,SmPL,programming,BR,2020,4
 124,ActionScript,programming,BR,2020,4
 124,Meson,programming,BR,2020,4
@@ -16178,8 +16221,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 335,Jupyter Notebook,markup,BY,2020,4
 218,Sass,markup,BY,2020,4
 187,Roff,markup,BY,2020,4
-160,Handlebars,markup,BY,2020,4
 160,Pug,markup,BY,2020,4
+160,Handlebars,markup,BY,2020,4
 149,Blade,markup,BY,2020,4
 116,TeX,markup,BY,2020,4
 110,Rich Text Format,markup,BY,2020,4
@@ -16218,8 +16261,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Lua,programming,BY,2020,4
 140,XSLT,programming,BY,2020,4
 122,Smarty,programming,BY,2020,4
-120,Vim Script,programming,BY,2020,4
 120,GLSL,programming,BY,2020,4
+120,Vim Script,programming,BY,2020,4
 103,Rust,programming,BY,2020,4
 121,HTML,markup,BZ,2020,4
 55297,HTML,markup,CA,2020,4
@@ -16319,8 +16362,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 274,VBScript,programming,CA,2020,4
 258,Prolog,programming,CA,2020,4
 256,FreeMarker,programming,CA,2020,4
-250,AppleScript,programming,CA,2020,4
 250,Visual Basic .NET,programming,CA,2020,4
+250,AppleScript,programming,CA,2020,4
 246,Verilog,programming,CA,2020,4
 246,GAP,programming,CA,2020,4
 241,F#,programming,CA,2020,4
@@ -16330,8 +16373,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 225,GDScript,programming,CA,2020,4
 221,AutoHotkey,programming,CA,2020,4
 217,Rebol,programming,CA,2020,4
-212,Meson,programming,CA,2020,4
 212,OCaml,programming,CA,2020,4
+212,Meson,programming,CA,2020,4
 209,DTrace,programming,CA,2020,4
 200,VBA,programming,CA,2020,4
 191,ANTLR,programming,CA,2020,4
@@ -16352,8 +16395,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,PureBasic,programming,CA,2020,4
 118,ActionScript,programming,CA,2020,4
 117,RenderScript,programming,CA,2020,4
-107,SuperCollider,programming,CA,2020,4
 107,Thrift,programming,CA,2020,4
+107,SuperCollider,programming,CA,2020,4
 105,Crystal,programming,CA,2020,4
 105,SmPL,programming,CA,2020,4
 105,Ada,programming,CA,2020,4
@@ -16440,8 +16483,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,M,programming,CH,2020,4
 149,Raku,programming,CH,2020,4
 146,NSIS,programming,CH,2020,4
-143,Clojure,programming,CH,2020,4
 143,NASL,programming,CH,2020,4
+143,Clojure,programming,CH,2020,4
 143,Mako,programming,CH,2020,4
 130,Rebol,programming,CH,2020,4
 124,Common Lisp,programming,CH,2020,4
@@ -16839,8 +16882,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 166,Objective-C++,programming,CZ,2020,4
 164,HCL,programming,CZ,2020,4
 158,Dart,programming,CZ,2020,4
-142,Starlark,programming,CZ,2020,4
 142,Haskell,programming,CZ,2020,4
+142,Starlark,programming,CZ,2020,4
 139,Tcl,programming,CZ,2020,4
 136,FreeMarker,programming,CZ,2020,4
 131,Smalltalk,programming,CZ,2020,4
@@ -16853,8 +16896,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Nix,programming,CZ,2020,4
 111,CoffeeScript,programming,CZ,2020,4
 110,Mako,programming,CZ,2020,4
-109,Meson,programming,CZ,2020,4
 109,Clojure,programming,CZ,2020,4
+109,Meson,programming,CZ,2020,4
 59856,HTML,markup,DE,2020,4
 42567,CSS,markup,DE,2020,4
 14659,SCSS,markup,DE,2020,4
@@ -17000,8 +17043,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 208,OpenEdge ABL,programming,DE,2020,4
 203,PureBasic,programming,DE,2020,4
 199,Thrift,programming,DE,2020,4
-189,Module Management System,programming,DE,2020,4
 189,SystemVerilog,programming,DE,2020,4
+189,Module Management System,programming,DE,2020,4
 177,Nim,programming,DE,2020,4
 174,SQLPL,programming,DE,2020,4
 169,RobotFramework,programming,DE,2020,4
@@ -17010,11 +17053,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 162,SAS,programming,DE,2020,4
 155,ABAP,programming,DE,2020,4
 147,SaltStack,programming,DE,2020,4
-144,WebAssembly,programming,DE,2020,4
 144,Stata,programming,DE,2020,4
+144,WebAssembly,programming,DE,2020,4
 142,BitBake,programming,DE,2020,4
-140,Coq,programming,DE,2020,4
 140,Mercury,programming,DE,2020,4
+140,Coq,programming,DE,2020,4
 139,XQuery,programming,DE,2020,4
 133,Haxe,programming,DE,2020,4
 127,NewLisp,programming,DE,2020,4
@@ -17025,15 +17068,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,ASL,programming,DE,2020,4
 119,Racket,programming,DE,2020,4
 119,AGS Script,programming,DE,2020,4
+115,RPC,programming,DE,2020,4
 115,VCL,programming,DE,2020,4
 115,Ragel,programming,DE,2020,4
-115,RPC,programming,DE,2020,4
-113,IDL,programming,DE,2020,4
 113,Isabelle,programming,DE,2020,4
-112,EmberScript,programming,DE,2020,4
+113,IDL,programming,DE,2020,4
 112,COBOL,programming,DE,2020,4
-110,Classic ASP,programming,DE,2020,4
+112,EmberScript,programming,DE,2020,4
 110,Terra,programming,DE,2020,4
+110,Classic ASP,programming,DE,2020,4
 105,AngelScript,programming,DE,2020,4
 102,ReScript,programming,DE,2020,4
 101,POV-Ray SDL,programming,DE,2020,4
@@ -17299,12 +17342,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 360,Starlark,programming,ES,2020,4
 348,CoffeeScript,programming,ES,2020,4
 323,Awk,programming,ES,2020,4
-321,Fortran,programming,ES,2020,4
 321,ASP.NET,programming,ES,2020,4
+321,Fortran,programming,ES,2020,4
 314,sed,programming,ES,2020,4
 309,Lex,programming,ES,2020,4
-301,Yacc,programming,ES,2020,4
 301,PLpgSQL,programming,ES,2020,4
+301,Yacc,programming,ES,2020,4
 297,Haskell,programming,ES,2020,4
 285,Tcl,programming,ES,2020,4
 275,Pascal,programming,ES,2020,4
@@ -17327,8 +17370,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 166,GDB,programming,ES,2020,4
 158,Visual Basic .NET,programming,ES,2020,4
 155,Common Lisp,programming,ES,2020,4
-147,Scheme,programming,ES,2020,4
 147,M,programming,ES,2020,4
+147,Scheme,programming,ES,2020,4
 146,ANTLR,programming,ES,2020,4
 140,Prolog,programming,ES,2020,4
 139,Ada,programming,ES,2020,4
@@ -17357,6 +17400,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 175,PHP,programming,ET,2020,4
 125,TypeScript,programming,ET,2020,4
 105,Dockerfile,programming,ET,2020,4
+337955,HTML,markup,EU,2020,4
+251180,CSS,markup,EU,2020,4
+81334,SCSS,markup,EU,2020,4
+40839,Jupyter Notebook,markup,EU,2020,4
+23559,Vue,markup,EU,2020,4
+18542,TeX,markup,EU,2020,4
+15750,Roff,markup,EU,2020,4
+12543,Less,markup,EU,2020,4
+8297,Twig,markup,EU,2020,4
+7154,Blade,markup,EU,2020,4
+6789,Handlebars,markup,EU,2020,4
+4269,Pug,markup,EU,2020,4
+4087,Sass,markup,EU,2020,4
+4086,Rich Text Format,markup,EU,2020,4
+1418,Stylus,markup,EU,2020,4
+1372,Svelte,markup,EU,2020,4
+1316,Vim Snippet,markup,EU,2020,4
+1148,PostScript,markup,EU,2020,4
+343,Haml,markup,EU,2020,4
+275,Liquid,markup,EU,2020,4
+228,Slim,markup,EU,2020,4
+216,Latte,markup,EU,2020,4
+157,YASnippet,markup,EU,2020,4
 285632,JavaScript,programming,EU,2020,4
 200035,Shell,programming,EU,2020,4
 187503,Python,programming,EU,2020,4
@@ -17443,8 +17509,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1231,D,programming,EU,2020,4
 1178,F#,programming,EU,2020,4
 1089,VBScript,programming,EU,2020,4
-1027,Verilog,programming,EU,2020,4
 1027,Pawn,programming,EU,2020,4
+1027,Verilog,programming,EU,2020,4
 981,DIGITAL Command Language,programming,EU,2020,4
 945,VBA,programming,EU,2020,4
 904,VHDL,programming,EU,2020,4
@@ -17494,8 +17560,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 162,SAS,programming,EU,2020,4
 155,ABAP,programming,EU,2020,4
 147,SaltStack,programming,EU,2020,4
-144,WebAssembly,programming,EU,2020,4
 144,Stata,programming,EU,2020,4
+144,WebAssembly,programming,EU,2020,4
 142,BitBake,programming,EU,2020,4
 140,Mercury,programming,EU,2020,4
 139,XQuery,programming,EU,2020,4
@@ -17505,16 +17571,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,Max,programming,EU,2020,4
 121,Apex,programming,EU,2020,4
 120,ASL,programming,EU,2020,4
-119,AGS Script,programming,EU,2020,4
 119,Racket,programming,EU,2020,4
-115,Ragel,programming,EU,2020,4
+119,AGS Script,programming,EU,2020,4
 115,RPC,programming,EU,2020,4
+115,Ragel,programming,EU,2020,4
 113,Isabelle,programming,EU,2020,4
 113,IDL,programming,EU,2020,4
 112,Papyrus,programming,EU,2020,4
 112,EmberScript,programming,EU,2020,4
-110,Terra,programming,EU,2020,4
 110,Classic ASP,programming,EU,2020,4
+110,Terra,programming,EU,2020,4
 105,AngelScript,programming,EU,2020,4
 102,ReScript,programming,EU,2020,4
 101,POV-Ray SDL,programming,EU,2020,4
@@ -17650,8 +17716,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 706,OCaml,programming,FR,2020,4
 640,Tcl,programming,FR,2020,4
 637,CoffeeScript,programming,FR,2020,4
-566,Pascal,programming,FR,2020,4
 566,Cuda,programming,FR,2020,4
+566,Pascal,programming,FR,2020,4
 565,sed,programming,FR,2020,4
 558,NSIS,programming,FR,2020,4
 550,Haskell,programming,FR,2020,4
@@ -17673,8 +17739,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 381,Mako,programming,FR,2020,4
 372,FreeMarker,programming,FR,2020,4
 368,GAP,programming,FR,2020,4
-367,Prolog,programming,FR,2020,4
 367,Clojure,programming,FR,2020,4
+367,Prolog,programming,FR,2020,4
 354,NASL,programming,FR,2020,4
 352,Solidity,programming,FR,2020,4
 337,QML,programming,FR,2020,4
@@ -17697,14 +17763,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 203,Ada,programming,FR,2020,4
 202,VBA,programming,FR,2020,4
 198,Scilab,programming,FR,2020,4
-180,Coq,programming,FR,2020,4
 180,SmPL,programming,FR,2020,4
+180,Coq,programming,FR,2020,4
 176,Visual Basic .NET,programming,FR,2020,4
-173,OpenSCAD,programming,FR,2020,4
 173,XS,programming,FR,2020,4
+173,OpenSCAD,programming,FR,2020,4
 168,DTrace,programming,FR,2020,4
-167,ActionScript,programming,FR,2020,4
 167,LLVM,programming,FR,2020,4
+167,ActionScript,programming,FR,2020,4
 165,AMPL,programming,FR,2020,4
 163,Elm,programming,FR,2020,4
 161,Jsonnet,programming,FR,2020,4
@@ -17715,9 +17781,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 150,G-code,programming,FR,2020,4
 129,Haxe,programming,FR,2020,4
 128,Puppet,programming,FR,2020,4
-126,VCL,programming,FR,2020,4
-126,COBOL,programming,FR,2020,4
 126,SourcePawn,programming,FR,2020,4
+126,COBOL,programming,FR,2020,4
+126,VCL,programming,FR,2020,4
 124,OpenEdge ABL,programming,FR,2020,4
 120,UnrealScript,programming,FR,2020,4
 118,RenderScript,programming,FR,2020,4
@@ -17818,27 +17884,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 484,Scheme,programming,GB,2020,4
 482,Elixir,programming,GB,2020,4
 479,Mako,programming,GB,2020,4
-461,M,programming,GB,2020,4
 461,SWIG,programming,GB,2020,4
+461,M,programming,GB,2020,4
 445,OCaml,programming,GB,2020,4
 401,NASL,programming,GB,2020,4
 398,Processing,programming,GB,2020,4
 394,AppleScript,programming,GB,2020,4
-388,VBScript,programming,GB,2020,4
 388,Prolog,programming,GB,2020,4
+388,VBScript,programming,GB,2020,4
 382,Pawn,programming,GB,2020,4
 374,Solidity,programming,GB,2020,4
 367,FreeMarker,programming,GB,2020,4
 362,ANTLR,programming,GB,2020,4
 347,Inno Setup,programming,GB,2020,4
 344,Gnuplot,programming,GB,2020,4
-343,GAP,programming,GB,2020,4
 343,DTrace,programming,GB,2020,4
+343,GAP,programming,GB,2020,4
 338,Erlang,programming,GB,2020,4
 336,Meson,programming,GB,2020,4
 336,DIGITAL Command Language,programming,GB,2020,4
-333,Forth,programming,GB,2020,4
 333,Visual Basic .NET,programming,GB,2020,4
+333,Forth,programming,GB,2020,4
 324,D,programming,GB,2020,4
 318,Rebol,programming,GB,2020,4
 297,Puppet,programming,GB,2020,4
@@ -17849,8 +17915,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 253,Standard ML,programming,GB,2020,4
 252,Logos,programming,GB,2020,4
 248,Cycript,programming,GB,2020,4
-242,Elm,programming,GB,2020,4
 242,OpenSCAD,programming,GB,2020,4
+242,Elm,programming,GB,2020,4
 240,VBA,programming,GB,2020,4
 235,SuperCollider,programming,GB,2020,4
 226,RenderScript,programming,GB,2020,4
@@ -17875,17 +17941,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,SourcePawn,programming,GB,2020,4
 142,VHDL,programming,GB,2020,4
 133,MLIR,programming,GB,2020,4
-132,RobotFramework,programming,GB,2020,4
 132,Stan,programming,GB,2020,4
+132,RobotFramework,programming,GB,2020,4
 131,SystemVerilog,programming,GB,2020,4
-127,PureScript,programming,GB,2020,4
 127,Apex,programming,GB,2020,4
+127,PureScript,programming,GB,2020,4
 124,Module Management System,programming,GB,2020,4
 120,SAS,programming,GB,2020,4
-119,Nim,programming,GB,2020,4
 119,Racket,programming,GB,2020,4
-118,Brainfuck,programming,GB,2020,4
+119,Nim,programming,GB,2020,4
 118,DM,programming,GB,2020,4
+118,Brainfuck,programming,GB,2020,4
 115,VCL,programming,GB,2020,4
 112,COBOL,programming,GB,2020,4
 111,Cool,programming,GB,2020,4
@@ -17957,12 +18023,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 309,Go,programming,GR,2020,4
 254,Assembly,programming,GR,2020,4
 248,R,programming,GR,2020,4
-237,MATLAB,programming,GR,2020,4
 237,PowerShell,programming,GR,2020,4
+237,MATLAB,programming,GR,2020,4
 233,Perl,programming,GR,2020,4
 206,Kotlin,programming,GR,2020,4
-180,Hack,programming,GR,2020,4
 180,Vim Script,programming,GR,2020,4
+180,Hack,programming,GR,2020,4
 159,Swift,programming,GR,2020,4
 156,Lua,programming,GR,2020,4
 122,M4,programming,GR,2020,4
@@ -18043,8 +18109,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 695,Smarty,programming,HK,2020,4
 669,Dart,programming,HK,2020,4
 648,MATLAB,programming,HK,2020,4
-644,Yacc,programming,HK,2020,4
 644,R,programming,HK,2020,4
+644,Yacc,programming,HK,2020,4
 643,Rust,programming,HK,2020,4
 630,Awk,programming,HK,2020,4
 618,Lex,programming,HK,2020,4
@@ -18064,8 +18130,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 304,TSQL,programming,HK,2020,4
 265,CoffeeScript,programming,HK,2020,4
 261,Ada,programming,HK,2020,4
-259,ShaderLab,programming,HK,2020,4
 259,HLSL,programming,HK,2020,4
+259,ShaderLab,programming,HK,2020,4
 244,GDB,programming,HK,2020,4
 244,Hack,programming,HK,2020,4
 238,Tcl,programming,HK,2020,4
@@ -18089,8 +18155,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,NASL,programming,HK,2020,4
 130,Smalltalk,programming,HK,2020,4
 125,UnrealScript,programming,HK,2020,4
-124,Pawn,programming,HK,2020,4
 124,ASL,programming,HK,2020,4
+124,Pawn,programming,HK,2020,4
 122,VBScript,programming,HK,2020,4
 111,Classic ASP,programming,HK,2020,4
 110,PLSQL,programming,HK,2020,4
@@ -18187,8 +18253,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Lex,programming,HU,2020,4
 116,Smarty,programming,HU,2020,4
 114,Starlark,programming,HU,2020,4
-111,HLSL,programming,HU,2020,4
 111,TSQL,programming,HU,2020,4
+111,HLSL,programming,HU,2020,4
 110,PLpgSQL,programming,HU,2020,4
 109,Gherkin,programming,HU,2020,4
 104,Emacs Lisp,programming,HU,2020,4
@@ -18231,8 +18297,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 814,PowerShell,programming,ID,2020,4
 659,Perl,programming,ID,2020,4
 656,Smarty,programming,ID,2020,4
-638,Assembly,programming,ID,2020,4
 638,R,programming,ID,2020,4
+638,Assembly,programming,ID,2020,4
 609,Rust,programming,ID,2020,4
 531,CoffeeScript,programming,ID,2020,4
 419,MATLAB,programming,ID,2020,4
@@ -18255,8 +18321,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 235,Scala,programming,ID,2020,4
 231,Julia,programming,ID,2020,4
 217,Prolog,programming,ID,2020,4
-207,Brainfuck,programming,ID,2020,4
 207,Elixir,programming,ID,2020,4
+207,Brainfuck,programming,ID,2020,4
 205,Forth,programming,ID,2020,4
 203,XSLT,programming,ID,2020,4
 202,GLSL,programming,ID,2020,4
@@ -18269,8 +18335,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 159,Tcl,programming,ID,2020,4
 159,Nim,programming,ID,2020,4
 157,Scheme,programming,ID,2020,4
-151,Yacc,programming,ID,2020,4
 151,Lex,programming,ID,2020,4
+151,Yacc,programming,ID,2020,4
 147,F#,programming,ID,2020,4
 145,Processing,programming,ID,2020,4
 144,Common Lisp,programming,ID,2020,4
@@ -18288,8 +18354,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,XS,programming,ID,2020,4
 112,M,programming,ID,2020,4
 111,VBScript,programming,ID,2020,4
-110,SmPL,programming,ID,2020,4
 110,Objective-C++,programming,ID,2020,4
+110,SmPL,programming,ID,2020,4
 109,CLIPS,programming,ID,2020,4
 109,UnrealScript,programming,ID,2020,4
 102,ABAP,programming,ID,2020,4
@@ -18343,10 +18409,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 139,GLSL,programming,IE,2020,4
 138,Gherkin,programming,IE,2020,4
 131,MATLAB,programming,IE,2020,4
-125,Cuda,programming,IE,2020,4
 125,Awk,programming,IE,2020,4
-118,ASP.NET,programming,IE,2020,4
+125,Cuda,programming,IE,2020,4
 118,Objective-C++,programming,IE,2020,4
+118,ASP.NET,programming,IE,2020,4
 118,Yacc,programming,IE,2020,4
 13335,HTML,markup,IL,2020,4
 9623,CSS,markup,IL,2020,4
@@ -18533,8 +18599,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 631,Nemerle,programming,IN,2020,4
 609,NewLisp,programming,IN,2020,4
 604,PureScript,programming,IN,2020,4
-594,Brightscript,programming,IN,2020,4
 594,QMake,programming,IN,2020,4
+594,Brightscript,programming,IN,2020,4
 588,FreeMarker,programming,IN,2020,4
 569,PureBasic,programming,IN,2020,4
 552,SmPL,programming,IN,2020,4
@@ -18577,8 +18643,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 211,LiveScript,programming,IN,2020,4
 211,GDScript,programming,IN,2020,4
 208,REXX,programming,IN,2020,4
-202,Red,programming,IN,2020,4
 202,SAS,programming,IN,2020,4
+202,Red,programming,IN,2020,4
 196,Gnuplot,programming,IN,2020,4
 194,Factor,programming,IN,2020,4
 193,Ring,programming,IN,2020,4
@@ -18598,8 +18664,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,Coq,programming,IN,2020,4
 148,Opa,programming,IN,2020,4
 146,Io,programming,IN,2020,4
-143,Limbo,programming,IN,2020,4
 143,Shen,programming,IN,2020,4
+143,Limbo,programming,IN,2020,4
 141,Golo,programming,IN,2020,4
 138,SourcePawn,programming,IN,2020,4
 134,Boo,programming,IN,2020,4
@@ -18611,8 +18677,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,PicoLisp,programming,IN,2020,4
 119,ASL,programming,IN,2020,4
 117,Objective-J,programming,IN,2020,4
-115,Frege,programming,IN,2020,4
 115,Mercury,programming,IN,2020,4
+115,Frege,programming,IN,2020,4
 114,SuperCollider,programming,IN,2020,4
 113,Odin,programming,IN,2020,4
 111,XQuery,programming,IN,2020,4
@@ -18747,8 +18813,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 284,Objective-C++,programming,IT,2020,4
 276,sed,programming,IT,2020,4
 260,Gherkin,programming,IT,2020,4
-256,Cuda,programming,IT,2020,4
 256,HCL,programming,IT,2020,4
+256,Cuda,programming,IT,2020,4
 219,Pascal,programming,IT,2020,4
 204,NSIS,programming,IT,2020,4
 201,Prolog,programming,IT,2020,4
@@ -18763,8 +18829,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 173,ASP.NET,programming,IT,2020,4
 172,FreeMarker,programming,IT,2020,4
 169,Julia,programming,IT,2020,4
-166,Solidity,programming,IT,2020,4
 166,PLSQL,programming,IT,2020,4
+166,Solidity,programming,IT,2020,4
 157,Gnuplot,programming,IT,2020,4
 155,ANTLR,programming,IT,2020,4
 151,Smalltalk,programming,IT,2020,4
@@ -18874,10 +18940,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 548,Groovy,programming,JP,2020,4
 540,Cuda,programming,JP,2020,4
 487,Lex,programming,JP,2020,4
-477,Fortran,programming,JP,2020,4
 477,sed,programming,JP,2020,4
-419,Nix,programming,JP,2020,4
+477,Fortran,programming,JP,2020,4
 419,TSQL,programming,JP,2020,4
+419,Nix,programming,JP,2020,4
 386,Processing,programming,JP,2020,4
 385,Smalltalk,programming,JP,2020,4
 382,Raku,programming,JP,2020,4
@@ -19062,14 +19128,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 324,Emacs Lisp,programming,KR,2020,4
 308,Smalltalk,programming,KR,2020,4
 294,Raku,programming,KR,2020,4
-275,sed,programming,KR,2020,4
 275,HCL,programming,KR,2020,4
+275,sed,programming,KR,2020,4
 257,CoffeeScript,programming,KR,2020,4
 244,Gherkin,programming,KR,2020,4
 222,Clojure,programming,KR,2020,4
 220,NSIS,programming,KR,2020,4
-206,TSQL,programming,KR,2020,4
 206,Mako,programming,KR,2020,4
+206,TSQL,programming,KR,2020,4
 182,XS,programming,KR,2020,4
 175,Mathematica,programming,KR,2020,4
 172,Pascal,programming,KR,2020,4
@@ -19176,16 +19242,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 209,Groovy,programming,LK,2020,4
 208,Perl,programming,LK,2020,4
 194,XSLT,programming,LK,2020,4
-187,Starlark,programming,LK,2020,4
 187,R,programming,LK,2020,4
+187,Starlark,programming,LK,2020,4
 180,MATLAB,programming,LK,2020,4
 175,Ballerina,programming,LK,2020,4
 158,Scala,programming,LK,2020,4
 148,PLSQL,programming,LK,2020,4
 117,CMake,programming,LK,2020,4
 117,ASP.NET,programming,LK,2020,4
-112,SQLPL,programming,LK,2020,4
 112,Assembly,programming,LK,2020,4
+112,SQLPL,programming,LK,2020,4
 111,Haskell,programming,LK,2020,4
 129,HTML,markup,LR,2020,4
 2859,HTML,markup,LT,2020,4
@@ -19480,8 +19546,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 13991,HTML,markup,NG,2020,4
 10759,CSS,markup,NG,2020,4
 3150,SCSS,markup,NG,2020,4
-1289,Vue,markup,NG,2020,4
 1289,Jupyter Notebook,markup,NG,2020,4
+1289,Vue,markup,NG,2020,4
 803,Blade,markup,NG,2020,4
 689,Less,markup,NG,2020,4
 292,Handlebars,markup,NG,2020,4
@@ -19578,8 +19644,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 441,Dart,programming,NL,2020,4
 403,Haskell,programming,NL,2020,4
 396,TSQL,programming,NL,2020,4
-390,Objective-C++,programming,NL,2020,4
 390,Yacc,programming,NL,2020,4
+390,Objective-C++,programming,NL,2020,4
 385,Awk,programming,NL,2020,4
 379,PLpgSQL,programming,NL,2020,4
 356,Starlark,programming,NL,2020,4
@@ -19605,8 +19671,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 194,SWIG,programming,NL,2020,4
 189,FreeMarker,programming,NL,2020,4
 182,Prolog,programming,NL,2020,4
-177,Julia,programming,NL,2020,4
 177,ANTLR,programming,NL,2020,4
+177,Julia,programming,NL,2020,4
 176,QML,programming,NL,2020,4
 166,Solidity,programming,NL,2020,4
 162,NASL,programming,NL,2020,4
@@ -19676,8 +19742,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 163,Scala,programming,NO,2020,4
 160,QMake,programming,NO,2020,4
 153,Gherkin,programming,NO,2020,4
-150,Tcl,programming,NO,2020,4
 150,Smarty,programming,NO,2020,4
+150,Tcl,programming,NO,2020,4
 146,PLpgSQL,programming,NO,2020,4
 146,Pascal,programming,NO,2020,4
 144,Fortran,programming,NO,2020,4
@@ -19762,8 +19828,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 187,Lua,programming,NZ,2020,4
 177,TSQL,programming,NZ,2020,4
 171,XSLT,programming,NZ,2020,4
-151,Scheme,programming,NZ,2020,4
 151,GLSL,programming,NZ,2020,4
+151,Scheme,programming,NZ,2020,4
 140,M4,programming,NZ,2020,4
 139,MATLAB,programming,NZ,2020,4
 135,Dart,programming,NZ,2020,4
@@ -19855,8 +19921,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 264,Go,programming,PH,2020,4
 256,PowerShell,programming,PH,2020,4
 230,R,programming,PH,2020,4
-186,Perl,programming,PH,2020,4
 186,Lua,programming,PH,2020,4
+186,Perl,programming,PH,2020,4
 178,ASP.NET,programming,PH,2020,4
 171,Rebol,programming,PH,2020,4
 159,CMake,programming,PH,2020,4
@@ -19974,8 +20040,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 333,Emacs Lisp,programming,PL,2020,4
 330,Yacc,programming,PL,2020,4
 323,Awk,programming,PL,2020,4
-309,Lex,programming,PL,2020,4
 309,Objective-C++,programming,PL,2020,4
+309,Lex,programming,PL,2020,4
 298,Haskell,programming,PL,2020,4
 291,Tcl,programming,PL,2020,4
 249,Pascal,programming,PL,2020,4
@@ -20001,10 +20067,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 129,ANTLR,programming,PL,2020,4
 125,F#,programming,PL,2020,4
 122,Scheme,programming,PL,2020,4
-121,SmPL,programming,PL,2020,4
 121,Julia,programming,PL,2020,4
-121,FreeMarker,programming,PL,2020,4
+121,SmPL,programming,PL,2020,4
 121,GDScript,programming,PL,2020,4
+121,FreeMarker,programming,PL,2020,4
 120,Inno Setup,programming,PL,2020,4
 119,Meson,programming,PL,2020,4
 118,VBA,programming,PL,2020,4
@@ -20153,8 +20219,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 403,Assembly,programming,RO,2020,4
 331,Perl,programming,RO,2020,4
 265,Hack,programming,RO,2020,4
-258,Dart,programming,RO,2020,4
 258,ASP.NET,programming,RO,2020,4
+258,Dart,programming,RO,2020,4
 248,XSLT,programming,RO,2020,4
 229,Vim Script,programming,RO,2020,4
 229,TSQL,programming,RO,2020,4
@@ -20175,8 +20241,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 128,Haskell,programming,RO,2020,4
 124,R,programming,RO,2020,4
 122,Awk,programming,RO,2020,4
-108,Tcl,programming,RO,2020,4
 108,HCL,programming,RO,2020,4
+108,Tcl,programming,RO,2020,4
 5646,HTML,markup,RS,2020,4
 4299,CSS,markup,RS,2020,4
 1327,SCSS,markup,RS,2020,4
@@ -20273,8 +20339,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 839,Starlark,programming,RU,2020,4
 820,Emacs Lisp,programming,RU,2020,4
 815,Yacc,programming,RU,2020,4
-801,MATLAB,programming,RU,2020,4
 801,Gherkin,programming,RU,2020,4
+801,MATLAB,programming,RU,2020,4
 754,Haskell,programming,RU,2020,4
 706,Lex,programming,RU,2020,4
 589,HCL,programming,RU,2020,4
@@ -20332,20 +20398,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,Logos,programming,RU,2020,4
 146,UnrealScript,programming,RU,2020,4
 140,GDScript,programming,RU,2020,4
-139,ActionScript,programming,RU,2020,4
 139,DM,programming,RU,2020,4
+139,ActionScript,programming,RU,2020,4
 136,SystemVerilog,programming,RU,2020,4
 132,LLVM,programming,RU,2020,4
 132,RenderScript,programming,RU,2020,4
 129,Module Management System,programming,RU,2020,4
-123,Jsonnet,programming,RU,2020,4
 123,Racket,programming,RU,2020,4
+123,Jsonnet,programming,RU,2020,4
 121,Thrift,programming,RU,2020,4
 119,Ada,programming,RU,2020,4
 117,OpenSCAD,programming,RU,2020,4
 113,AMPL,programming,RU,2020,4
-109,AutoHotkey,programming,RU,2020,4
 109,Classic ASP,programming,RU,2020,4
+109,AutoHotkey,programming,RU,2020,4
 107,Haxe,programming,RU,2020,4
 107,Metal,programming,RU,2020,4
 103,SAS,programming,RU,2020,4
@@ -20457,8 +20523,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 262,ASP.NET,programming,SE,2020,4
 248,HCL,programming,SE,2020,4
 231,QMake,programming,SE,2020,4
-216,Gherkin,programming,SE,2020,4
 216,Elixir,programming,SE,2020,4
+216,Gherkin,programming,SE,2020,4
 215,Yacc,programming,SE,2020,4
 212,Erlang,programming,SE,2020,4
 209,sed,programming,SE,2020,4
@@ -20474,8 +20540,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,Common Lisp,programming,SE,2020,4
 164,CoffeeScript,programming,SE,2020,4
 157,Smalltalk,programming,SE,2020,4
-149,Pascal,programming,SE,2020,4
 149,NSIS,programming,SE,2020,4
+149,Pascal,programming,SE,2020,4
 145,Scheme,programming,SE,2020,4
 144,F#,programming,SE,2020,4
 142,Raku,programming,SE,2020,4
@@ -20554,8 +20620,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 164,Objective-C++,programming,SG,2020,4
 152,Pascal,programming,SG,2020,4
 145,CoffeeScript,programming,SG,2020,4
-138,sed,programming,SG,2020,4
 138,Verilog,programming,SG,2020,4
+138,sed,programming,SG,2020,4
 136,Haskell,programming,SG,2020,4
 125,ANTLR,programming,SG,2020,4
 121,Clojure,programming,SG,2020,4
@@ -20593,8 +20659,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 226,Vue,markup,SK,2020,4
 188,Jupyter Notebook,markup,SK,2020,4
 160,TeX,markup,SK,2020,4
-128,Blade,markup,SK,2020,4
 128,Roff,markup,SK,2020,4
+128,Blade,markup,SK,2020,4
 120,Less,markup,SK,2020,4
 2166,JavaScript,programming,SK,2020,4
 1548,Shell,programming,SK,2020,4
@@ -20792,19 +20858,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 196,Gherkin,programming,TR,2020,4
 191,Rust,programming,TR,2020,4
 179,M4,programming,TR,2020,4
-138,XSLT,programming,TR,2020,4
 138,CoffeeScript,programming,TR,2020,4
+138,XSLT,programming,TR,2020,4
 136,QMake,programming,TR,2020,4
 126,PLpgSQL,programming,TR,2020,4
-117,HCL,programming,TR,2020,4
 117,Yacc,programming,TR,2020,4
-113,Groovy,programming,TR,2020,4
+117,HCL,programming,TR,2020,4
 113,Tcl,programming,TR,2020,4
+113,Groovy,programming,TR,2020,4
 112,Objective-C++,programming,TR,2020,4
 108,Lex,programming,TR,2020,4
 104,Scala,programming,TR,2020,4
-101,Haskell,programming,TR,2020,4
 101,Smalltalk,programming,TR,2020,4
+101,Haskell,programming,TR,2020,4
 260,HTML,markup,TT,2020,4
 180,CSS,markup,TT,2020,4
 182,JavaScript,programming,TT,2020,4
@@ -20939,8 +21005,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 455,Vim Script,programming,UA,2020,4
 452,HCL,programming,UA,2020,4
 428,Gherkin,programming,UA,2020,4
-426,Lua,programming,UA,2020,4
 426,TSQL,programming,UA,2020,4
+426,Lua,programming,UA,2020,4
 413,M4,programming,UA,2020,4
 410,Groovy,programming,UA,2020,4
 398,XSLT,programming,UA,2020,4
@@ -20965,12 +21031,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,sed,programming,UA,2020,4
 126,VCL,programming,UA,2020,4
 120,PLSQL,programming,UA,2020,4
-116,QML,programming,UA,2020,4
 116,Tcl,programming,UA,2020,4
 116,MATLAB,programming,UA,2020,4
+116,QML,programming,UA,2020,4
 115,Fortran,programming,UA,2020,4
-112,Erlang,programming,UA,2020,4
 112,Raku,programming,UA,2020,4
+112,Erlang,programming,UA,2020,4
 111,GDB,programming,UA,2020,4
 107,ANTLR,programming,UA,2020,4
 103,DIGITAL Command Language,programming,UA,2020,4
@@ -21167,8 +21233,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 390,Ragel,programming,US,2020,4
 384,NCL,programming,US,2020,4
 373,Arc,programming,US,2020,4
-368,RPC,programming,US,2020,4
 368,EmberScript,programming,US,2020,4
+368,RPC,programming,US,2020,4
 364,AGS Script,programming,US,2020,4
 355,q,programming,US,2020,4
 350,ReScript,programming,US,2020,4
@@ -21184,8 +21250,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 297,VCL,programming,US,2020,4
 288,CodeQL,programming,US,2020,4
 273,SMT,programming,US,2020,4
-270,xBase,programming,US,2020,4
 270,Open Policy Agent,programming,US,2020,4
+270,xBase,programming,US,2020,4
 268,XQuery,programming,US,2020,4
 267,LookML,programming,US,2020,4
 263,MAXScript,programming,US,2020,4
@@ -21202,17 +21268,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 200,eC,programming,US,2020,4
 197,Red,programming,US,2020,4
 194,TLA,programming,US,2020,4
+193,Qt Script,programming,US,2020,4
 193,mcfunction,programming,US,2020,4
 193,LOLCODE,programming,US,2020,4
-193,Qt Script,programming,US,2020,4
 192,Objective-J,programming,US,2020,4
 190,Common Workflow Language,programming,US,2020,4
 185,LiveScript,programming,US,2020,4
 184,AutoIt,programming,US,2020,4
 176,AspectJ,programming,US,2020,4
 166,Turing,programming,US,2020,4
-162,LabVIEW,programming,US,2020,4
 162,Hy,programming,US,2020,4
+162,LabVIEW,programming,US,2020,4
 157,ABAP,programming,US,2020,4
 153,E,programming,US,2020,4
 151,BlitzBasic,programming,US,2020,4
@@ -21223,17 +21289,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,Slash,programming,US,2020,4
 141,Eiffel,programming,US,2020,4
 139,CWeb,programming,US,2020,4
-133,REXX,programming,US,2020,4
 133,LilyPond,programming,US,2020,4
+133,REXX,programming,US,2020,4
 132,P4,programming,US,2020,4
-130,Zeek,programming,US,2020,4
 130,Clean,programming,US,2020,4
+130,Zeek,programming,US,2020,4
 130,Isabelle,programming,US,2020,4
 128,J,programming,US,2020,4
 128,Modelica,programming,US,2020,4
-127,Brightscript,programming,US,2020,4
-127,ZenScript,programming,US,2020,4
 127,Ren'Py,programming,US,2020,4
+127,ZenScript,programming,US,2020,4
+127,Brightscript,programming,US,2020,4
 121,Agda,programming,US,2020,4
 120,Xtend,programming,US,2020,4
 119,FLUX,programming,US,2020,4
@@ -21241,8 +21307,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Rascal,programming,US,2020,4
 115,mIRC Script,programming,US,2020,4
 114,Lean,programming,US,2020,4
-112,HyPhy,programming,US,2020,4
 112,Faust,programming,US,2020,4
+112,HyPhy,programming,US,2020,4
 112,LSL,programming,US,2020,4
 111,SQF,programming,US,2020,4
 110,Idris,programming,US,2020,4
@@ -21497,8 +21563,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 166,Makefile,programming,AM,2021,1
 157,C,programming,AM,2021,1
 136,Kotlin,programming,AM,2021,1
-106,Objective-C,programming,AM,2021,1
 106,Swift,programming,AM,2021,1
+106,Objective-C,programming,AM,2021,1
 427,HTML,markup,AO,2021,1
 319,CSS,markup,AO,2021,1
 361,JavaScript,programming,AO,2021,1
@@ -21629,14 +21695,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,PLpgSQL,programming,AT,2021,1
 130,Lex,programming,AT,2021,1
 129,ANTLR,programming,AT,2021,1
-117,Starlark,programming,AT,2021,1
 117,Cuda,programming,AT,2021,1
+117,Starlark,programming,AT,2021,1
 116,TSQL,programming,AT,2021,1
 113,HCL,programming,AT,2021,1
 109,NSIS,programming,AT,2021,1
 107,Raku,programming,AT,2021,1
-102,GDB,programming,AT,2021,1
 102,Haskell,programming,AT,2021,1
+102,GDB,programming,AT,2021,1
 101,ASP.NET,programming,AT,2021,1
 23766,HTML,markup,AU,2021,1
 17498,CSS,markup,AU,2021,1
@@ -21747,13 +21813,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,Gnuplot,programming,AU,2021,1
 106,Erlang,programming,AU,2021,1
 105,D,programming,AU,2021,1
-101,M,programming,AU,2021,1
 101,Puppet,programming,AU,2021,1
+101,M,programming,AU,2021,1
 1767,HTML,markup,AZ,2021,1
 1342,CSS,markup,AZ,2021,1
 537,SCSS,markup,AZ,2021,1
-102,Jupyter Notebook,markup,AZ,2021,1
 102,Vue,markup,AZ,2021,1
+102,Jupyter Notebook,markup,AZ,2021,1
 1345,JavaScript,programming,AZ,2021,1
 547,Python,programming,AZ,2021,1
 442,Shell,programming,AZ,2021,1
@@ -21868,8 +21934,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 384,XSLT,programming,BE,2021,1
 376,Lua,programming,BE,2021,1
 351,Swift,programming,BE,2021,1
-288,Rust,programming,BE,2021,1
 288,MATLAB,programming,BE,2021,1
+288,Rust,programming,BE,2021,1
 281,Smarty,programming,BE,2021,1
 245,M4,programming,BE,2021,1
 236,GLSL,programming,BE,2021,1
@@ -21889,14 +21955,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,ASP.NET,programming,BE,2021,1
 130,Pascal,programming,BE,2021,1
 123,Yacc,programming,BE,2021,1
-118,Haskell,programming,BE,2021,1
 118,QMake,programming,BE,2021,1
+118,Haskell,programming,BE,2021,1
 115,Nix,programming,BE,2021,1
 113,NSIS,programming,BE,2021,1
 111,Julia,programming,BE,2021,1
 109,Raku,programming,BE,2021,1
-106,Starlark,programming,BE,2021,1
 106,sed,programming,BE,2021,1
+106,Starlark,programming,BE,2021,1
 103,Common Lisp,programming,BE,2021,1
 139,HTML,markup,BF,2021,1
 5800,HTML,markup,BG,2021,1
@@ -21985,8 +22051,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 658,Pug,markup,BR,2021,1
 383,Rich Text Format,markup,BR,2021,1
 360,Stylus,markup,BR,2021,1
-306,Nunjucks,markup,BR,2021,1
 306,Twig,markup,BR,2021,1
+306,Nunjucks,markup,BR,2021,1
 233,Mustache,markup,BR,2021,1
 213,Svelte,markup,BR,2021,1
 199,Vim Snippet,markup,BR,2021,1
@@ -22082,13 +22148,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,xBase,programming,BR,2021,1
 134,Inno Setup,programming,BR,2021,1
 130,F#,programming,BR,2021,1
-128,D,programming,BR,2021,1
 128,Meson,programming,BR,2021,1
+128,D,programming,BR,2021,1
 127,Erlang,programming,BR,2021,1
 126,Gnuplot,programming,BR,2021,1
 123,SmPL,programming,BR,2021,1
-122,Classic ASP,programming,BR,2021,1
 122,Rebol,programming,BR,2021,1
+122,Classic ASP,programming,BR,2021,1
 118,Scilab,programming,BR,2021,1
 116,M,programming,BR,2021,1
 111,AMPL,programming,BR,2021,1
@@ -22135,8 +22201,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 178,Perl,programming,BY,2021,1
 177,TSQL,programming,BY,2021,1
 163,HLSL,programming,BY,2021,1
-160,Groovy,programming,BY,2021,1
 160,Dart,programming,BY,2021,1
+160,Groovy,programming,BY,2021,1
 159,ASP.NET,programming,BY,2021,1
 146,Starlark,programming,BY,2021,1
 143,Lua,programming,BY,2021,1
@@ -22267,9 +22333,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 164,SystemVerilog,programming,CA,2021,1
 156,QML,programming,CA,2021,1
 153,G-code,programming,CA,2021,1
-151,Jsonnet,programming,CA,2021,1
-151,Gnuplot,programming,CA,2021,1
 151,Rebol,programming,CA,2021,1
+151,Gnuplot,programming,CA,2021,1
+151,Jsonnet,programming,CA,2021,1
 138,OCaml,programming,CA,2021,1
 136,SourcePawn,programming,CA,2021,1
 132,LLVM,programming,CA,2021,1
@@ -22332,8 +22398,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 951,PowerShell,programming,CH,2021,1
 781,Assembly,programming,CH,2021,1
 725,Vim Script,programming,CH,2021,1
-656,Kotlin,programming,CH,2021,1
 656,MATLAB,programming,CH,2021,1
+656,Kotlin,programming,CH,2021,1
 600,Lua,programming,CH,2021,1
 572,XSLT,programming,CH,2021,1
 565,M4,programming,CH,2021,1
@@ -22363,8 +22429,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 213,HLSL,programming,CH,2021,1
 212,ShaderLab,programming,CH,2021,1
 211,Lex,programming,CH,2021,1
-205,TSQL,programming,CH,2021,1
 205,CoffeeScript,programming,CH,2021,1
+205,TSQL,programming,CH,2021,1
 201,Haskell,programming,CH,2021,1
 176,NSIS,programming,CH,2021,1
 172,GDB,programming,CH,2021,1
@@ -22377,13 +22443,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 146,Gnuplot,programming,CH,2021,1
 137,PLSQL,programming,CH,2021,1
 137,Julia,programming,CH,2021,1
-135,Smalltalk,programming,CH,2021,1
 135,Clojure,programming,CH,2021,1
+135,Smalltalk,programming,CH,2021,1
 135,M,programming,CH,2021,1
 123,ASP.NET,programming,CH,2021,1
 121,Common Lisp,programming,CH,2021,1
-119,ANTLR,programming,CH,2021,1
 119,Meson,programming,CH,2021,1
+119,ANTLR,programming,CH,2021,1
 108,QML,programming,CH,2021,1
 106,Rebol,programming,CH,2021,1
 106,VHDL,programming,CH,2021,1
@@ -22565,8 +22631,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 306,Julia,programming,CN,2021,1
 302,LLVM,programming,CN,2021,1
 299,ActionScript,programming,CN,2021,1
-298,SystemVerilog,programming,CN,2021,1
 298,Forth,programming,CN,2021,1
+298,SystemVerilog,programming,CN,2021,1
 295,Meson,programming,CN,2021,1
 289,SourcePawn,programming,CN,2021,1
 272,Erlang,programming,CN,2021,1
@@ -22574,8 +22640,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 245,Prolog,programming,CN,2021,1
 243,Logos,programming,CN,2021,1
 229,D,programming,CN,2021,1
-229,Gnuplot,programming,CN,2021,1
 229,Brainfuck,programming,CN,2021,1
+229,Gnuplot,programming,CN,2021,1
 226,Metal,programming,CN,2021,1
 218,OpenEdge ABL,programming,CN,2021,1
 214,Nix,programming,CN,2021,1
@@ -22749,8 +22815,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 398,Groovy,programming,CZ,2021,1
 385,Swift,programming,CZ,2021,1
 327,Smarty,programming,CZ,2021,1
-318,Hack,programming,CZ,2021,1
 318,R,programming,CZ,2021,1
+318,Hack,programming,CZ,2021,1
 302,Rust,programming,CZ,2021,1
 292,GLSL,programming,CZ,2021,1
 287,Awk,programming,CZ,2021,1
@@ -22766,11 +22832,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,Gherkin,programming,CZ,2021,1
 182,PLpgSQL,programming,CZ,2021,1
 180,Scala,programming,CZ,2021,1
-179,TSQL,programming,CZ,2021,1
 179,Objective-C++,programming,CZ,2021,1
+179,TSQL,programming,CZ,2021,1
 177,Starlark,programming,CZ,2021,1
-154,FreeMarker,programming,CZ,2021,1
 154,Dart,programming,CZ,2021,1
+154,FreeMarker,programming,CZ,2021,1
 141,Raku,programming,CZ,2021,1
 140,Smalltalk,programming,CZ,2021,1
 139,Haskell,programming,CZ,2021,1
@@ -22929,13 +22995,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 216,Ada,programming,DE,2021,1
 214,RenderScript,programming,DE,2021,1
 212,OpenEdge ABL,programming,DE,2021,1
-203,POV-Ray SDL,programming,DE,2021,1
 203,Thrift,programming,DE,2021,1
+203,POV-Ray SDL,programming,DE,2021,1
 192,Crystal,programming,DE,2021,1
 184,SystemVerilog,programming,DE,2021,1
 174,SAS,programming,DE,2021,1
-172,Module Management System,programming,DE,2021,1
 172,RPC,programming,DE,2021,1
+172,Module Management System,programming,DE,2021,1
 171,SuperCollider,programming,DE,2021,1
 170,BitBake,programming,DE,2021,1
 167,WebAssembly,programming,DE,2021,1
@@ -22954,8 +23020,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,JSONiq,programming,DE,2021,1
 122,SQLPL,programming,DE,2021,1
 119,Modelica,programming,DE,2021,1
-118,Coq,programming,DE,2021,1
 118,Brainfuck,programming,DE,2021,1
+118,Coq,programming,DE,2021,1
 116,Qt Script,programming,DE,2021,1
 115,Classic ASP,programming,DE,2021,1
 113,Sage,programming,DE,2021,1
@@ -23062,11 +23128,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,Objective-C,programming,DZ,2021,1
 178,Kotlin,programming,DZ,2021,1
 171,C++,programming,DZ,2021,1
-148,Dockerfile,programming,DZ,2021,1
 148,Batchfile,programming,DZ,2021,1
 148,Dart,programming,DZ,2021,1
-143,Swift,programming,DZ,2021,1
+148,Dockerfile,programming,DZ,2021,1
 143,Makefile,programming,DZ,2021,1
+143,Swift,programming,DZ,2021,1
 4188,HTML,markup,EC,2021,1
 3261,CSS,markup,EC,2021,1
 1068,SCSS,markup,EC,2021,1
@@ -23156,8 +23222,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 268,ASP.NET,programming,EG,2021,1
 262,Go,programming,EG,2021,1
 199,Perl,programming,EG,2021,1
-186,Smarty,programming,EG,2021,1
 186,Starlark,programming,EG,2021,1
+186,Smarty,programming,EG,2021,1
 166,MATLAB,programming,EG,2021,1
 153,TSQL,programming,EG,2021,1
 141,Mako,programming,EG,2021,1
@@ -23230,8 +23296,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 327,CoffeeScript,programming,ES,2021,1
 326,Awk,programming,ES,2021,1
 325,Yacc,programming,ES,2021,1
-316,QMake,programming,ES,2021,1
 316,Lex,programming,ES,2021,1
+316,QMake,programming,ES,2021,1
 307,Fortran,programming,ES,2021,1
 306,TSQL,programming,ES,2021,1
 300,Solidity,programming,ES,2021,1
@@ -23287,6 +23353,32 @@ num_pushers,language,language_type,iso2_code,year,quarter
 178,Swift,programming,ET,2021,1
 106,C++,programming,ET,2021,1
 103,TypeScript,programming,ET,2021,1
+363444,HTML,markup,EU,2021,1
+272514,CSS,markup,EU,2021,1
+89823,SCSS,markup,EU,2021,1
+45404,Jupyter Notebook,markup,EU,2021,1
+25965,Vue,markup,EU,2021,1
+19823,TeX,markup,EU,2021,1
+16486,Roff,markup,EU,2021,1
+12980,Less,markup,EU,2021,1
+9098,Blade,markup,EU,2021,1
+9089,Twig,markup,EU,2021,1
+7278,Handlebars,markup,EU,2021,1
+4784,EJS,markup,EU,2021,1
+4564,Pug,markup,EU,2021,1
+4425,Sass,markup,EU,2021,1
+4304,Rich Text Format,markup,EU,2021,1
+3260,Mustache,markup,EU,2021,1
+1763,Svelte,markup,EU,2021,1
+1427,Stylus,markup,EU,2021,1
+1308,Vim Snippet,markup,EU,2021,1
+1047,PostScript,markup,EU,2021,1
+368,Haml,markup,EU,2021,1
+337,Nunjucks,markup,EU,2021,1
+304,Liquid,markup,EU,2021,1
+263,Latte,markup,EU,2021,1
+150,YASnippet,markup,EU,2021,1
+136,Slim,markup,EU,2021,1
 309658,JavaScript,programming,EU,2021,1
 213693,Shell,programming,EU,2021,1
 202489,Python,programming,EU,2021,1
@@ -23427,8 +23519,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,Nim,programming,EU,2021,1
 143,Vala,programming,EU,2021,1
 142,AGS Script,programming,EU,2021,1
-138,Max,programming,EU,2021,1
 138,XQuery,programming,EU,2021,1
+138,Max,programming,EU,2021,1
 135,ASL,programming,EU,2021,1
 133,Apex,programming,EU,2021,1
 126,JSONiq,programming,EU,2021,1
@@ -23485,8 +23577,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 324,Rust,programming,FI,2021,1
 281,GLSL,programming,FI,2021,1
 275,M4,programming,FI,2021,1
-258,MATLAB,programming,FI,2021,1
 258,Swift,programming,FI,2021,1
+258,MATLAB,programming,FI,2021,1
 252,XSLT,programming,FI,2021,1
 231,QMake,programming,FI,2021,1
 221,Emacs Lisp,programming,FI,2021,1
@@ -23499,14 +23591,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 160,Clojure,programming,FI,2021,1
 158,RobotFramework,programming,FI,2021,1
 150,Starlark,programming,FI,2021,1
-140,Awk,programming,FI,2021,1
 140,Objective-C++,programming,FI,2021,1
+140,Awk,programming,FI,2021,1
 126,Yacc,programming,FI,2021,1
 116,Groovy,programming,FI,2021,1
 108,Dart,programming,FI,2021,1
 106,Fortran,programming,FI,2021,1
-103,Haskell,programming,FI,2021,1
 103,Nix,programming,FI,2021,1
+103,Haskell,programming,FI,2021,1
 102,Raku,programming,FI,2021,1
 60824,HTML,markup,FR,2021,1
 48906,CSS,markup,FR,2021,1
@@ -23583,9 +23675,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 643,Tcl,programming,FR,2021,1
 581,CoffeeScript,programming,FR,2021,1
 567,Cuda,programming,FR,2021,1
-562,NSIS,programming,FR,2021,1
-562,Pascal,programming,FR,2021,1
 562,ASP.NET,programming,FR,2021,1
+562,Pascal,programming,FR,2021,1
+562,NSIS,programming,FR,2021,1
 550,sed,programming,FR,2021,1
 532,Nix,programming,FR,2021,1
 518,Smalltalk,programming,FR,2021,1
@@ -23599,8 +23691,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 419,Julia,programming,FR,2021,1
 399,Gnuplot,programming,FR,2021,1
 395,SWIG,programming,FR,2021,1
-373,PLSQL,programming,FR,2021,1
 373,Inno Setup,programming,FR,2021,1
+373,PLSQL,programming,FR,2021,1
 372,Common Lisp,programming,FR,2021,1
 368,Mathematica,programming,FR,2021,1
 358,FreeMarker,programming,FR,2021,1
@@ -23611,8 +23703,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 311,Elixir,programming,FR,2021,1
 307,ANTLR,programming,FR,2021,1
 300,Clojure,programming,FR,2021,1
-297,D,programming,FR,2021,1
 297,Prolog,programming,FR,2021,1
+297,D,programming,FR,2021,1
 280,Erlang,programming,FR,2021,1
 275,Pawn,programming,FR,2021,1
 274,VBScript,programming,FR,2021,1
@@ -23645,14 +23737,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,AutoHotkey,programming,FR,2021,1
 131,Logos,programming,FR,2021,1
 130,Puppet,programming,FR,2021,1
-130,Elm,programming,FR,2021,1
 130,POV-Ray SDL,programming,FR,2021,1
+130,Elm,programming,FR,2021,1
 125,Haxe,programming,FR,2021,1
 116,Xtend,programming,FR,2021,1
 114,OpenEdge ABL,programming,FR,2021,1
 111,SQLPL,programming,FR,2021,1
-107,Thrift,programming,FR,2021,1
 107,UnrealScript,programming,FR,2021,1
+107,Thrift,programming,FR,2021,1
 106,COBOL,programming,FR,2021,1
 106,RenderScript,programming,FR,2021,1
 105,VCL,programming,FR,2021,1
@@ -23777,8 +23869,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 286,Forth,programming,GB,2021,1
 282,Verilog,programming,GB,2021,1
 279,Cycript,programming,GB,2021,1
-278,VBA,programming,GB,2021,1
 278,Processing,programming,GB,2021,1
+278,VBA,programming,GB,2021,1
 260,OpenSCAD,programming,GB,2021,1
 254,Standard ML,programming,GB,2021,1
 247,Rebol,programming,GB,2021,1
@@ -23794,8 +23886,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 190,Scilab,programming,GB,2021,1
 187,Thrift,programming,GB,2021,1
 185,Logos,programming,GB,2021,1
-181,AMPL,programming,GB,2021,1
 181,VHDL,programming,GB,2021,1
+181,AMPL,programming,GB,2021,1
 179,OpenEdge ABL,programming,GB,2021,1
 178,Ada,programming,GB,2021,1
 177,Stata,programming,GB,2021,1
@@ -23807,8 +23899,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,PureBasic,programming,GB,2021,1
 146,UnrealScript,programming,GB,2021,1
 132,Open Policy Agent,programming,GB,2021,1
-132,POV-Ray SDL,programming,GB,2021,1
 132,RobotFramework,programming,GB,2021,1
+132,POV-Ray SDL,programming,GB,2021,1
 130,Nextflow,programming,GB,2021,1
 129,Module Management System,programming,GB,2021,1
 129,Coq,programming,GB,2021,1
@@ -23820,9 +23912,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,PureScript,programming,GB,2021,1
 115,Sage,programming,GB,2021,1
 114,VCL,programming,GB,2021,1
-113,WebAssembly,programming,GB,2021,1
-113,q,programming,GB,2021,1
 113,Haxe,programming,GB,2021,1
+113,q,programming,GB,2021,1
+113,WebAssembly,programming,GB,2021,1
 112,JSONiq,programming,GB,2021,1
 108,Nim,programming,GB,2021,1
 107,Metal,programming,GB,2021,1
@@ -24019,8 +24111,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 172,XS,programming,HK,2021,1
 161,NSIS,programming,HK,2021,1
 152,SmPL,programming,HK,2021,1
-149,Verilog,programming,HK,2021,1
 149,Pascal,programming,HK,2021,1
+149,Verilog,programming,HK,2021,1
 148,ASP.NET,programming,HK,2021,1
 144,AppleScript,programming,HK,2021,1
 139,Haskell,programming,HK,2021,1
@@ -24028,9 +24120,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 124,NASL,programming,HK,2021,1
 121,Nix,programming,HK,2021,1
 120,DTrace,programming,HK,2021,1
-119,UnrealScript,programming,HK,2021,1
 119,Smalltalk,programming,HK,2021,1
 119,PLSQL,programming,HK,2021,1
+119,UnrealScript,programming,HK,2021,1
 118,DIGITAL Command Language,programming,HK,2021,1
 116,M,programming,HK,2021,1
 110,PureBasic,programming,HK,2021,1
@@ -24057,8 +24149,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 2837,JavaScript,programming,HR,2021,1
 1393,Shell,programming,HR,2021,1
 1279,Python,programming,HR,2021,1
-960,C#,programming,HR,2021,1
 960,Java,programming,HR,2021,1
+960,C#,programming,HR,2021,1
 668,TypeScript,programming,HR,2021,1
 642,C++,programming,HR,2021,1
 611,C,programming,HR,2021,1
@@ -24127,10 +24219,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 134,Rust,programming,HU,2021,1
 128,HLSL,programming,HU,2021,1
 125,Gherkin,programming,HU,2021,1
-117,ShaderLab,programming,HU,2021,1
 117,Awk,programming,HU,2021,1
-113,PLpgSQL,programming,HU,2021,1
+117,ShaderLab,programming,HU,2021,1
 113,Yacc,programming,HU,2021,1
+113,PLpgSQL,programming,HU,2021,1
 109,Starlark,programming,HU,2021,1
 103,TSQL,programming,HU,2021,1
 102,Emacs Lisp,programming,HU,2021,1
@@ -24194,8 +24286,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 201,Yacc,programming,ID,2021,1
 198,Lex,programming,ID,2021,1
 194,Clojure,programming,ID,2021,1
-186,Raku,programming,ID,2021,1
 186,GLSL,programming,ID,2021,1
+186,Raku,programming,ID,2021,1
 183,MATLAB,programming,ID,2021,1
 165,TSQL,programming,ID,2021,1
 164,HCL,programming,ID,2021,1
@@ -24258,8 +24350,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 170,Starlark,programming,IE,2021,1
 150,Emacs Lisp,programming,IE,2021,1
 147,MATLAB,programming,IE,2021,1
-142,Gherkin,programming,IE,2021,1
 142,Scala,programming,IE,2021,1
+142,Gherkin,programming,IE,2021,1
 140,GLSL,programming,IE,2021,1
 129,Cuda,programming,IE,2021,1
 126,Objective-C++,programming,IE,2021,1
@@ -24313,21 +24405,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 335,Starlark,programming,IL,2021,1
 329,Vim Script,programming,IL,2021,1
 318,HLSL,programming,IL,2021,1
-300,XSLT,programming,IL,2021,1
 300,Groovy,programming,IL,2021,1
+300,XSLT,programming,IL,2021,1
 298,Rust,programming,IL,2021,1
-284,Dart,programming,IL,2021,1
 284,R,programming,IL,2021,1
+284,Dart,programming,IL,2021,1
 272,M4,programming,IL,2021,1
 242,Scala,programming,IL,2021,1
 228,TSQL,programming,IL,2021,1
-199,Lex,programming,IL,2021,1
 199,Hack,programming,IL,2021,1
+199,Lex,programming,IL,2021,1
 189,GLSL,programming,IL,2021,1
 187,Emacs Lisp,programming,IL,2021,1
 181,Tcl,programming,IL,2021,1
-168,Fortran,programming,IL,2021,1
 168,Awk,programming,IL,2021,1
+168,Fortran,programming,IL,2021,1
 166,Yacc,programming,IL,2021,1
 164,Objective-C++,programming,IL,2021,1
 163,PLpgSQL,programming,IL,2021,1
@@ -24452,30 +24544,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 256,Scilab,programming,IN,2021,1
 251,Common Lisp,programming,IN,2021,1
 248,M,programming,IN,2021,1
-244,DTrace,programming,IN,2021,1
 244,Nix,programming,IN,2021,1
+244,DTrace,programming,IN,2021,1
 241,Mathematica,programming,IN,2021,1
 229,VBA,programming,IN,2021,1
 229,Thrift,programming,IN,2021,1
 228,AppleScript,programming,IN,2021,1
-216,D,programming,IN,2021,1
 216,OCaml,programming,IN,2021,1
+216,D,programming,IN,2021,1
 212,Erlang,programming,IN,2021,1
 200,Standard ML,programming,IN,2021,1
 197,Inno Setup,programming,IN,2021,1
 196,Pawn,programming,IN,2021,1
 186,QML,programming,IN,2021,1
-182,F#,programming,IN,2021,1
 182,Puppet,programming,IN,2021,1
+182,F#,programming,IN,2021,1
 176,Gnuplot,programming,IN,2021,1
-167,OpenEdge ABL,programming,IN,2021,1
 167,SystemVerilog,programming,IN,2021,1
+167,OpenEdge ABL,programming,IN,2021,1
 166,Meson,programming,IN,2021,1
 153,SourcePawn,programming,IN,2021,1
 144,VHDL,programming,IN,2021,1
 139,HiveQL,programming,IN,2021,1
-136,ASL,programming,IN,2021,1
 136,MAXScript,programming,IN,2021,1
+136,ASL,programming,IN,2021,1
 129,RenderScript,programming,IN,2021,1
 128,SQLPL,programming,IN,2021,1
 127,Brainfuck,programming,IN,2021,1
@@ -24507,8 +24599,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 503,Blade,markup,IR,2021,1
 382,Less,markup,IR,2021,1
 261,TeX,markup,IR,2021,1
-125,Handlebars,markup,IR,2021,1
 125,Roff,markup,IR,2021,1
+125,Handlebars,markup,IR,2021,1
 4647,JavaScript,programming,IR,2021,1
 3293,Python,programming,IR,2021,1
 2710,Shell,programming,IR,2021,1
@@ -24547,8 +24639,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,Makefile,programming,IS,2021,1
 142,C++,programming,IS,2021,1
 109,Ruby,programming,IS,2021,1
-107,C,programming,IS,2021,1
 107,C#,programming,IS,2021,1
+107,C,programming,IS,2021,1
 20486,HTML,markup,IT,2021,1
 15479,CSS,markup,IT,2021,1
 4867,SCSS,markup,IT,2021,1
@@ -24624,13 +24716,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 199,NSIS,programming,IT,2021,1
 198,Raku,programming,IT,2021,1
 196,VHDL,programming,IT,2021,1
-186,Solidity,programming,IT,2021,1
 186,GDB,programming,IT,2021,1
+186,Solidity,programming,IT,2021,1
 180,Haskell,programming,IT,2021,1
-178,FreeMarker,programming,IT,2021,1
 178,QML,programming,IT,2021,1
-172,Gnuplot,programming,IT,2021,1
+178,FreeMarker,programming,IT,2021,1
 172,ANTLR,programming,IT,2021,1
+172,Gnuplot,programming,IT,2021,1
 167,PLSQL,programming,IT,2021,1
 159,M,programming,IT,2021,1
 157,SWIG,programming,IT,2021,1
@@ -24776,8 +24868,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 270,OCaml,programming,JP,2021,1
 257,VBScript,programming,JP,2021,1
 247,Mako,programming,JP,2021,1
-224,NSIS,programming,JP,2021,1
 224,Gnuplot,programming,JP,2021,1
+224,NSIS,programming,JP,2021,1
 222,NASL,programming,JP,2021,1
 220,Verilog,programming,JP,2021,1
 212,Mathematica,programming,JP,2021,1
@@ -24791,14 +24883,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 177,Erlang,programming,JP,2021,1
 176,XS,programming,JP,2021,1
 168,DIGITAL Command Language,programming,JP,2021,1
-161,DTrace,programming,JP,2021,1
 161,Standard ML,programming,JP,2021,1
+161,DTrace,programming,JP,2021,1
 160,AppleScript,programming,JP,2021,1
 157,Pawn,programming,JP,2021,1
 150,Scilab,programming,JP,2021,1
 148,ANTLR,programming,JP,2021,1
-142,Ada,programming,JP,2021,1
 142,LLVM,programming,JP,2021,1
+142,Ada,programming,JP,2021,1
 140,Nim,programming,JP,2021,1
 139,SmPL,programming,JP,2021,1
 137,Meson,programming,JP,2021,1
@@ -24849,8 +24941,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 862,Python,programming,KG,2021,1
 609,Java,programming,KG,2021,1
 448,Shell,programming,KG,2021,1
-171,Ruby,programming,KG,2021,1
 171,PHP,programming,KG,2021,1
+171,Ruby,programming,KG,2021,1
 164,Kotlin,programming,KG,2021,1
 160,PowerShell,programming,KG,2021,1
 143,Dockerfile,programming,KG,2021,1
@@ -24957,8 +25049,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 148,FreeMarker,programming,KR,2021,1
 147,SWIG,programming,KR,2021,1
 136,Verilog,programming,KR,2021,1
-133,QML,programming,KR,2021,1
 133,Mathematica,programming,KR,2021,1
+133,QML,programming,KR,2021,1
 123,XS,programming,KR,2021,1
 113,NASL,programming,KR,2021,1
 107,PureBasic,programming,KR,2021,1
@@ -25050,8 +25142,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 246,TSQL,programming,LK,2021,1
 217,PowerShell,programming,LK,2021,1
 204,XSLT,programming,LK,2021,1
-192,Ballerina,programming,LK,2021,1
 192,Starlark,programming,LK,2021,1
+192,Ballerina,programming,LK,2021,1
 186,Go,programming,LK,2021,1
 159,PLSQL,programming,LK,2021,1
 139,Groovy,programming,LK,2021,1
@@ -25081,8 +25173,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 173,Go,programming,LT,2021,1
 169,Hack,programming,LT,2021,1
 168,PowerShell,programming,LT,2021,1
-154,CMake,programming,LT,2021,1
 154,Kotlin,programming,LT,2021,1
+154,CMake,programming,LT,2021,1
 143,ShaderLab,programming,LT,2021,1
 137,Swift,programming,LT,2021,1
 132,HLSL,programming,LT,2021,1
@@ -25119,8 +25211,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 284,Makefile,programming,LV,2021,1
 272,C,programming,LV,2021,1
 178,Batchfile,programming,LV,2021,1
-114,Go,programming,LV,2021,1
 114,Objective-C,programming,LV,2021,1
+114,Go,programming,LV,2021,1
 108,Hack,programming,LV,2021,1
 186,HTML,markup,LY,2021,1
 118,CSS,markup,LY,2021,1
@@ -25190,8 +25282,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 460,Java,programming,MK,2021,1
 386,Shell,programming,MK,2021,1
 380,C#,programming,MK,2021,1
-287,Python,programming,MK,2021,1
 287,TypeScript,programming,MK,2021,1
+287,Python,programming,MK,2021,1
 215,Dockerfile,programming,MK,2021,1
 210,PHP,programming,MK,2021,1
 163,Ruby,programming,MK,2021,1
@@ -25374,8 +25466,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1003,Kotlin,programming,NG,2021,1
 1000,Objective-C,programming,NG,2021,1
 831,C#,programming,NG,2021,1
-768,Dart,programming,NG,2021,1
 768,Swift,programming,NG,2021,1
+768,Dart,programming,NG,2021,1
 660,Hack,programming,NG,2021,1
 392,Makefile,programming,NG,2021,1
 337,Batchfile,programming,NG,2021,1
@@ -25502,8 +25594,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,Gnuplot,programming,NL,2021,1
 124,Pawn,programming,NL,2021,1
 123,AppleScript,programming,NL,2021,1
-122,OpenSCAD,programming,NL,2021,1
 122,DIGITAL Command Language,programming,NL,2021,1
+122,OpenSCAD,programming,NL,2021,1
 120,D,programming,NL,2021,1
 113,Scilab,programming,NL,2021,1
 105,VBA,programming,NL,2021,1
@@ -25566,13 +25658,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 136,Scala,programming,NO,2021,1
 129,Pascal,programming,NO,2021,1
 128,Hack,programming,NO,2021,1
-123,Yacc,programming,NO,2021,1
 123,PLpgSQL,programming,NO,2021,1
+123,Yacc,programming,NO,2021,1
 121,Tcl,programming,NO,2021,1
 114,Starlark,programming,NO,2021,1
+111,Lex,programming,NO,2021,1
 111,Objective-C++,programming,NO,2021,1
 111,Nix,programming,NO,2021,1
-111,Lex,programming,NO,2021,1
 105,TSQL,programming,NO,2021,1
 103,VBA,programming,NO,2021,1
 5453,HTML,markup,NP,2021,1
@@ -25742,8 +25834,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 193,ASP.NET,programming,PH,2021,1
 189,ShaderLab,programming,PH,2021,1
 173,CMake,programming,PH,2021,1
-168,Starlark,programming,PH,2021,1
 168,HLSL,programming,PH,2021,1
+168,Starlark,programming,PH,2021,1
 160,Perl,programming,PH,2021,1
 145,Vim Script,programming,PH,2021,1
 144,Assembly,programming,PH,2021,1
@@ -25869,8 +25961,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 242,Fortran,programming,PL,2021,1
 238,PLSQL,programming,PL,2021,1
 234,Elixir,programming,PL,2021,1
-227,sed,programming,PL,2021,1
 227,GDB,programming,PL,2021,1
+227,sed,programming,PL,2021,1
 225,Mako,programming,PL,2021,1
 211,NSIS,programming,PL,2021,1
 208,Smalltalk,programming,PL,2021,1
@@ -25885,31 +25977,31 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,Mathematica,programming,PL,2021,1
 138,Verilog,programming,PL,2021,1
 138,ANTLR,programming,PL,2021,1
-137,Pawn,programming,PL,2021,1
 137,Meson,programming,PL,2021,1
+137,Pawn,programming,PL,2021,1
 132,Scheme,programming,PL,2021,1
 131,SmPL,programming,PL,2021,1
 130,Julia,programming,PL,2021,1
 126,PureBasic,programming,PL,2021,1
-124,GDScript,programming,PL,2021,1
-124,Inno Setup,programming,PL,2021,1
 124,Common Lisp,programming,PL,2021,1
+124,Inno Setup,programming,PL,2021,1
+124,GDScript,programming,PL,2021,1
 123,NASL,programming,PL,2021,1
 121,GAP,programming,PL,2021,1
 116,FreeMarker,programming,PL,2021,1
 113,VBScript,programming,PL,2021,1
 112,F#,programming,PL,2021,1
-111,VBA,programming,PL,2021,1
 111,Prolog,programming,PL,2021,1
-104,OCaml,programming,PL,2021,1
+111,VBA,programming,PL,2021,1
 104,D,programming,PL,2021,1
+104,OCaml,programming,PL,2021,1
 101,SWIG,programming,PL,2021,1
 600,HTML,markup,PR,2021,1
 464,CSS,markup,PR,2021,1
 107,SCSS,markup,PR,2021,1
 461,JavaScript,programming,PR,2021,1
-285,Python,programming,PR,2021,1
 285,Shell,programming,PR,2021,1
+285,Python,programming,PR,2021,1
 145,C++,programming,PR,2021,1
 135,Ruby,programming,PR,2021,1
 102,C,programming,PR,2021,1
@@ -25919,8 +26011,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 178,SCSS,markup,PS,2021,1
 138,Vue,markup,PS,2021,1
 926,JavaScript,programming,PS,2021,1
-476,Shell,programming,PS,2021,1
 476,Java,programming,PS,2021,1
+476,Shell,programming,PS,2021,1
 350,PHP,programming,PS,2021,1
 259,Python,programming,PS,2021,1
 209,Kotlin,programming,PS,2021,1
@@ -25972,8 +26064,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 245,XSLT,programming,PT,2021,1
 240,Hack,programming,PT,2021,1
 222,GLSL,programming,PT,2021,1
-209,Rust,programming,PT,2021,1
 209,Starlark,programming,PT,2021,1
+209,Rust,programming,PT,2021,1
 190,Smarty,programming,PT,2021,1
 184,M4,programming,PT,2021,1
 173,HCL,programming,PT,2021,1
@@ -26077,8 +26169,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,HCL,programming,RO,2021,1
 118,Fortran,programming,RO,2021,1
 117,PLSQL,programming,RO,2021,1
-115,Objective-C++,programming,RO,2021,1
 115,Scala,programming,RO,2021,1
+115,Objective-C++,programming,RO,2021,1
 112,Emacs Lisp,programming,RO,2021,1
 106,Prolog,programming,RO,2021,1
 102,Verilog,programming,RO,2021,1
@@ -26227,8 +26319,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 219,1C Enterprise,programming,RU,2021,1
 216,Erlang,programming,RU,2021,1
 213,DTrace,programming,RU,2021,1
-204,Verilog,programming,RU,2021,1
 204,VBA,programming,RU,2021,1
+204,Verilog,programming,RU,2021,1
 199,GAP,programming,RU,2021,1
 195,Scilab,programming,RU,2021,1
 194,SmPL,programming,RU,2021,1
@@ -26251,8 +26343,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,OpenSCAD,programming,RU,2021,1
 115,Thrift,programming,RU,2021,1
 111,Metal,programming,RU,2021,1
-111,Classic ASP,programming,RU,2021,1
 111,AMPL,programming,RU,2021,1
+111,Classic ASP,programming,RU,2021,1
 109,Standard ML,programming,RU,2021,1
 106,Ada,programming,RU,2021,1
 105,SystemVerilog,programming,RU,2021,1
@@ -26355,8 +26447,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 382,Haskell,programming,SE,2021,1
 360,Smarty,programming,SE,2021,1
 355,HCL,programming,SE,2021,1
-312,Dart,programming,SE,2021,1
 312,Nix,programming,SE,2021,1
+312,Dart,programming,SE,2021,1
 311,ASP.NET,programming,SE,2021,1
 308,Starlark,programming,SE,2021,1
 305,Groovy,programming,SE,2021,1
@@ -26604,8 +26696,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 328,PowerShell,programming,TH,2021,1
 277,CMake,programming,TH,2021,1
 245,Starlark,programming,TH,2021,1
-225,ShaderLab,programming,TH,2021,1
 225,Assembly,programming,TH,2021,1
+225,ShaderLab,programming,TH,2021,1
 220,HLSL,programming,TH,2021,1
 215,Solidity,programming,TH,2021,1
 195,Perl,programming,TH,2021,1
@@ -26778,8 +26870,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 304,Smarty,programming,TW,2021,1
 293,Yacc,programming,TW,2021,1
 274,Awk,programming,TW,2021,1
-272,Lex,programming,TW,2021,1
 272,Cuda,programming,TW,2021,1
+272,Lex,programming,TW,2021,1
 269,XSLT,programming,TW,2021,1
 256,Verilog,programming,TW,2021,1
 241,Rust,programming,TW,2021,1
@@ -26893,8 +26985,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,Haskell,programming,UA,2021,1
 129,PLSQL,programming,UA,2021,1
 128,Raku,programming,UA,2021,1
-114,Tcl,programming,UA,2021,1
 114,GDB,programming,UA,2021,1
+114,Tcl,programming,UA,2021,1
 111,VCL,programming,UA,2021,1
 110,NSIS,programming,UA,2021,1
 107,MATLAB,programming,UA,2021,1
@@ -27105,8 +27197,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 329,Open Policy Agent,programming,US,2021,1
 320,XQuery,programming,US,2021,1
 318,q,programming,US,2021,1
-305,CodeQL,programming,US,2021,1
 305,Terra,programming,US,2021,1
+305,CodeQL,programming,US,2021,1
 302,VCL,programming,US,2021,1
 295,V,programming,US,2021,1
 291,BitBake,programming,US,2021,1
@@ -27118,8 +27210,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 266,Nextflow,programming,US,2021,1
 263,Io,programming,US,2021,1
 258,Vala,programming,US,2021,1
-240,nesC,programming,US,2021,1
 240,MAXScript,programming,US,2021,1
+240,nesC,programming,US,2021,1
 236,Cool,programming,US,2021,1
 235,mcfunction,programming,US,2021,1
 223,xBase,programming,US,2021,1
@@ -27133,8 +27225,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 200,LabVIEW,programming,US,2021,1
 197,Rascal,programming,US,2021,1
 196,TLA,programming,US,2021,1
-190,AutoIt,programming,US,2021,1
 190,AspectJ,programming,US,2021,1
+190,AutoIt,programming,US,2021,1
 190,Red,programming,US,2021,1
 189,YARA,programming,US,2021,1
 185,E,programming,US,2021,1
@@ -27145,16 +27237,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 161,Pike,programming,US,2021,1
 156,Clarion,programming,US,2021,1
 151,CLIPS,programming,US,2021,1
-148,Hy,programming,US,2021,1
 148,CartoCSS,programming,US,2021,1
+148,Hy,programming,US,2021,1
 147,Nearley,programming,US,2021,1
 146,Slash,programming,US,2021,1
-142,Zeek,programming,US,2021,1
 142,REXX,programming,US,2021,1
+142,Zeek,programming,US,2021,1
 141,LilyPond,programming,US,2021,1
 138,CWeb,programming,US,2021,1
-136,mIRC Script,programming,US,2021,1
 136,Clean,programming,US,2021,1
+136,mIRC Script,programming,US,2021,1
 135,Harbour,programming,US,2021,1
 135,Lean,programming,US,2021,1
 132,Xtend,programming,US,2021,1
@@ -27162,19 +27254,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,J,programming,US,2021,1
 127,Sieve,programming,US,2021,1
 126,NetLogo,programming,US,2021,1
-125,P4,programming,US,2021,1
 125,Turing,programming,US,2021,1
+125,P4,programming,US,2021,1
 120,ChucK,programming,US,2021,1
 120,LSL,programming,US,2021,1
 119,Eiffel,programming,US,2021,1
 119,Agda,programming,US,2021,1
 114,SQF,programming,US,2021,1
 113,F*,programming,US,2021,1
-107,ABAP,programming,US,2021,1
 107,Modula-3,programming,US,2021,1
+107,ABAP,programming,US,2021,1
 104,Faust,programming,US,2021,1
-102,Ren'Py,programming,US,2021,1
 102,XC,programming,US,2021,1
+102,Ren'Py,programming,US,2021,1
 101,Asymptote,programming,US,2021,1
 101,KRL,programming,US,2021,1
 113,Markdown,prose,US,2021,1
@@ -27513,8 +27605,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 136,PLpgSQL,programming,AR,2021,2
 130,Wollok,programming,AR,2021,2
 130,M4,programming,AR,2021,2
-129,Groovy,programming,AR,2021,2
 129,Scala,programming,AR,2021,2
+129,Groovy,programming,AR,2021,2
 116,Visual Basic .NET,programming,AR,2021,2
 115,Prolog,programming,AR,2021,2
 112,NSIS,programming,AR,2021,2
@@ -27578,9 +27670,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 174,Awk,programming,AT,2021,2
 157,Scala,programming,AT,2021,2
 156,Objective-C++,programming,AT,2021,2
+144,Starlark,programming,AT,2021,2
 144,Yacc,programming,AT,2021,2
 144,PLpgSQL,programming,AT,2021,2
-144,Starlark,programming,AT,2021,2
 142,sed,programming,AT,2021,2
 124,Tcl,programming,AT,2021,2
 123,Lex,programming,AT,2021,2
@@ -27602,8 +27694,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 577,Handlebars,markup,AU,2021,2
 448,Jinja,markup,AU,2021,2
 407,Pug,markup,AU,2021,2
-388,Blade,markup,AU,2021,2
 388,Rich Text Format,markup,AU,2021,2
+388,Blade,markup,AU,2021,2
 366,Mustache,markup,AU,2021,2
 326,Sass,markup,AU,2021,2
 215,Svelte,markup,AU,2021,2
@@ -27641,8 +27733,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 867,HLSL,programming,AU,2021,2
 769,HCL,programming,AU,2021,2
 696,GLSL,programming,AU,2021,2
-683,MATLAB,programming,AU,2021,2
 683,XSLT,programming,AU,2021,2
+683,MATLAB,programming,AU,2021,2
 636,M4,programming,AU,2021,2
 613,Smarty,programming,AU,2021,2
 601,Hack,programming,AU,2021,2
@@ -27659,8 +27751,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 356,Scala,programming,AU,2021,2
 332,CoffeeScript,programming,AU,2021,2
 332,Haskell,programming,AU,2021,2
-313,PLpgSQL,programming,AU,2021,2
 313,Nix,programming,AU,2021,2
+313,PLpgSQL,programming,AU,2021,2
 296,Fortran,programming,AU,2021,2
 293,Mathematica,programming,AU,2021,2
 293,Yacc,programming,AU,2021,2
@@ -27671,8 +27763,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 236,QMake,programming,AU,2021,2
 226,Scheme,programming,AU,2021,2
 222,Mako,programming,AU,2021,2
-208,Raku,programming,AU,2021,2
 208,Clojure,programming,AU,2021,2
+208,Raku,programming,AU,2021,2
 204,NSIS,programming,AU,2021,2
 198,GDB,programming,AU,2021,2
 194,Julia,programming,AU,2021,2
@@ -27684,18 +27776,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,F#,programming,AU,2021,2
 165,Elixir,programming,AU,2021,2
 164,NASL,programming,AU,2021,2
-157,Common Lisp,programming,AU,2021,2
 157,VBScript,programming,AU,2021,2
+157,Common Lisp,programming,AU,2021,2
 155,Visual Basic .NET,programming,AU,2021,2
-134,Meson,programming,AU,2021,2
 134,GAP,programming,AU,2021,2
+134,Meson,programming,AU,2021,2
 132,AppleScript,programming,AU,2021,2
 130,D,programming,AU,2021,2
 123,Erlang,programming,AU,2021,2
 122,Processing,programming,AU,2021,2
 122,Gnuplot,programming,AU,2021,2
-119,Prolog,programming,AU,2021,2
 119,PLSQL,programming,AU,2021,2
+119,Prolog,programming,AU,2021,2
 117,DIGITAL Command Language,programming,AU,2021,2
 115,G-code,programming,AU,2021,2
 112,QML,programming,AU,2021,2
@@ -28050,8 +28142,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 177,Standard ML,programming,BR,2021,2
 176,Gnuplot,programming,BR,2021,2
 167,Erlang,programming,BR,2021,2
-165,Inno Setup,programming,BR,2021,2
 165,Meson,programming,BR,2021,2
+165,Inno Setup,programming,BR,2021,2
 162,Forth,programming,BR,2021,2
 155,xBase,programming,BR,2021,2
 153,NASL,programming,BR,2021,2
@@ -28226,15 +28318,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 303,VBScript,programming,CA,2021,2
 285,Common Lisp,programming,CA,2021,2
 284,Prolog,programming,CA,2021,2
-276,AutoHotkey,programming,CA,2021,2
 276,ANTLR,programming,CA,2021,2
+276,AutoHotkey,programming,CA,2021,2
 268,Pawn,programming,CA,2021,2
 264,VHDL,programming,CA,2021,2
 260,FreeMarker,programming,CA,2021,2
 257,GAP,programming,CA,2021,2
 255,Meson,programming,CA,2021,2
-243,Inno Setup,programming,CA,2021,2
 243,SWIG,programming,CA,2021,2
+243,Inno Setup,programming,CA,2021,2
 226,AppleScript,programming,CA,2021,2
 223,SystemVerilog,programming,CA,2021,2
 209,D,programming,CA,2021,2
@@ -28249,18 +28341,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 170,Jsonnet,programming,CA,2021,2
 169,G-code,programming,CA,2021,2
 163,OpenSCAD,programming,CA,2021,2
-160,SourcePawn,programming,CA,2021,2
 160,DTrace,programming,CA,2021,2
+160,SourcePawn,programming,CA,2021,2
 148,LLVM,programming,CA,2021,2
 143,OCaml,programming,CA,2021,2
 141,PureBasic,programming,CA,2021,2
-130,XS,programming,CA,2021,2
 130,Forth,programming,CA,2021,2
+130,XS,programming,CA,2021,2
 126,Jasmin,programming,CA,2021,2
 123,Racket,programming,CA,2021,2
 122,AMPL,programming,CA,2021,2
-121,VBA,programming,CA,2021,2
 121,Standard ML,programming,CA,2021,2
+121,VBA,programming,CA,2021,2
 120,SmPL,programming,CA,2021,2
 116,Stata,programming,CA,2021,2
 114,Elm,programming,CA,2021,2
@@ -28352,12 +28444,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 200,Solidity,programming,CH,2021,2
 179,TSQL,programming,CH,2021,2
 164,GDB,programming,CH,2021,2
-162,Mako,programming,CH,2021,2
 162,CoffeeScript,programming,CH,2021,2
+162,Mako,programming,CH,2021,2
 160,SWIG,programming,CH,2021,2
 158,Gnuplot,programming,CH,2021,2
-148,Scheme,programming,CH,2021,2
 148,Raku,programming,CH,2021,2
+148,Scheme,programming,CH,2021,2
 147,NSIS,programming,CH,2021,2
 141,Julia,programming,CH,2021,2
 138,Clojure,programming,CH,2021,2
@@ -28367,8 +28459,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,ASP.NET,programming,CH,2021,2
 117,ANTLR,programming,CH,2021,2
 116,Meson,programming,CH,2021,2
-102,Common Lisp,programming,CH,2021,2
 102,Verilog,programming,CH,2021,2
+102,Common Lisp,programming,CH,2021,2
 101,M,programming,CH,2021,2
 679,HTML,markup,CI,2021,2
 471,CSS,markup,CI,2021,2
@@ -28649,8 +28741,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 148,HCL,programming,CO,2021,2
 144,PureBasic,programming,CO,2021,2
 129,GLSL,programming,CO,2021,2
-120,Lua,programming,CO,2021,2
 120,PLpgSQL,programming,CO,2021,2
+120,Lua,programming,CO,2021,2
 118,XSLT,programming,CO,2021,2
 112,Rust,programming,CO,2021,2
 104,Solidity,programming,CO,2021,2
@@ -28673,8 +28765,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 439,C,programming,CR,2021,2
 427,Ruby,programming,CR,2021,2
 393,Makefile,programming,CR,2021,2
-218,TSQL,programming,CR,2021,2
 218,ASP.NET,programming,CR,2021,2
+218,TSQL,programming,CR,2021,2
 188,Kotlin,programming,CR,2021,2
 176,CMake,programming,CR,2021,2
 171,Hack,programming,CR,2021,2
@@ -28706,8 +28798,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 326,Python,programming,CY,2021,2
 156,Java,programming,CY,2021,2
 150,Dockerfile,programming,CY,2021,2
-143,PHP,programming,CY,2021,2
 143,Makefile,programming,CY,2021,2
+143,PHP,programming,CY,2021,2
 124,C,programming,CY,2021,2
 119,C++,programming,CY,2021,2
 114,TypeScript,programming,CY,2021,2
@@ -28790,8 +28882,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 115,Meson,programming,CZ,2021,2
 114,ShaderLab,programming,CZ,2021,2
 113,Mako,programming,CZ,2021,2
-111,OpenSCAD,programming,CZ,2021,2
 111,GDB,programming,CZ,2021,2
+111,OpenSCAD,programming,CZ,2021,2
 107,NSIS,programming,CZ,2021,2
 101,SWIG,programming,CZ,2021,2
 101,PLSQL,programming,CZ,2021,2
@@ -28901,8 +28993,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 555,Prolog,programming,DE,2021,2
 526,PLSQL,programming,DE,2021,2
 468,Erlang,programming,DE,2021,2
-466,VBScript,programming,DE,2021,2
 466,ASP.NET,programming,DE,2021,2
+466,VBScript,programming,DE,2021,2
 445,OpenSCAD,programming,DE,2021,2
 441,VHDL,programming,DE,2021,2
 433,Pawn,programming,DE,2021,2
@@ -28914,8 +29006,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 397,Verilog,programming,DE,2021,2
 390,SourcePawn,programming,DE,2021,2
 377,AutoHotkey,programming,DE,2021,2
-369,G-code,programming,DE,2021,2
 369,DTrace,programming,DE,2021,2
+369,G-code,programming,DE,2021,2
 368,F#,programming,DE,2021,2
 358,Visual Basic .NET,programming,DE,2021,2
 352,OCaml,programming,DE,2021,2
@@ -28955,26 +29047,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,SaltStack,programming,DE,2021,2
 154,SuperCollider,programming,DE,2021,2
 153,AGS Script,programming,DE,2021,2
-150,Vala,programming,DE,2021,2
 150,XQuery,programming,DE,2021,2
+150,Vala,programming,DE,2021,2
 146,Reason,programming,DE,2021,2
 145,ASL,programming,DE,2021,2
 141,Haxe,programming,DE,2021,2
 139,Stata,programming,DE,2021,2
 129,Limbo,programming,DE,2021,2
 123,AIDL,programming,DE,2021,2
-122,Isabelle,programming,DE,2021,2
 122,Coq,programming,DE,2021,2
+122,Isabelle,programming,DE,2021,2
 120,Max,programming,DE,2021,2
 119,Brainfuck,programming,DE,2021,2
-118,SQLPL,programming,DE,2021,2
-118,Sage,programming,DE,2021,2
 118,ABAP,programming,DE,2021,2
+118,Sage,programming,DE,2021,2
+118,SQLPL,programming,DE,2021,2
 116,BASIC,programming,DE,2021,2
 115,Metal,programming,DE,2021,2
-112,NewLisp,programming,DE,2021,2
-112,Cap'n Proto,programming,DE,2021,2
 112,VCL,programming,DE,2021,2
+112,Cap'n Proto,programming,DE,2021,2
+112,NewLisp,programming,DE,2021,2
 110,Ragel,programming,DE,2021,2
 109,SQF,programming,DE,2021,2
 107,Apex,programming,DE,2021,2
@@ -29016,8 +29108,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 409,Perl,programming,DK,2021,2
 376,MATLAB,programming,DK,2021,2
 370,ShaderLab,programming,DK,2021,2
-340,Lua,programming,DK,2021,2
 340,Vim Script,programming,DK,2021,2
+340,Lua,programming,DK,2021,2
 334,HLSL,programming,DK,2021,2
 332,Rust,programming,DK,2021,2
 318,Swift,programming,DK,2021,2
@@ -29039,9 +29131,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,Fortran,programming,DK,2021,2
 133,F#,programming,DK,2021,2
 131,Tcl,programming,DK,2021,2
-127,Nix,programming,DK,2021,2
-127,Objective-C++,programming,DK,2021,2
 127,Mathematica,programming,DK,2021,2
+127,Objective-C++,programming,DK,2021,2
+127,Nix,programming,DK,2021,2
 125,Processing,programming,DK,2021,2
 121,Groovy,programming,DK,2021,2
 120,Starlark,programming,DK,2021,2
@@ -29063,10 +29155,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 238,Dockerfile,programming,DO,2021,2
 144,Objective-C,programming,DO,2021,2
 142,ASP.NET,programming,DO,2021,2
-117,Kotlin,programming,DO,2021,2
 117,TSQL,programming,DO,2021,2
-113,Swift,programming,DO,2021,2
+117,Kotlin,programming,DO,2021,2
 113,C++,programming,DO,2021,2
+113,Swift,programming,DO,2021,2
 112,C,programming,DO,2021,2
 102,Batchfile,programming,DO,2021,2
 2360,HTML,markup,DZ,2021,2
@@ -29289,19 +29381,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,VHDL,programming,ES,2021,2
 152,NASL,programming,ES,2021,2
 146,GAP,programming,ES,2021,2
+146,Visual Basic .NET,programming,ES,2021,2
 146,VBScript,programming,ES,2021,2
 146,FreeMarker,programming,ES,2021,2
-146,Visual Basic .NET,programming,ES,2021,2
 144,DIGITAL Command Language,programming,ES,2021,2
 136,GDScript,programming,ES,2021,2
 133,Verilog,programming,ES,2021,2
 132,Scheme,programming,ES,2021,2
 130,Prolog,programming,ES,2021,2
-128,PureBasic,programming,ES,2021,2
 128,ANTLR,programming,ES,2021,2
+128,PureBasic,programming,ES,2021,2
 127,Julia,programming,ES,2021,2
-121,QML,programming,ES,2021,2
 121,Ada,programming,ES,2021,2
+121,QML,programming,ES,2021,2
 120,Inno Setup,programming,ES,2021,2
 111,Common Lisp,programming,ES,2021,2
 101,CLIPS,programming,ES,2021,2
@@ -29323,6 +29415,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,TypeScript,programming,ET,2021,2
 127,Swift,programming,ET,2021,2
 113,C#,programming,ET,2021,2
+351731,HTML,markup,EU,2021,2
+270636,CSS,markup,EU,2021,2
+90563,SCSS,markup,EU,2021,2
+44787,Jupyter Notebook,markup,EU,2021,2
+25700,Vue,markup,EU,2021,2
+19549,TeX,markup,EU,2021,2
+16313,Roff,markup,EU,2021,2
+12224,Less,markup,EU,2021,2
+9208,Blade,markup,EU,2021,2
+8790,Twig,markup,EU,2021,2
+7685,EJS,markup,EU,2021,2
+7407,Handlebars,markup,EU,2021,2
+5745,Jinja,markup,EU,2021,2
+5485,Mustache,markup,EU,2021,2
+4572,Pug,markup,EU,2021,2
+4323,Sass,markup,EU,2021,2
+4010,Rich Text Format,markup,EU,2021,2
+2316,Svelte,markup,EU,2021,2
+1322,Stylus,markup,EU,2021,2
+1177,PostScript,markup,EU,2021,2
+973,Vim Snippet,markup,EU,2021,2
+837,Nunjucks,markup,EU,2021,2
+352,Haml,markup,EU,2021,2
+327,Liquid,markup,EU,2021,2
+226,Latte,markup,EU,2021,2
+141,YASnippet,markup,EU,2021,2
+117,Slim,markup,EU,2021,2
 311128,JavaScript,programming,EU,2021,2
 211920,Shell,programming,EU,2021,2
 202861,Python,programming,EU,2021,2
@@ -29434,8 +29553,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 447,LLVM,programming,EU,2021,2
 434,Puppet,programming,EU,2021,2
 411,Xtend,programming,EU,2021,2
-392,Elm,programming,EU,2021,2
 392,UnrealScript,programming,EU,2021,2
+392,Elm,programming,EU,2021,2
 366,POV-Ray SDL,programming,EU,2021,2
 350,Rebol,programming,EU,2021,2
 345,ActionScript,programming,EU,2021,2
@@ -29470,8 +29589,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,Isabelle,programming,EU,2021,2
 120,Max,programming,EU,2021,2
 119,Brainfuck,programming,EU,2021,2
-118,SQLPL,programming,EU,2021,2
 118,ABAP,programming,EU,2021,2
+118,SQLPL,programming,EU,2021,2
 118,Sage,programming,EU,2021,2
 116,BASIC,programming,EU,2021,2
 115,Metal,programming,EU,2021,2
@@ -29493,8 +29612,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 317,TeX,markup,FI,2021,2
 283,Less,markup,FI,2021,2
 189,EJS,markup,FI,2021,2
-167,Jinja,markup,FI,2021,2
 167,Pug,markup,FI,2021,2
+167,Jinja,markup,FI,2021,2
 126,Handlebars,markup,FI,2021,2
 110,Mustache,markup,FI,2021,2
 106,Svelte,markup,FI,2021,2
@@ -29518,8 +29637,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 445,Kotlin,programming,FI,2021,2
 408,Assembly,programming,FI,2021,2
 397,PowerShell,programming,FI,2021,2
-392,Lua,programming,FI,2021,2
 392,R,programming,FI,2021,2
+392,Lua,programming,FI,2021,2
 347,Rust,programming,FI,2021,2
 344,Vim Script,programming,FI,2021,2
 302,HLSL,programming,FI,2021,2
@@ -29627,8 +29746,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 580,TSQL,programming,FR,2021,2
 556,sed,programming,FR,2021,2
 546,ASP.NET,programming,FR,2021,2
-543,Cuda,programming,FR,2021,2
 543,CoffeeScript,programming,FR,2021,2
+543,Cuda,programming,FR,2021,2
 533,NSIS,programming,FR,2021,2
 514,Pascal,programming,FR,2021,2
 504,Haskell,programming,FR,2021,2
@@ -29657,8 +29776,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 298,D,programming,FR,2021,2
 287,VBScript,programming,FR,2021,2
 280,GDScript,programming,FR,2021,2
-264,VHDL,programming,FR,2021,2
 264,Erlang,programming,FR,2021,2
+264,VHDL,programming,FR,2021,2
 244,Forth,programming,FR,2021,2
 240,PureBasic,programming,FR,2021,2
 233,Pawn,programming,FR,2021,2
@@ -29668,8 +29787,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 213,Visual Basic .NET,programming,FR,2021,2
 203,AppleScript,programming,FR,2021,2
 195,Verilog,programming,FR,2021,2
-190,OpenSCAD,programming,FR,2021,2
 190,AMPL,programming,FR,2021,2
+190,OpenSCAD,programming,FR,2021,2
 188,Coq,programming,FR,2021,2
 186,SourcePawn,programming,FR,2021,2
 185,SmPL,programming,FR,2021,2
@@ -29684,13 +29803,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 157,VBA,programming,FR,2021,2
 154,DTrace,programming,FR,2021,2
 148,Puppet,programming,FR,2021,2
-142,LLVM,programming,FR,2021,2
 142,Rebol,programming,FR,2021,2
+142,LLVM,programming,FR,2021,2
 138,POV-Ray SDL,programming,FR,2021,2
 131,Haxe,programming,FR,2021,2
 124,ActionScript,programming,FR,2021,2
-111,Thrift,programming,FR,2021,2
 111,Crystal,programming,FR,2021,2
+111,Thrift,programming,FR,2021,2
 110,OpenEdge ABL,programming,FR,2021,2
 106,UnrealScript,programming,FR,2021,2
 104,Xtend,programming,FR,2021,2
@@ -29847,23 +29966,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,UnrealScript,programming,GB,2021,2
 145,Apex,programming,GB,2021,2
 135,SuperCollider,programming,GB,2021,2
-132,Rebol,programming,GB,2021,2
 132,Haxe,programming,GB,2021,2
+132,Rebol,programming,GB,2021,2
 130,Module Management System,programming,GB,2021,2
+128,Stan,programming,GB,2021,2
 128,PureScript,programming,GB,2021,2
 128,Metal,programming,GB,2021,2
-128,Stan,programming,GB,2021,2
-126,Coq,programming,GB,2021,2
 126,Sage,programming,GB,2021,2
+126,Coq,programming,GB,2021,2
 124,RenderScript,programming,GB,2021,2
 119,SAS,programming,GB,2021,2
 116,Nim,programming,GB,2021,2
 113,DM,programming,GB,2021,2
-113,WebAssembly,programming,GB,2021,2
 113,Racket,programming,GB,2021,2
+113,WebAssembly,programming,GB,2021,2
 111,ASL,programming,GB,2021,2
-110,Crystal,programming,GB,2021,2
 110,COBOL,programming,GB,2021,2
+110,Crystal,programming,GB,2021,2
 107,RPC,programming,GB,2021,2
 106,VCL,programming,GB,2021,2
 104,Jasmin,programming,GB,2021,2
@@ -29886,8 +30005,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 163,Dockerfile,programming,GE,2021,2
 146,C++,programming,GE,2021,2
 117,C,programming,GE,2021,2
-108,Swift,programming,GE,2021,2
 108,Makefile,programming,GE,2021,2
+108,Swift,programming,GE,2021,2
 103,Objective-C,programming,GE,2021,2
 2877,HTML,markup,GH,2021,2
 2097,CSS,markup,GH,2021,2
@@ -29942,8 +30061,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 296,Go,programming,GR,2021,2
 236,MATLAB,programming,GR,2021,2
 235,Kotlin,programming,GR,2021,2
-234,PowerShell,programming,GR,2021,2
 234,Perl,programming,GR,2021,2
+234,PowerShell,programming,GR,2021,2
 222,Assembly,programming,GR,2021,2
 215,R,programming,GR,2021,2
 207,Hack,programming,GR,2021,2
@@ -30077,8 +30196,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 204,SmPL,programming,HK,2021,2
 198,DIGITAL Command Language,programming,HK,2021,2
 183,Nix,programming,HK,2021,2
-179,UnrealScript,programming,HK,2021,2
 179,Haskell,programming,HK,2021,2
+179,UnrealScript,programming,HK,2021,2
 177,AIDL,programming,HK,2021,2
 173,PLSQL,programming,HK,2021,2
 166,DTrace,programming,HK,2021,2
@@ -30096,18 +30215,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 128,Scheme,programming,HK,2021,2
 121,Julia,programming,HK,2021,2
 118,M,programming,HK,2021,2
-116,AspectJ,programming,HK,2021,2
 116,QML,programming,HK,2021,2
+116,AspectJ,programming,HK,2021,2
 110,Scilab,programming,HK,2021,2
 106,AutoHotkey,programming,HK,2021,2
-105,Erlang,programming,HK,2021,2
 105,Visual Basic .NET,programming,HK,2021,2
+105,Erlang,programming,HK,2021,2
 104,Meson,programming,HK,2021,2
-103,HiveQL,programming,HK,2021,2
 103,q,programming,HK,2021,2
+103,HiveQL,programming,HK,2021,2
 102,Coq,programming,HK,2021,2
-102,Module Management System,programming,HK,2021,2
 102,Metal,programming,HK,2021,2
+102,Module Management System,programming,HK,2021,2
 101,Sage,programming,HK,2021,2
 1257,HTML,markup,HN,2021,2
 1033,CSS,markup,HN,2021,2
@@ -30200,10 +30319,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 151,GLSL,programming,HU,2021,2
 150,Rust,programming,HU,2021,2
 149,Smarty,programming,HU,2021,2
-133,MATLAB,programming,HU,2021,2
 133,PLpgSQL,programming,HU,2021,2
-121,ShaderLab,programming,HU,2021,2
+133,MATLAB,programming,HU,2021,2
 121,HLSL,programming,HU,2021,2
+121,ShaderLab,programming,HU,2021,2
 108,Awk,programming,HU,2021,2
 107,QMake,programming,HU,2021,2
 104,Yacc,programming,HU,2021,2
@@ -30405,8 +30524,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,PLpgSQL,programming,IL,2021,2
 147,Fortran,programming,IL,2021,2
 145,Tcl,programming,IL,2021,2
-143,Yacc,programming,IL,2021,2
 143,Cuda,programming,IL,2021,2
+143,Yacc,programming,IL,2021,2
 138,Solidity,programming,IL,2021,2
 113,Smalltalk,programming,IL,2021,2
 109,Mako,programming,IL,2021,2
@@ -30525,13 +30644,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 323,Prolog,programming,IN,2021,2
 314,LLVM,programming,IN,2021,2
 313,Rebol,programming,IN,2021,2
-298,NSIS,programming,IN,2021,2
 298,Elixir,programming,IN,2021,2
-297,Processing,programming,IN,2021,2
+298,NSIS,programming,IN,2021,2
 297,Thrift,programming,IN,2021,2
+297,Processing,programming,IN,2021,2
 295,RobotFramework,programming,IN,2021,2
-293,ActionScript,programming,IN,2021,2
 293,Common Lisp,programming,IN,2021,2
+293,ActionScript,programming,IN,2021,2
 286,Mathematica,programming,IN,2021,2
 272,DTrace,programming,IN,2021,2
 270,Scilab,programming,IN,2021,2
@@ -30542,8 +30661,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 221,Erlang,programming,IN,2021,2
 218,Standard ML,programming,IN,2021,2
 217,QML,programming,IN,2021,2
-207,Meson,programming,IN,2021,2
 207,Puppet,programming,IN,2021,2
+207,Meson,programming,IN,2021,2
 204,SourcePawn,programming,IN,2021,2
 201,VHDL,programming,IN,2021,2
 200,VBA,programming,IN,2021,2
@@ -30563,13 +30682,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,RPC,programming,IN,2021,2
 116,Stata,programming,IN,2021,2
 113,COBOL,programming,IN,2021,2
-112,Elm,programming,IN,2021,2
 112,CodeQL,programming,IN,2021,2
 112,ReScript,programming,IN,2021,2
+112,Elm,programming,IN,2021,2
 111,VCL,programming,IN,2021,2
 110,SQLPL,programming,IN,2021,2
-109,Open Policy Agent,programming,IN,2021,2
 109,POV-Ray SDL,programming,IN,2021,2
+109,Open Policy Agent,programming,IN,2021,2
 108,AutoHotkey,programming,IN,2021,2
 1092,HTML,markup,IQ,2021,2
 699,CSS,markup,IQ,2021,2
@@ -30710,12 +30829,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 222,Prolog,programming,IT,2021,2
 218,Pascal,programming,IT,2021,2
 201,GDB,programming,IT,2021,2
-190,ASP.NET,programming,IT,2021,2
 190,Haskell,programming,IT,2021,2
+190,ASP.NET,programming,IT,2021,2
 188,Raku,programming,IT,2021,2
 186,Gnuplot,programming,IT,2021,2
-183,QML,programming,IT,2021,2
 183,NASL,programming,IT,2021,2
+183,QML,programming,IT,2021,2
 174,NSIS,programming,IT,2021,2
 171,ANTLR,programming,IT,2021,2
 169,SWIG,programming,IT,2021,2
@@ -30725,11 +30844,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,Smalltalk,programming,IT,2021,2
 144,Scheme,programming,IT,2021,2
 143,Julia,programming,IT,2021,2
-143,Elixir,programming,IT,2021,2
 143,VHDL,programming,IT,2021,2
+143,Elixir,programming,IT,2021,2
 141,Mathematica,programming,IT,2021,2
-139,Meson,programming,IT,2021,2
 139,Clojure,programming,IT,2021,2
+139,Meson,programming,IT,2021,2
 136,Processing,programming,IT,2021,2
 134,Nix,programming,IT,2021,2
 121,M,programming,IT,2021,2
@@ -30739,11 +30858,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Inno Setup,programming,IT,2021,2
 109,Forth,programming,IT,2021,2
 108,AMPL,programming,IT,2021,2
-102,SmPL,programming,IT,2021,2
 102,G-code,programming,IT,2021,2
+102,SmPL,programming,IT,2021,2
 101,XS,programming,IT,2021,2
-101,PureBasic,programming,IT,2021,2
 101,Visual Basic .NET,programming,IT,2021,2
+101,PureBasic,programming,IT,2021,2
 603,HTML,markup,JM,2021,2
 496,CSS,markup,JM,2021,2
 115,SCSS,markup,JM,2021,2
@@ -30811,8 +30930,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 5307,Batchfile,programming,JP,2021,2
 4099,Objective-C,programming,JP,2021,2
 3761,Swift,programming,JP,2021,2
-3604,CMake,programming,JP,2021,2
 3604,Vim Script,programming,JP,2021,2
+3604,CMake,programming,JP,2021,2
 3416,Kotlin,programming,JP,2021,2
 2640,CoffeeScript,programming,JP,2021,2
 2580,Rust,programming,JP,2021,2
@@ -30856,16 +30975,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 334,Julia,programming,JP,2021,2
 330,PLSQL,programming,JP,2021,2
 325,Gherkin,programming,JP,2021,2
-321,Clojure,programming,JP,2021,2
 321,Common Lisp,programming,JP,2021,2
+321,Clojure,programming,JP,2021,2
 316,TSQL,programming,JP,2021,2
 314,VBA,programming,JP,2021,2
 311,ASP.NET,programming,JP,2021,2
 292,Elixir,programming,JP,2021,2
 264,NASL,programming,JP,2021,2
 260,Smalltalk,programming,JP,2021,2
-245,Mako,programming,JP,2021,2
 245,VBScript,programming,JP,2021,2
+245,Mako,programming,JP,2021,2
 243,Verilog,programming,JP,2021,2
 241,Gnuplot,programming,JP,2021,2
 236,Mathematica,programming,JP,2021,2
@@ -30886,11 +31005,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,F#,programming,JP,2021,2
 150,Jsonnet,programming,JP,2021,2
 150,LLVM,programming,JP,2021,2
-148,Pawn,programming,JP,2021,2
 148,DTrace,programming,JP,2021,2
+148,Pawn,programming,JP,2021,2
 147,Standard ML,programming,JP,2021,2
-144,Meson,programming,JP,2021,2
 144,Scilab,programming,JP,2021,2
+144,Meson,programming,JP,2021,2
 142,SmPL,programming,JP,2021,2
 141,Erlang,programming,JP,2021,2
 141,SystemVerilog,programming,JP,2021,2
@@ -30905,8 +31024,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 108,M,programming,JP,2021,2
 106,Ragel,programming,JP,2021,2
 102,ActionScript,programming,JP,2021,2
-101,PureBasic,programming,JP,2021,2
 101,Forth,programming,JP,2021,2
+101,PureBasic,programming,JP,2021,2
 7032,HTML,markup,KE,2021,2
 5237,CSS,markup,KE,2021,2
 1515,SCSS,markup,KE,2021,2
@@ -30989,8 +31108,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 346,Rich Text Format,markup,KR,2021,2
 333,Sass,markup,KR,2021,2
 267,Blade,markup,KR,2021,2
-230,Stylus,markup,KR,2021,2
 230,Jinja,markup,KR,2021,2
+230,Stylus,markup,KR,2021,2
 183,Svelte,markup,KR,2021,2
 135,Liquid,markup,KR,2021,2
 117,Vim Snippet,markup,KR,2021,2
@@ -31579,8 +31698,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 477,Dart,programming,NL,2021,2
 454,Objective-C++,programming,NL,2021,2
 405,Awk,programming,NL,2021,2
-397,Yacc,programming,NL,2021,2
 397,Starlark,programming,NL,2021,2
+397,Yacc,programming,NL,2021,2
 389,PLpgSQL,programming,NL,2021,2
 369,Haskell,programming,NL,2021,2
 364,Nix,programming,NL,2021,2
@@ -31622,8 +31741,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 134,DIGITAL Command Language,programming,NL,2021,2
 133,F#,programming,NL,2021,2
 126,VBScript,programming,NL,2021,2
-124,AutoHotkey,programming,NL,2021,2
 124,Gnuplot,programming,NL,2021,2
+124,AutoHotkey,programming,NL,2021,2
 115,OpenSCAD,programming,NL,2021,2
 114,OCaml,programming,NL,2021,2
 113,PureBasic,programming,NL,2021,2
@@ -31666,8 +31785,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 580,R,programming,NO,2021,2
 568,Perl,programming,NO,2021,2
 426,Vim Script,programming,NO,2021,2
-381,MATLAB,programming,NO,2021,2
 381,Lua,programming,NO,2021,2
+381,MATLAB,programming,NO,2021,2
 380,Assembly,programming,NO,2021,2
 312,Rust,programming,NO,2021,2
 301,XSLT,programming,NO,2021,2
@@ -31688,8 +31807,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,Haskell,programming,NO,2021,2
 132,PLpgSQL,programming,NO,2021,2
 122,Hack,programming,NO,2021,2
-121,Tcl,programming,NO,2021,2
 121,Scala,programming,NO,2021,2
+121,Tcl,programming,NO,2021,2
 114,Yacc,programming,NO,2021,2
 113,Starlark,programming,NO,2021,2
 111,Pascal,programming,NO,2021,2
@@ -32027,12 +32146,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Pawn,programming,PL,2021,2
 133,SmPL,programming,PL,2021,2
 133,Scheme,programming,PL,2021,2
-129,Prolog,programming,PL,2021,2
 129,NASL,programming,PL,2021,2
+129,Prolog,programming,PL,2021,2
 128,VHDL,programming,PL,2021,2
 125,GAP,programming,PL,2021,2
-118,Inno Setup,programming,PL,2021,2
 118,Erlang,programming,PL,2021,2
+118,Inno Setup,programming,PL,2021,2
 117,F#,programming,PL,2021,2
 112,Common Lisp,programming,PL,2021,2
 108,FreeMarker,programming,PL,2021,2
@@ -32097,16 +32216,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 393,Swift,programming,PT,2021,2
 389,Assembly,programming,PT,2021,2
 355,ShaderLab,programming,PT,2021,2
-348,Perl,programming,PT,2021,2
 348,HLSL,programming,PT,2021,2
+348,Perl,programming,PT,2021,2
 343,Vim Script,programming,PT,2021,2
 283,Lua,programming,PT,2021,2
 265,R,programming,PT,2021,2
 240,GLSL,programming,PT,2021,2
 231,Dart,programming,PT,2021,2
 221,Hack,programming,PT,2021,2
-208,Gherkin,programming,PT,2021,2
 208,XSLT,programming,PT,2021,2
+208,Gherkin,programming,PT,2021,2
 200,Rust,programming,PT,2021,2
 195,Smarty,programming,PT,2021,2
 180,Starlark,programming,PT,2021,2
@@ -32119,8 +32238,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Haskell,programming,PT,2021,2
 133,Objective-C++,programming,PT,2021,2
 120,Solidity,programming,PT,2021,2
-113,Yacc,programming,PT,2021,2
 113,Emacs Lisp,programming,PT,2021,2
+113,Yacc,programming,PT,2021,2
 111,ASP.NET,programming,PT,2021,2
 107,Awk,programming,PT,2021,2
 106,PLpgSQL,programming,PT,2021,2
@@ -32207,8 +32326,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 145,PureBasic,programming,RO,2021,2
 142,Awk,programming,RO,2021,2
 140,Haskell,programming,RO,2021,2
-139,Lex,programming,RO,2021,2
 139,HCL,programming,RO,2021,2
+139,Lex,programming,RO,2021,2
 127,QMake,programming,RO,2021,2
 123,Scala,programming,RO,2021,2
 118,Tcl,programming,RO,2021,2
@@ -32271,8 +32390,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 213,PostScript,markup,RU,2021,2
 209,Slim,markup,RU,2021,2
 195,Nunjucks,markup,RU,2021,2
-169,Vim Snippet,markup,RU,2021,2
 169,Haml,markup,RU,2021,2
+169,Vim Snippet,markup,RU,2021,2
 131,Liquid,markup,RU,2021,2
 62145,JavaScript,programming,RU,2021,2
 44136,Python,programming,RU,2021,2
@@ -32347,8 +32466,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 325,Common Lisp,programming,RU,2021,2
 311,Meson,programming,RU,2021,2
 300,Scheme,programming,RU,2021,2
-293,Prolog,programming,RU,2021,2
 293,Inno Setup,programming,RU,2021,2
+293,Prolog,programming,RU,2021,2
 283,F#,programming,RU,2021,2
 281,Visual Basic .NET,programming,RU,2021,2
 280,DIGITAL Command Language,programming,RU,2021,2
@@ -32361,8 +32480,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 239,SourcePawn,programming,RU,2021,2
 235,XS,programming,RU,2021,2
 223,D,programming,RU,2021,2
-222,Gnuplot,programming,RU,2021,2
 222,DTrace,programming,RU,2021,2
+222,Gnuplot,programming,RU,2021,2
 216,Verilog,programming,RU,2021,2
 201,Julia,programming,RU,2021,2
 193,SmPL,programming,RU,2021,2
@@ -32376,8 +32495,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 157,Forth,programming,RU,2021,2
 147,AIDL,programming,RU,2021,2
 145,Processing,programming,RU,2021,2
-144,Module Management System,programming,RU,2021,2
 144,Classic ASP,programming,RU,2021,2
+144,Module Management System,programming,RU,2021,2
 144,AMPL,programming,RU,2021,2
 143,UnrealScript,programming,RU,2021,2
 139,Jsonnet,programming,RU,2021,2
@@ -32503,19 +32622,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 198,Mathematica,programming,SE,2021,2
 190,TSQL,programming,SE,2021,2
 188,PLpgSQL,programming,SE,2021,2
-182,Lex,programming,SE,2021,2
 182,Elixir,programming,SE,2021,2
+182,Lex,programming,SE,2021,2
 178,Erlang,programming,SE,2021,2
 173,GDB,programming,SE,2021,2
-164,Julia,programming,SE,2021,2
 164,NSIS,programming,SE,2021,2
+164,Julia,programming,SE,2021,2
 161,Scheme,programming,SE,2021,2
 158,Tcl,programming,SE,2021,2
 156,Clojure,programming,SE,2021,2
 153,Fortran,programming,SE,2021,2
 129,CoffeeScript,programming,SE,2021,2
-127,AutoHotkey,programming,SE,2021,2
 127,Raku,programming,SE,2021,2
+127,AutoHotkey,programming,SE,2021,2
 124,Smalltalk,programming,SE,2021,2
 120,GAP,programming,SE,2021,2
 120,Pascal,programming,SE,2021,2
@@ -32857,8 +32976,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 170,HCL,programming,TR,2021,2
 137,Fortran,programming,TR,2021,2
 137,CoffeeScript,programming,TR,2021,2
-120,Groovy,programming,TR,2021,2
 120,Smalltalk,programming,TR,2021,2
+120,Groovy,programming,TR,2021,2
 113,Cuda,programming,TR,2021,2
 108,Emacs Lisp,programming,TR,2021,2
 108,Yacc,programming,TR,2021,2
@@ -32950,8 +33069,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,Processing,programming,TW,2021,2
 123,Clojure,programming,TW,2021,2
 117,NASL,programming,TW,2021,2
-115,NSIS,programming,TW,2021,2
 115,PLpgSQL,programming,TW,2021,2
+115,NSIS,programming,TW,2021,2
 111,XS,programming,TW,2021,2
 103,SWIG,programming,TW,2021,2
 1019,HTML,markup,TZ,2021,2
@@ -32962,8 +33081,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 392,Shell,programming,TZ,2021,2
 284,PHP,programming,TZ,2021,2
 218,Python,programming,TZ,2021,2
-156,Ruby,programming,TZ,2021,2
 156,Java,programming,TZ,2021,2
+156,Ruby,programming,TZ,2021,2
 38449,HTML,markup,UA,2021,2
 29227,CSS,markup,UA,2021,2
 12359,SCSS,markup,UA,2021,2
@@ -33045,8 +33164,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,PureBasic,programming,UA,2021,2
 117,Tcl,programming,UA,2021,2
 113,NSIS,programming,UA,2021,2
-111,Fortran,programming,UA,2021,2
 111,Nix,programming,UA,2021,2
+111,Fortran,programming,UA,2021,2
 110,NASL,programming,UA,2021,2
 108,MATLAB,programming,UA,2021,2
 103,PLSQL,programming,UA,2021,2
@@ -33248,8 +33367,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 400,AGS Script,programming,US,2021,2
 398,Ragel,programming,US,2021,2
 396,ReScript,programming,US,2021,2
-390,Open Policy Agent,programming,US,2021,2
 390,q,programming,US,2021,2
+390,Open Policy Agent,programming,US,2021,2
 389,Jasmin,programming,US,2021,2
 388,Max,programming,US,2021,2
 385,SaltStack,programming,US,2021,2
@@ -33292,8 +33411,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 195,Cool,programming,US,2021,2
 192,YARA,programming,US,2021,2
 191,E,programming,US,2021,2
-188,Modelica,programming,US,2021,2
 188,FreeBasic,programming,US,2021,2
+188,Modelica,programming,US,2021,2
 187,AutoIt,programming,US,2021,2
 184,BlitzBasic,programming,US,2021,2
 179,LiveScript,programming,US,2021,2
@@ -33307,8 +33426,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,CLIPS,programming,US,2021,2
 163,CartoCSS,programming,US,2021,2
 161,Singularity,programming,US,2021,2
-160,Slash,programming,US,2021,2
 160,ZenScript,programming,US,2021,2
+160,Slash,programming,US,2021,2
 159,Fluent,programming,US,2021,2
 157,AngelScript,programming,US,2021,2
 152,Pike,programming,US,2021,2
@@ -33320,8 +33439,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,CWeb,programming,US,2021,2
 140,Agda,programming,US,2021,2
 140,Hy,programming,US,2021,2
-134,Harbour,programming,US,2021,2
 134,LilyPond,programming,US,2021,2
+134,Harbour,programming,US,2021,2
 133,Zeek,programming,US,2021,2
 131,SQF,programming,US,2021,2
 130,NetLogo,programming,US,2021,2
@@ -33329,8 +33448,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,LSL,programming,US,2021,2
 124,Faust,programming,US,2021,2
 124,F*,programming,US,2021,2
-123,Xtend,programming,US,2021,2
 123,J,programming,US,2021,2
+123,Xtend,programming,US,2021,2
 120,Sieve,programming,US,2021,2
 119,Isabelle,programming,US,2021,2
 119,Lean,programming,US,2021,2
@@ -33457,8 +33576,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 500,Vim Script,programming,VN,2021,2
 485,XSLT,programming,VN,2021,2
 479,Perl,programming,VN,2021,2
-412,ShaderLab,programming,VN,2021,2
 412,Smarty,programming,VN,2021,2
+412,ShaderLab,programming,VN,2021,2
 395,HLSL,programming,VN,2021,2
 346,Lua,programming,VN,2021,2
 290,CoffeeScript,programming,VN,2021,2
@@ -33476,8 +33595,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 164,Fortran,programming,VN,2021,2
 160,Cuda,programming,VN,2021,2
 160,QMake,programming,VN,2021,2
-144,Scala,programming,VN,2021,2
 144,Awk,programming,VN,2021,2
+144,Scala,programming,VN,2021,2
 132,Pascal,programming,VN,2021,2
 128,Mako,programming,VN,2021,2
 125,Emacs Lisp,programming,VN,2021,2
@@ -33534,8 +33653,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Lua,programming,ZA,2021,2
 107,Solidity,programming,ZA,2021,2
 106,Gherkin,programming,ZA,2021,2
-104,HCL,programming,ZA,2021,2
 104,Smarty,programming,ZA,2021,2
+104,HCL,programming,ZA,2021,2
 101,Starlark,programming,ZA,2021,2
 348,HTML,markup,ZM,2021,2
 242,CSS,markup,ZM,2021,2
@@ -33673,8 +33792,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 251,GLSL,programming,AR,2021,3
 246,Gherkin,programming,AR,2021,3
 233,HCL,programming,AR,2021,3
-219,Smalltalk,programming,AR,2021,3
 219,Rust,programming,AR,2021,3
+219,Smalltalk,programming,AR,2021,3
 215,XSLT,programming,AR,2021,3
 214,Haskell,programming,AR,2021,3
 202,Yacc,programming,AR,2021,3
@@ -33685,15 +33804,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,Groovy,programming,AR,2021,3
 123,M4,programming,AR,2021,3
 122,Processing,programming,AR,2021,3
-120,Pascal,programming,AR,2021,3
 120,Objective-C++,programming,AR,2021,3
+120,Pascal,programming,AR,2021,3
 116,CoffeeScript,programming,AR,2021,3
 113,Scala,programming,AR,2021,3
 112,GDScript,programming,AR,2021,3
 111,Wollok,programming,AR,2021,3
 103,Awk,programming,AR,2021,3
-102,Mako,programming,AR,2021,3
 102,Visual Basic .NET,programming,AR,2021,3
+102,Mako,programming,AR,2021,3
 5913,HTML,markup,AT,2021,3
 4432,CSS,markup,AT,2021,3
 1742,SCSS,markup,AT,2021,3
@@ -33780,9 +33899,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 249,Svelte,markup,AU,2021,3
 170,Twig,markup,AU,2021,3
 146,Stylus,markup,AU,2021,3
+134,Vim Snippet,markup,AU,2021,3
 134,Liquid,markup,AU,2021,3
 134,PostScript,markup,AU,2021,3
-134,Vim Snippet,markup,AU,2021,3
 131,Nunjucks,markup,AU,2021,3
 24070,JavaScript,programming,AU,2021,3
 15569,Shell,programming,AU,2021,3
@@ -33856,8 +33975,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,Mako,programming,AU,2021,3
 161,GAP,programming,AU,2021,3
 160,AutoHotkey,programming,AU,2021,3
-155,Processing,programming,AU,2021,3
 155,SWIG,programming,AU,2021,3
+155,Processing,programming,AU,2021,3
 154,Common Lisp,programming,AU,2021,3
 151,VBScript,programming,AU,2021,3
 149,Visual Basic .NET,programming,AU,2021,3
@@ -33865,8 +33984,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 143,Meson,programming,AU,2021,3
 139,DIGITAL Command Language,programming,AU,2021,3
 135,Prolog,programming,AU,2021,3
-128,PLSQL,programming,AU,2021,3
 128,ANTLR,programming,AU,2021,3
+128,PLSQL,programming,AU,2021,3
 127,AppleScript,programming,AU,2021,3
 125,D,programming,AU,2021,3
 121,GDScript,programming,AU,2021,3
@@ -33875,8 +33994,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,Gnuplot,programming,AU,2021,3
 114,Pawn,programming,AU,2021,3
 111,G-code,programming,AU,2021,3
-105,Verilog,programming,AU,2021,3
 105,OCaml,programming,AU,2021,3
+105,Verilog,programming,AU,2021,3
 103,Erlang,programming,AU,2021,3
 102,QML,programming,AU,2021,3
 1923,HTML,markup,AZ,2021,3
@@ -33990,8 +34109,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1114,Batchfile,programming,BE,2021,3
 663,CMake,programming,BE,2021,3
 586,PowerShell,programming,BE,2021,3
-499,Go,programming,BE,2021,3
 499,R,programming,BE,2021,3
+499,Go,programming,BE,2021,3
 494,Perl,programming,BE,2021,3
 464,Objective-C,programming,BE,2021,3
 414,Kotlin,programming,BE,2021,3
@@ -34020,8 +34139,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 134,Emacs Lisp,programming,BE,2021,3
 120,Nix,programming,BE,2021,3
 118,Julia,programming,BE,2021,3
-110,Pascal,programming,BE,2021,3
 110,Haskell,programming,BE,2021,3
+110,Pascal,programming,BE,2021,3
 108,Objective-C++,programming,BE,2021,3
 102,QMake,programming,BE,2021,3
 130,HTML,markup,BF,2021,3
@@ -34096,8 +34215,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 225,C++,programming,BO,2021,3
 221,Hack,programming,BO,2021,3
 209,Ruby,programming,BO,2021,3
-207,Objective-C,programming,BO,2021,3
 207,Kotlin,programming,BO,2021,3
+207,Objective-C,programming,BO,2021,3
 165,Swift,programming,BO,2021,3
 160,Dart,programming,BO,2021,3
 109,C,programming,BO,2021,3
@@ -34198,8 +34317,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 285,Julia,programming,BR,2021,3
 285,Scheme,programming,BR,2021,3
 274,ANTLR,programming,BR,2021,3
-272,Mathematica,programming,BR,2021,3
 272,VBScript,programming,BR,2021,3
+272,Mathematica,programming,BR,2021,3
 269,Nix,programming,BR,2021,3
 239,Processing,programming,BR,2021,3
 235,GDB,programming,BR,2021,3
@@ -34227,14 +34346,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,Apex,programming,BR,2021,3
 123,AIDL,programming,BR,2021,3
 122,Scilab,programming,BR,2021,3
-114,AMPL,programming,BR,2021,3
 114,D,programming,BR,2021,3
+114,AMPL,programming,BR,2021,3
 112,AutoHotkey,programming,BR,2021,3
 109,Xonsh,programming,BR,2021,3
 107,Game Maker Language,programming,BR,2021,3
 104,Classic ASP,programming,BR,2021,3
-104,DIGITAL Command Language,programming,BR,2021,3
 104,ActionScript,programming,BR,2021,3
+104,DIGITAL Command Language,programming,BR,2021,3
 102,M,programming,BR,2021,3
 126,HTML,markup,BT,2021,3
 115,JavaScript,programming,BT,2021,3
@@ -34281,9 +34400,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 177,Starlark,programming,BY,2021,3
 166,Dart,programming,BY,2021,3
 158,Lua,programming,BY,2021,3
-155,Perl,programming,BY,2021,3
-155,Groovy,programming,BY,2021,3
 155,TSQL,programming,BY,2021,3
+155,Groovy,programming,BY,2021,3
+155,Perl,programming,BY,2021,3
 142,HCL,programming,BY,2021,3
 134,GLSL,programming,BY,2021,3
 133,Smarty,programming,BY,2021,3
@@ -34360,8 +34479,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 665,PLpgSQL,programming,CA,2021,3
 617,Yacc,programming,CA,2021,3
 612,Nix,programming,CA,2021,3
-555,ASP.NET,programming,CA,2021,3
 555,Scala,programming,CA,2021,3
+555,ASP.NET,programming,CA,2021,3
 549,TSQL,programming,CA,2021,3
 539,Haskell,programming,CA,2021,3
 536,sed,programming,CA,2021,3
@@ -34419,8 +34538,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,OpenSCAD,programming,CA,2021,3
 137,OCaml,programming,CA,2021,3
 116,SmPL,programming,CA,2021,3
-115,Standard ML,programming,CA,2021,3
 115,VBA,programming,CA,2021,3
+115,Standard ML,programming,CA,2021,3
 115,SystemVerilog,programming,CA,2021,3
 114,Forth,programming,CA,2021,3
 112,DM,programming,CA,2021,3
@@ -34512,15 +34631,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,Raku,programming,CH,2021,3
 154,PLSQL,programming,CH,2021,3
 153,Gnuplot,programming,CH,2021,3
-143,Scheme,programming,CH,2021,3
 143,Cython,programming,CH,2021,3
+143,Scheme,programming,CH,2021,3
 141,CoffeeScript,programming,CH,2021,3
 140,HLSL,programming,CH,2021,3
 137,Mako,programming,CH,2021,3
 135,NSIS,programming,CH,2021,3
 131,Julia,programming,CH,2021,3
-129,ShaderLab,programming,CH,2021,3
 129,Meson,programming,CH,2021,3
+129,ShaderLab,programming,CH,2021,3
 126,Clojure,programming,CH,2021,3
 123,Smalltalk,programming,CH,2021,3
 123,VHDL,programming,CH,2021,3
@@ -34673,8 +34792,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 916,AIDL,programming,CN,2021,3
 915,ShaderLab,programming,CN,2021,3
 910,Raku,programming,CN,2021,3
-868,ASP.NET,programming,CN,2021,3
 868,HLSL,programming,CN,2021,3
+868,ASP.NET,programming,CN,2021,3
 791,Solidity,programming,CN,2021,3
 784,SWIG,programming,CN,2021,3
 773,Clojure,programming,CN,2021,3
@@ -34720,8 +34839,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 295,Common Lisp,programming,CN,2021,3
 293,Inno Setup,programming,CN,2021,3
 282,ActionScript,programming,CN,2021,3
-277,Gnuplot,programming,CN,2021,3
 277,Julia,programming,CN,2021,3
+277,Gnuplot,programming,CN,2021,3
 269,Erlang,programming,CN,2021,3
 263,Metal,programming,CN,2021,3
 252,Coq,programming,CN,2021,3
@@ -34744,8 +34863,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 164,WebAssembly,programming,CN,2021,3
 159,eC,programming,CN,2021,3
 157,POV-Ray SDL,programming,CN,2021,3
-154,Standard ML,programming,CN,2021,3
 154,Elixir,programming,CN,2021,3
+154,Standard ML,programming,CN,2021,3
 148,Ragel,programming,CN,2021,3
 146,Stata,programming,CN,2021,3
 145,OCaml,programming,CN,2021,3
@@ -34917,8 +35036,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 260,Awk,programming,CZ,2021,3
 245,GLSL,programming,CZ,2021,3
 225,HCL,programming,CZ,2021,3
-214,Yacc,programming,CZ,2021,3
 214,Hack,programming,CZ,2021,3
+214,Yacc,programming,CZ,2021,3
 206,Emacs Lisp,programming,CZ,2021,3
 200,QMake,programming,CZ,2021,3
 183,Lex,programming,CZ,2021,3
@@ -34938,8 +35057,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,FreeMarker,programming,CZ,2021,3
 114,Smalltalk,programming,CZ,2021,3
 111,GDB,programming,CZ,2021,3
-105,Mako,programming,CZ,2021,3
 105,Pascal,programming,CZ,2021,3
+105,Mako,programming,CZ,2021,3
 104,Meson,programming,CZ,2021,3
 55972,HTML,markup,DE,2021,3
 41719,CSS,markup,DE,2021,3
@@ -35094,8 +35213,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 183,SystemVerilog,programming,DE,2021,3
 180,BitBake,programming,DE,2021,3
 178,RobotFramework,programming,DE,2021,3
-171,Module Management System,programming,DE,2021,3
 171,Thrift,programming,DE,2021,3
+171,Module Management System,programming,DE,2021,3
 170,SAS,programming,DE,2021,3
 163,WebAssembly,programming,DE,2021,3
 154,Rebol,programming,DE,2021,3
@@ -35106,15 +35225,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Logos,programming,DE,2021,3
 132,Cap'n Proto,programming,DE,2021,3
 131,ASL,programming,DE,2021,3
-131,Stata,programming,DE,2021,3
 131,XQuery,programming,DE,2021,3
+131,Stata,programming,DE,2021,3
 127,AGS Script,programming,DE,2021,3
 123,jq,programming,DE,2021,3
 122,Fluent,programming,DE,2021,3
 122,Limbo,programming,DE,2021,3
 121,Metal,programming,DE,2021,3
-119,SuperCollider,programming,DE,2021,3
 119,SQLPL,programming,DE,2021,3
+119,SuperCollider,programming,DE,2021,3
 117,Ragel,programming,DE,2021,3
 116,BASIC,programming,DE,2021,3
 115,Classic ASP,programming,DE,2021,3
@@ -35180,8 +35299,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,M4,programming,DK,2021,3
 133,Objective-C++,programming,DK,2021,3
 118,Haskell,programming,DK,2021,3
-116,Scala,programming,DK,2021,3
 116,Groovy,programming,DK,2021,3
+116,Scala,programming,DK,2021,3
 115,Tcl,programming,DK,2021,3
 107,Awk,programming,DK,2021,3
 104,Smalltalk,programming,DK,2021,3
@@ -35401,8 +35520,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 257,sed,programming,ES,2021,3
 255,QMake,programming,ES,2021,3
 253,TSQL,programming,ES,2021,3
-238,Haskell,programming,ES,2021,3
 238,Cuda,programming,ES,2021,3
+238,Haskell,programming,ES,2021,3
 231,NSIS,programming,ES,2021,3
 221,Raku,programming,ES,2021,3
 220,ASP.NET,programming,ES,2021,3
@@ -35451,6 +35570,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,Assembly,programming,ET,2021,3
 123,Dockerfile,programming,ET,2021,3
 111,C#,programming,ET,2021,3
+291536,HTML,markup,EU,2021,3
+223527,CSS,markup,EU,2021,3
+78431,SCSS,markup,EU,2021,3
+36065,Jupyter Notebook,markup,EU,2021,3
+21957,Vue,markup,EU,2021,3
+16496,TeX,markup,EU,2021,3
+15158,Roff,markup,EU,2021,3
+10638,Less,markup,EU,2021,3
+7192,Twig,markup,EU,2021,3
+6766,Blade,markup,EU,2021,3
+6508,Handlebars,markup,EU,2021,3
+6332,EJS,markup,EU,2021,3
+6209,Jinja,markup,EU,2021,3
+5358,Mustache,markup,EU,2021,3
+3631,Pug,markup,EU,2021,3
+3511,Sass,markup,EU,2021,3
+3452,Rich Text Format,markup,EU,2021,3
+2131,Svelte,markup,EU,2021,3
+1155,Stylus,markup,EU,2021,3
+887,PostScript,markup,EU,2021,3
+857,Vim Snippet,markup,EU,2021,3
+733,Nunjucks,markup,EU,2021,3
+340,Liquid,markup,EU,2021,3
+293,Haml,markup,EU,2021,3
+168,Latte,markup,EU,2021,3
+144,YASnippet,markup,EU,2021,3
+115,Slim,markup,EU,2021,3
 264115,JavaScript,programming,EU,2021,3
 185418,Shell,programming,EU,2021,3
 172468,Python,programming,EU,2021,3
@@ -35520,8 +35666,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1869,Julia,programming,EU,2021,3
 1612,ANTLR,programming,EU,2021,3
 1604,Mako,programming,EU,2021,3
-1587,PLSQL,programming,EU,2021,3
 1587,Elixir,programming,EU,2021,3
+1587,PLSQL,programming,EU,2021,3
 1535,FreeMarker,programming,EU,2021,3
 1495,SWIG,programming,EU,2021,3
 1492,Prolog,programming,EU,2021,3
@@ -35590,16 +35736,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,Vala,programming,EU,2021,3
 140,Logos,programming,EU,2021,3
 132,Cap'n Proto,programming,EU,2021,3
-131,XQuery,programming,EU,2021,3
 131,ASL,programming,EU,2021,3
 131,Stata,programming,EU,2021,3
+131,XQuery,programming,EU,2021,3
 127,AGS Script,programming,EU,2021,3
 123,jq,programming,EU,2021,3
-122,Limbo,programming,EU,2021,3
 122,Fluent,programming,EU,2021,3
+122,Limbo,programming,EU,2021,3
 121,Metal,programming,EU,2021,3
-119,SuperCollider,programming,EU,2021,3
 119,SQLPL,programming,EU,2021,3
+119,SuperCollider,programming,EU,2021,3
 117,Ragel,programming,EU,2021,3
 116,BASIC,programming,EU,2021,3
 115,Classic ASP,programming,EU,2021,3
@@ -35660,14 +35806,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 178,QMake,programming,FI,2021,3
 165,Clojure,programming,FI,2021,3
 162,HCL,programming,FI,2021,3
-150,Scala,programming,FI,2021,3
 150,Awk,programming,FI,2021,3
+150,Scala,programming,FI,2021,3
 146,Starlark,programming,FI,2021,3
 145,Objective-C++,programming,FI,2021,3
 131,Nix,programming,FI,2021,3
 126,Yacc,programming,FI,2021,3
-125,Haskell,programming,FI,2021,3
 125,Gherkin,programming,FI,2021,3
+125,Haskell,programming,FI,2021,3
 122,Hack,programming,FI,2021,3
 121,RobotFramework,programming,FI,2021,3
 107,sed,programming,FI,2021,3
@@ -35725,8 +35871,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1807,Vim Script,programming,FR,2021,3
 1727,Smarty,programming,FR,2021,3
 1499,XSLT,programming,FR,2021,3
-1359,M4,programming,FR,2021,3
 1359,GLSL,programming,FR,2021,3
+1359,M4,programming,FR,2021,3
 1089,HCL,programming,FR,2021,3
 1082,Gherkin,programming,FR,2021,3
 1013,Emacs Lisp,programming,FR,2021,3
@@ -35783,21 +35929,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 233,GAP,programming,FR,2021,3
 227,Erlang,programming,FR,2021,3
 218,VHDL,programming,FR,2021,3
-215,DIGITAL Command Language,programming,FR,2021,3
 215,Forth,programming,FR,2021,3
+215,DIGITAL Command Language,programming,FR,2021,3
 211,Pawn,programming,FR,2021,3
 200,SourcePawn,programming,FR,2021,3
 199,AppleScript,programming,FR,2021,3
 188,GDScript,programming,FR,2021,3
 188,Visual Basic .NET,programming,FR,2021,3
-183,PureBasic,programming,FR,2021,3
 183,M,programming,FR,2021,3
+183,PureBasic,programming,FR,2021,3
 181,SmPL,programming,FR,2021,3
 178,F#,programming,FR,2021,3
 177,Verilog,programming,FR,2021,3
 170,Processing,programming,FR,2021,3
-169,AMPL,programming,FR,2021,3
 169,Coq,programming,FR,2021,3
+169,AMPL,programming,FR,2021,3
 167,DTrace,programming,FR,2021,3
 165,XS,programming,FR,2021,3
 159,Ada,programming,FR,2021,3
@@ -35806,8 +35952,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 143,Puppet,programming,FR,2021,3
 142,POV-Ray SDL,programming,FR,2021,3
 141,LLVM,programming,FR,2021,3
-137,AutoHotkey,programming,FR,2021,3
 137,OpenSCAD,programming,FR,2021,3
+137,AutoHotkey,programming,FR,2021,3
 126,Elm,programming,FR,2021,3
 121,VBA,programming,FR,2021,3
 118,G-code,programming,FR,2021,3
@@ -35931,8 +36077,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 317,D,programming,GB,2021,3
 315,Pawn,programming,GB,2021,3
 295,Erlang,programming,GB,2021,3
-282,Cycript,programming,GB,2021,3
 282,SourcePawn,programming,GB,2021,3
+282,Cycript,programming,GB,2021,3
 273,DTrace,programming,GB,2021,3
 272,AppleScript,programming,GB,2021,3
 263,M,programming,GB,2021,3
@@ -35959,8 +36105,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 163,Scilab,programming,GB,2021,3
 159,Ada,programming,GB,2021,3
 156,Stata,programming,GB,2021,3
-155,Haxe,programming,GB,2021,3
 155,Nextflow,programming,GB,2021,3
+155,Haxe,programming,GB,2021,3
 151,UnrealScript,programming,GB,2021,3
 147,VBA,programming,GB,2021,3
 146,Logos,programming,GB,2021,3
@@ -35969,9 +36115,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,SystemVerilog,programming,GB,2021,3
 129,POV-Ray SDL,programming,GB,2021,3
 126,Nim,programming,GB,2021,3
+124,Metal,programming,GB,2021,3
 124,SuperCollider,programming,GB,2021,3
 124,Bicep,programming,GB,2021,3
-124,Metal,programming,GB,2021,3
 121,ActionScript,programming,GB,2021,3
 118,Sage,programming,GB,2021,3
 116,WebAssembly,programming,GB,2021,3
@@ -36173,12 +36319,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 349,Thrift,programming,HK,2021,3
 345,Clojure,programming,HK,2021,3
 341,TSQL,programming,HK,2021,3
-333,CoffeeScript,programming,HK,2021,3
 333,Hack,programming,HK,2021,3
+333,CoffeeScript,programming,HK,2021,3
 329,Ada,programming,HK,2021,3
 314,NSIS,programming,HK,2021,3
-312,AIDL,programming,HK,2021,3
 312,Fortran,programming,HK,2021,3
+312,AIDL,programming,HK,2021,3
 305,SWIG,programming,HK,2021,3
 292,Gherkin,programming,HK,2021,3
 276,GAP,programming,HK,2021,3
@@ -36199,10 +36345,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 168,DTrace,programming,HK,2021,3
 161,Mako,programming,HK,2021,3
 153,Pawn,programming,HK,2021,3
+151,Scheme,programming,HK,2021,3
+151,ASL,programming,HK,2021,3
 151,PureBasic,programming,HK,2021,3
 151,Smalltalk,programming,HK,2021,3
-151,ASL,programming,HK,2021,3
-151,Scheme,programming,HK,2021,3
 147,Meson,programming,HK,2021,3
 145,Mathematica,programming,HK,2021,3
 142,RPC,programming,HK,2021,3
@@ -36214,8 +36360,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,Jsonnet,programming,HK,2021,3
 129,QML,programming,HK,2021,3
 125,Erlang,programming,HK,2021,3
-123,q,programming,HK,2021,3
 123,Common Lisp,programming,HK,2021,3
+123,q,programming,HK,2021,3
 119,AspectJ,programming,HK,2021,3
 117,HiveQL,programming,HK,2021,3
 113,M,programming,HK,2021,3
@@ -36511,8 +36657,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 208,Hack,programming,IL,2021,3
 195,Emacs Lisp,programming,IL,2021,3
 193,Objective-C++,programming,IL,2021,3
-187,Awk,programming,IL,2021,3
 187,Gherkin,programming,IL,2021,3
+187,Awk,programming,IL,2021,3
 173,GLSL,programming,IL,2021,3
 172,PLpgSQL,programming,IL,2021,3
 171,Yacc,programming,IL,2021,3
@@ -36657,8 +36803,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 257,AppleScript,programming,IN,2021,3
 244,SourcePawn,programming,IN,2021,3
 243,VHDL,programming,IN,2021,3
-241,Pawn,programming,IN,2021,3
 241,Scilab,programming,IN,2021,3
+241,Pawn,programming,IN,2021,3
 237,Standard ML,programming,IN,2021,3
 237,Meson,programming,IN,2021,3
 231,VBA,programming,IN,2021,3
@@ -36683,22 +36829,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 145,jq,programming,IN,2021,3
 138,ASL,programming,IN,2021,3
 130,AutoHotkey,programming,IN,2021,3
-128,AutoIt,programming,IN,2021,3
 128,BASIC,programming,IN,2021,3
+128,AutoIt,programming,IN,2021,3
 127,Racket,programming,IN,2021,3
 119,Open Policy Agent,programming,IN,2021,3
 117,Fluent,programming,IN,2021,3
 115,RenderScript,programming,IN,2021,3
-115,AMPL,programming,IN,2021,3
 115,PEG.js,programming,IN,2021,3
+115,AMPL,programming,IN,2021,3
 113,Bicep,programming,IN,2021,3
 112,VCL,programming,IN,2021,3
 110,Io,programming,IN,2021,3
 108,SAS,programming,IN,2021,3
 104,Metal,programming,IN,2021,3
 103,q,programming,IN,2021,3
-102,POV-Ray SDL,programming,IN,2021,3
 102,NewLisp,programming,IN,2021,3
+102,POV-Ray SDL,programming,IN,2021,3
 101,AspectJ,programming,IN,2021,3
 101,SQLPL,programming,IN,2021,3
 1202,HTML,markup,IQ,2021,3
@@ -36836,8 +36982,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 265,TSQL,programming,IT,2021,3
 265,Lex,programming,IT,2021,3
 257,Gherkin,programming,IT,2021,3
-252,Solidity,programming,IT,2021,3
 252,sed,programming,IT,2021,3
+252,Solidity,programming,IT,2021,3
 242,Tcl,programming,IT,2021,3
 238,Cuda,programming,IT,2021,3
 217,Pascal,programming,IT,2021,3
@@ -36849,8 +36995,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 166,FreeMarker,programming,IT,2021,3
 164,Gnuplot,programming,IT,2021,3
 163,Nix,programming,IT,2021,3
-162,NASL,programming,IT,2021,3
 162,QML,programming,IT,2021,3
+162,NASL,programming,IT,2021,3
 160,PLSQL,programming,IT,2021,3
 155,NSIS,programming,IT,2021,3
 150,VHDL,programming,IT,2021,3
@@ -36862,16 +37008,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Clojure,programming,IT,2021,3
 129,Julia,programming,IT,2021,3
 129,CoffeeScript,programming,IT,2021,3
-126,GAP,programming,IT,2021,3
 126,Meson,programming,IT,2021,3
+126,GAP,programming,IT,2021,3
 120,Inno Setup,programming,IT,2021,3
 115,Elixir,programming,IT,2021,3
 113,SmPL,programming,IT,2021,3
 109,Processing,programming,IT,2021,3
 108,M,programming,IT,2021,3
 107,Forth,programming,IT,2021,3
-106,XS,programming,IT,2021,3
 106,Common Lisp,programming,IT,2021,3
+106,XS,programming,IT,2021,3
 106,Mathematica,programming,IT,2021,3
 102,PureBasic,programming,IT,2021,3
 558,HTML,markup,JM,2021,3
@@ -37001,8 +37147,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 228,Mako,programming,JP,2021,3
 223,OCaml,programming,JP,2021,3
 217,DIGITAL Command Language,programming,JP,2021,3
-216,Processing,programming,JP,2021,3
 216,XS,programming,JP,2021,3
+216,Processing,programming,JP,2021,3
 209,Jsonnet,programming,JP,2021,3
 206,ANTLR,programming,JP,2021,3
 202,Prolog,programming,JP,2021,3
@@ -37024,13 +37170,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 146,Erlang,programming,JP,2021,3
 143,F#,programming,JP,2021,3
 136,AIDL,programming,JP,2021,3
-132,Standard ML,programming,JP,2021,3
 132,SystemVerilog,programming,JP,2021,3
+132,Standard ML,programming,JP,2021,3
 131,AMPL,programming,JP,2021,3
 130,LLVM,programming,JP,2021,3
 124,M,programming,JP,2021,3
-120,Thrift,programming,JP,2021,3
 120,Nim,programming,JP,2021,3
+120,Thrift,programming,JP,2021,3
 119,PureBasic,programming,JP,2021,3
 117,UnrealScript,programming,JP,2021,3
 115,Forth,programming,JP,2021,3
@@ -37188,9 +37334,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 187,QML,programming,KR,2021,3
 185,CoffeeScript,programming,KR,2021,3
 180,XS,programming,KR,2021,3
-179,PureBasic,programming,KR,2021,3
 179,AIDL,programming,KR,2021,3
 179,SWIG,programming,KR,2021,3
+179,PureBasic,programming,KR,2021,3
 176,Mathematica,programming,KR,2021,3
 171,TSQL,programming,KR,2021,3
 158,SmPL,programming,KR,2021,3
@@ -37519,8 +37665,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 760,Go,programming,MX,2021,3
 636,CMake,programming,MX,2021,3
 634,PowerShell,programming,MX,2021,3
-492,Assembly,programming,MX,2021,3
 492,ASP.NET,programming,MX,2021,3
+492,Assembly,programming,MX,2021,3
 490,Vim Script,programming,MX,2021,3
 382,Starlark,programming,MX,2021,3
 318,ShaderLab,programming,MX,2021,3
@@ -37589,8 +37735,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 129,Lua,programming,MY,2021,3
 121,Solidity,programming,MY,2021,3
 112,Vim Script,programming,MY,2021,3
-104,M4,programming,MY,2021,3
 104,Rust,programming,MY,2021,3
+104,M4,programming,MY,2021,3
 349,HTML,markup,MZ,2021,3
 275,CSS,markup,MZ,2021,3
 297,JavaScript,programming,MZ,2021,3
@@ -37648,8 +37794,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 212,C#,programming,NI,2021,3
 157,PHP,programming,NI,2021,3
 149,Java,programming,NI,2021,3
-142,TypeScript,programming,NI,2021,3
 142,Python,programming,NI,2021,3
+142,TypeScript,programming,NI,2021,3
 21265,HTML,markup,NL,2021,3
 16140,CSS,markup,NL,2021,3
 5750,SCSS,markup,NL,2021,3
@@ -37744,8 +37890,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 177,SWIG,programming,NL,2021,3
 177,Mako,programming,NL,2021,3
 176,Elixir,programming,NL,2021,3
-175,Common Lisp,programming,NL,2021,3
 175,Meson,programming,NL,2021,3
+175,Common Lisp,programming,NL,2021,3
 164,PLSQL,programming,NL,2021,3
 159,Prolog,programming,NL,2021,3
 159,QML,programming,NL,2021,3
@@ -37762,8 +37908,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,Verilog,programming,NL,2021,3
 110,OCaml,programming,NL,2021,3
 105,SourcePawn,programming,NL,2021,3
-103,OpenSCAD,programming,NL,2021,3
 103,Visual Basic .NET,programming,NL,2021,3
+103,OpenSCAD,programming,NL,2021,3
 101,AppleScript,programming,NL,2021,3
 7342,HTML,markup,NO,2021,3
 5614,CSS,markup,NO,2021,3
@@ -37801,8 +37947,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 433,Vim Script,programming,NO,2021,3
 411,Objective-C,programming,NO,2021,3
 367,Lua,programming,NO,2021,3
-335,Rust,programming,NO,2021,3
 335,Assembly,programming,NO,2021,3
+335,Rust,programming,NO,2021,3
 297,XSLT,programming,NO,2021,3
 268,MATLAB,programming,NO,2021,3
 254,HCL,programming,NO,2021,3
@@ -37890,8 +38036,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 228,HLSL,programming,NZ,2021,3
 223,Assembly,programming,NZ,2021,3
 222,ShaderLab,programming,NZ,2021,3
-212,Gherkin,programming,NZ,2021,3
 212,GLSL,programming,NZ,2021,3
+212,Gherkin,programming,NZ,2021,3
 208,Hack,programming,NZ,2021,3
 187,HCL,programming,NZ,2021,3
 181,XSLT,programming,NZ,2021,3
@@ -37955,8 +38101,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 256,ASP.NET,programming,PE,2021,3
 216,Go,programming,PE,2021,3
 197,PowerShell,programming,PE,2021,3
-145,Gherkin,programming,PE,2021,3
 145,Assembly,programming,PE,2021,3
+145,Gherkin,programming,PE,2021,3
 124,Vim Script,programming,PE,2021,3
 103,Perl,programming,PE,2021,3
 13448,HTML,markup,PH,2021,3
@@ -38016,8 +38162,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 289,Handlebars,markup,PK,2021,3
 259,Pug,markup,PK,2021,3
 173,Roff,markup,PK,2021,3
-131,Mustache,markup,PK,2021,3
 131,TeX,markup,PK,2021,3
+131,Mustache,markup,PK,2021,3
 109,Jinja,markup,PK,2021,3
 106,Rich Text Format,markup,PK,2021,3
 101,Sass,markup,PK,2021,3
@@ -38144,12 +38290,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 136,Meson,programming,PL,2021,3
 135,Verilog,programming,PL,2021,3
 131,VBScript,programming,PL,2021,3
-130,SmPL,programming,PL,2021,3
 130,Raku,programming,PL,2021,3
+130,SmPL,programming,PL,2021,3
 128,QML,programming,PL,2021,3
 127,ANTLR,programming,PL,2021,3
-122,Scheme,programming,PL,2021,3
 122,GAP,programming,PL,2021,3
+122,Scheme,programming,PL,2021,3
 119,Pawn,programming,PL,2021,3
 114,Inno Setup,programming,PL,2021,3
 109,F#,programming,PL,2021,3
@@ -38211,8 +38357,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 396,Swift,programming,PT,2021,3
 337,Perl,programming,PT,2021,3
 326,Assembly,programming,PT,2021,3
-300,Lua,programming,PT,2021,3
 300,Vim Script,programming,PT,2021,3
+300,Lua,programming,PT,2021,3
 243,Rust,programming,PT,2021,3
 236,R,programming,PT,2021,3
 228,MATLAB,programming,PT,2021,3
@@ -38309,8 +38455,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,Solidity,programming,RO,2021,3
 145,HCL,programming,RO,2021,3
 138,Yacc,programming,RO,2021,3
-135,ASP.NET,programming,RO,2021,3
 135,MATLAB,programming,RO,2021,3
+135,ASP.NET,programming,RO,2021,3
 133,Groovy,programming,RO,2021,3
 124,Awk,programming,RO,2021,3
 121,Lex,programming,RO,2021,3
@@ -38403,8 +38549,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1764,Rust,programming,RU,2021,3
 1648,QMake,programming,RU,2021,3
 1642,ShaderLab,programming,RU,2021,3
-1637,HLSL,programming,RU,2021,3
 1637,Dart,programming,RU,2021,3
+1637,HLSL,programming,RU,2021,3
 1593,Vim Script,programming,RU,2021,3
 1481,GLSL,programming,RU,2021,3
 1461,M4,programming,RU,2021,3
@@ -38456,8 +38602,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 278,GAP,programming,RU,2021,3
 273,DIGITAL Command Language,programming,RU,2021,3
 271,Visual Basic .NET,programming,RU,2021,3
-263,Common Lisp,programming,RU,2021,3
 263,XS,programming,RU,2021,3
+263,Common Lisp,programming,RU,2021,3
 259,F#,programming,RU,2021,3
 256,Prolog,programming,RU,2021,3
 246,Elixir,programming,RU,2021,3
@@ -38484,8 +38630,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,Forth,programming,RU,2021,3
 134,Scilab,programming,RU,2021,3
 132,Module Management System,programming,RU,2021,3
-127,Standard ML,programming,RU,2021,3
 127,AutoHotkey,programming,RU,2021,3
+127,Standard ML,programming,RU,2021,3
 121,Thrift,programming,RU,2021,3
 121,VHDL,programming,RU,2021,3
 116,Ada,programming,RU,2021,3
@@ -38618,8 +38764,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 139,ASP.NET,programming,SE,2021,3
 136,Pascal,programming,SE,2021,3
 136,Clojure,programming,SE,2021,3
-134,AutoHotkey,programming,SE,2021,3
 134,CoffeeScript,programming,SE,2021,3
+134,AutoHotkey,programming,SE,2021,3
 132,Fortran,programming,SE,2021,3
 123,Cuda,programming,SE,2021,3
 119,Raku,programming,SE,2021,3
@@ -38627,8 +38773,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,F#,programming,SE,2021,3
 111,NASL,programming,SE,2021,3
 108,Meson,programming,SE,2021,3
-105,Common Lisp,programming,SE,2021,3
 105,Inno Setup,programming,SE,2021,3
+105,Common Lisp,programming,SE,2021,3
 17738,HTML,markup,SG,2021,3
 12803,CSS,markup,SG,2021,3
 3795,SCSS,markup,SG,2021,3
@@ -38686,8 +38832,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 294,Scala,programming,SG,2021,3
 287,Groovy,programming,SG,2021,3
 267,GLSL,programming,SG,2021,3
-251,Emacs Lisp,programming,SG,2021,3
 251,Yacc,programming,SG,2021,3
+251,Emacs Lisp,programming,SG,2021,3
 238,Objective-C++,programming,SG,2021,3
 219,Lex,programming,SG,2021,3
 219,PLpgSQL,programming,SG,2021,3
@@ -38710,8 +38856,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,Mako,programming,SG,2021,3
 118,Pascal,programming,SG,2021,3
 118,FreeMarker,programming,SG,2021,3
-101,Verilog,programming,SG,2021,3
 101,Raku,programming,SG,2021,3
+101,Verilog,programming,SG,2021,3
 1364,HTML,markup,SI,2021,3
 1058,CSS,markup,SI,2021,3
 337,SCSS,markup,SI,2021,3
@@ -38850,8 +38996,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 392,CMake,programming,TH,2021,3
 342,PowerShell,programming,TH,2021,3
 322,Solidity,programming,TH,2021,3
-313,R,programming,TH,2021,3
 313,Lua,programming,TH,2021,3
+313,R,programming,TH,2021,3
 224,Starlark,programming,TH,2021,3
 220,Perl,programming,TH,2021,3
 219,Assembly,programming,TH,2021,3
@@ -39019,8 +39165,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 361,Rust,programming,TW,2021,3
 330,HLSL,programming,TW,2021,3
 302,Awk,programming,TW,2021,3
-300,XSLT,programming,TW,2021,3
 300,GLSL,programming,TW,2021,3
+300,XSLT,programming,TW,2021,3
 293,Solidity,programming,TW,2021,3
 276,Cuda,programming,TW,2021,3
 276,Yacc,programming,TW,2021,3
@@ -39038,8 +39184,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 162,Fortran,programming,TW,2021,3
 161,GDB,programming,TW,2021,3
 153,CoffeeScript,programming,TW,2021,3
-151,Raku,programming,TW,2021,3
 151,NASL,programming,TW,2021,3
+151,Raku,programming,TW,2021,3
 150,Pascal,programming,TW,2021,3
 146,PLpgSQL,programming,TW,2021,3
 144,Groovy,programming,TW,2021,3
@@ -39278,8 +39424,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1635,SourcePawn,programming,US,2021,3
 1634,M,programming,US,2021,3
 1615,F#,programming,US,2021,3
-1603,Inno Setup,programming,US,2021,3
 1603,Pawn,programming,US,2021,3
+1603,Inno Setup,programming,US,2021,3
 1595,AppleScript,programming,US,2021,3
 1591,LLVM,programming,US,2021,3
 1537,OCaml,programming,US,2021,3
@@ -39308,8 +39454,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 900,G-code,programming,US,2021,3
 888,Haxe,programming,US,2021,3
 876,Apex,programming,US,2021,3
-856,Scilab,programming,US,2021,3
 856,Ada,programming,US,2021,3
+856,Scilab,programming,US,2021,3
 843,SAS,programming,US,2021,3
 804,Rebol,programming,US,2021,3
 786,POV-Ray SDL,programming,US,2021,3
@@ -39390,18 +39536,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 219,nesC,programming,US,2021,3
 217,Modelica,programming,US,2021,3
 211,YARA,programming,US,2021,3
-208,PigLatin,programming,US,2021,3
 208,Common Workflow Language,programming,US,2021,3
+208,PigLatin,programming,US,2021,3
 207,Red,programming,US,2021,3
 204,Kaitai Struct,programming,US,2021,3
 200,eC,programming,US,2021,3
-195,REXX,programming,US,2021,3
 195,Objective-J,programming,US,2021,3
+195,REXX,programming,US,2021,3
 192,Lean,programming,US,2021,3
 187,BlitzBasic,programming,US,2021,3
 183,Cool,programming,US,2021,3
-182,Slash,programming,US,2021,3
 182,LabVIEW,programming,US,2021,3
+182,Slash,programming,US,2021,3
 176,AspectJ,programming,US,2021,3
 172,Singularity,programming,US,2021,3
 170,ZenScript,programming,US,2021,3
@@ -39412,8 +39558,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 158,Clarion,programming,US,2021,3
 155,CUE,programming,US,2021,3
 153,Clean,programming,US,2021,3
-152,ImageJ Macro,programming,US,2021,3
 152,Nearley,programming,US,2021,3
+152,ImageJ Macro,programming,US,2021,3
 149,NetLogo,programming,US,2021,3
 142,Hy,programming,US,2021,3
 139,CWeb,programming,US,2021,3
@@ -39422,8 +39568,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 134,Isabelle,programming,US,2021,3
 133,Pike,programming,US,2021,3
 130,Xtend,programming,US,2021,3
-126,J,programming,US,2021,3
 126,SQF,programming,US,2021,3
+126,J,programming,US,2021,3
 125,CartoCSS,programming,US,2021,3
 124,Ren'Py,programming,US,2021,3
 124,Zeek,programming,US,2021,3
@@ -39441,8 +39587,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,Idris,programming,US,2021,3
 103,P4,programming,US,2021,3
 103,KakouneScript,programming,US,2021,3
-102,Turing,programming,US,2021,3
 102,Eiffel,programming,US,2021,3
+102,Turing,programming,US,2021,3
 150,Markdown,prose,US,2021,3
 2567,HTML,markup,UY,2021,3
 2205,CSS,markup,UY,2021,3
@@ -39454,8 +39600,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 487,Java,programming,UY,2021,3
 432,TypeScript,programming,UY,2021,3
 399,C#,programming,UY,2021,3
-339,Dockerfile,programming,UY,2021,3
 339,Ruby,programming,UY,2021,3
+339,Dockerfile,programming,UY,2021,3
 285,PHP,programming,UY,2021,3
 230,C,programming,UY,2021,3
 188,Makefile,programming,UY,2021,3
@@ -39588,8 +39734,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,PureBasic,programming,VN,2021,3
 124,Fortran,programming,VN,2021,3
 120,Classic ASP,programming,VN,2021,3
-112,PLSQL,programming,VN,2021,3
 112,Yacc,programming,VN,2021,3
+112,PLSQL,programming,VN,2021,3
 109,Mako,programming,VN,2021,3
 105,Tcl,programming,VN,2021,3
 331,HTML,markup,YE,2021,3
@@ -39941,10 +40087,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 389,TSQL,programming,AU,2021,4
 372,Starlark,programming,AU,2021,4
 363,Awk,programming,AU,2021,4
-339,Yacc,programming,AU,2021,4
 339,Scala,programming,AU,2021,4
-334,PLpgSQL,programming,AU,2021,4
+339,Yacc,programming,AU,2021,4
 334,ASP.NET,programming,AU,2021,4
+334,PLpgSQL,programming,AU,2021,4
 319,sed,programming,AU,2021,4
 275,Smalltalk,programming,AU,2021,4
 272,CoffeeScript,programming,AU,2021,4
@@ -39983,11 +40129,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,ANTLR,programming,AU,2021,4
 117,Pawn,programming,AU,2021,4
 114,Gnuplot,programming,AU,2021,4
-111,DIGITAL Command Language,programming,AU,2021,4
 111,GDScript,programming,AU,2021,4
+111,DIGITAL Command Language,programming,AU,2021,4
 110,AppleScript,programming,AU,2021,4
-102,Verilog,programming,AU,2021,4
 102,Erlang,programming,AU,2021,4
+102,Verilog,programming,AU,2021,4
 2304,HTML,markup,AZ,2021,4
 1855,CSS,markup,AZ,2021,4
 669,SCSS,markup,AZ,2021,4
@@ -40120,8 +40266,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 341,Smarty,programming,BE,2021,4
 261,M4,programming,BE,2021,4
 253,HCL,programming,BE,2021,4
-252,HLSL,programming,BE,2021,4
 252,GLSL,programming,BE,2021,4
+252,HLSL,programming,BE,2021,4
 238,ShaderLab,programming,BE,2021,4
 231,MATLAB,programming,BE,2021,4
 216,Gherkin,programming,BE,2021,4
@@ -40219,8 +40365,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 235,Hack,programming,BO,2021,4
 230,Kotlin,programming,BO,2021,4
 221,Objective-C,programming,BO,2021,4
-203,Ruby,programming,BO,2021,4
 203,Dockerfile,programming,BO,2021,4
+203,Ruby,programming,BO,2021,4
 196,Swift,programming,BO,2021,4
 183,Dart,programming,BO,2021,4
 182,C++,programming,BO,2021,4
@@ -40316,8 +40462,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 382,FreeMarker,programming,BR,2021,4
 381,RobotFramework,programming,BR,2021,4
 379,VHDL,programming,BR,2021,4
-353,Nix,programming,BR,2021,4
 353,PureBasic,programming,BR,2021,4
+353,Nix,programming,BR,2021,4
 310,Scheme,programming,BR,2021,4
 295,VBA,programming,BR,2021,4
 294,Mathematica,programming,BR,2021,4
@@ -40334,8 +40480,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 223,GDB,programming,BR,2021,4
 222,Common Lisp,programming,BR,2021,4
 199,Stata,programming,BR,2021,4
-184,Standard ML,programming,BR,2021,4
 184,Inno Setup,programming,BR,2021,4
+184,Standard ML,programming,BR,2021,4
 182,F#,programming,BR,2021,4
 182,Forth,programming,BR,2021,4
 181,SWIG,programming,BR,2021,4
@@ -40412,8 +40558,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 176,Dart,programming,BY,2021,4
 172,Perl,programming,BY,2021,4
 171,Groovy,programming,BY,2021,4
-167,Lua,programming,BY,2021,4
 167,TSQL,programming,BY,2021,4
+167,Lua,programming,BY,2021,4
 158,GLSL,programming,BY,2021,4
 137,HCL,programming,BY,2021,4
 133,Objective-C++,programming,BY,2021,4
@@ -40512,8 +40658,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 420,GDB,programming,CA,2021,4
 411,Cuda,programming,CA,2021,4
 408,Scheme,programming,CA,2021,4
-393,NSIS,programming,CA,2021,4
 393,Julia,programming,CA,2021,4
+393,NSIS,programming,CA,2021,4
 381,Elixir,programming,CA,2021,4
 369,Smalltalk,programming,CA,2021,4
 369,Clojure,programming,CA,2021,4
@@ -40526,8 +40672,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 274,Meson,programming,CA,2021,4
 273,Prolog,programming,CA,2021,4
 269,AutoHotkey,programming,CA,2021,4
-264,Common Lisp,programming,CA,2021,4
 264,Verilog,programming,CA,2021,4
+264,Common Lisp,programming,CA,2021,4
 262,Pawn,programming,CA,2021,4
 258,SourcePawn,programming,CA,2021,4
 254,FreeMarker,programming,CA,2021,4
@@ -40546,12 +40692,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 186,DTrace,programming,CA,2021,4
 184,PureBasic,programming,CA,2021,4
 163,OCaml,programming,CA,2021,4
-159,Jsonnet,programming,CA,2021,4
 159,M,programming,CA,2021,4
+159,Jsonnet,programming,CA,2021,4
 156,Standard ML,programming,CA,2021,4
 156,OpenSCAD,programming,CA,2021,4
-150,LLVM,programming,CA,2021,4
 150,XS,programming,CA,2021,4
+150,LLVM,programming,CA,2021,4
 144,G-code,programming,CA,2021,4
 144,Stata,programming,CA,2021,4
 143,Nim,programming,CA,2021,4
@@ -40559,8 +40705,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,SystemVerilog,programming,CA,2021,4
 128,SmPL,programming,CA,2021,4
 123,Thrift,programming,CA,2021,4
-120,Racket,programming,CA,2021,4
 120,CUE,programming,CA,2021,4
+120,Racket,programming,CA,2021,4
 118,AIDL,programming,CA,2021,4
 117,Jasmin,programming,CA,2021,4
 115,VBA,programming,CA,2021,4
@@ -40656,16 +40802,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 175,PLSQL,programming,CH,2021,4
 170,VHDL,programming,CH,2021,4
 169,Julia,programming,CH,2021,4
-166,Raku,programming,CH,2021,4
 166,NSIS,programming,CH,2021,4
+166,Raku,programming,CH,2021,4
 163,Gnuplot,programming,CH,2021,4
 158,CoffeeScript,programming,CH,2021,4
 158,Clojure,programming,CH,2021,4
 155,Scheme,programming,CH,2021,4
 152,Meson,programming,CH,2021,4
 133,SourcePawn,programming,CH,2021,4
-132,Smalltalk,programming,CH,2021,4
 132,ASP.NET,programming,CH,2021,4
+132,Smalltalk,programming,CH,2021,4
 131,Mako,programming,CH,2021,4
 130,Common Lisp,programming,CH,2021,4
 129,Forth,programming,CH,2021,4
@@ -40720,8 +40866,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,CoffeeScript,programming,CL,2021,4
 149,Assembly,programming,CL,2021,4
 145,Lua,programming,CL,2021,4
-128,HLSL,programming,CL,2021,4
 128,ShaderLab,programming,CL,2021,4
+128,HLSL,programming,CL,2021,4
 123,ASP.NET,programming,CL,2021,4
 120,Perl,programming,CL,2021,4
 109,Smarty,programming,CL,2021,4
@@ -40740,11 +40886,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 384,Java,programming,CM,2021,4
 307,TypeScript,programming,CM,2021,4
 162,Objective-C,programming,CM,2021,4
-152,Kotlin,programming,CM,2021,4
 152,Dockerfile,programming,CM,2021,4
+152,Kotlin,programming,CM,2021,4
 149,C,programming,CM,2021,4
-144,Dart,programming,CM,2021,4
 144,Swift,programming,CM,2021,4
+144,Dart,programming,CM,2021,4
 143,Ruby,programming,CM,2021,4
 117,C#,programming,CM,2021,4
 88625,HTML,markup,CN,2021,4
@@ -40871,8 +41017,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 281,Gnuplot,programming,CN,2021,4
 277,Common Lisp,programming,CN,2021,4
 266,Julia,programming,CN,2021,4
-265,Metal,programming,CN,2021,4
 265,Scilab,programming,CN,2021,4
+265,Metal,programming,CN,2021,4
 256,SystemVerilog,programming,CN,2021,4
 255,Module Management System,programming,CN,2021,4
 247,Erlang,programming,CN,2021,4
@@ -40885,8 +41031,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 225,Coq,programming,CN,2021,4
 224,D,programming,CN,2021,4
 210,Forth,programming,CN,2021,4
-202,Processing,programming,CN,2021,4
 202,F#,programming,CN,2021,4
+202,Processing,programming,CN,2021,4
 193,Prolog,programming,CN,2021,4
 187,VHDL,programming,CN,2021,4
 185,Logos,programming,CN,2021,4
@@ -40894,24 +41040,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 178,POV-Ray SDL,programming,CN,2021,4
 156,Standard ML,programming,CN,2021,4
 154,Elixir,programming,CN,2021,4
-148,WebAssembly,programming,CN,2021,4
 148,Stata,programming,CN,2021,4
+148,WebAssembly,programming,CN,2021,4
 148,AMPL,programming,CN,2021,4
-147,OpenEdge ABL,programming,CN,2021,4
 147,Sage,programming,CN,2021,4
+147,OpenEdge ABL,programming,CN,2021,4
 146,OCaml,programming,CN,2021,4
 145,Ragel,programming,CN,2021,4
 144,SAS,programming,CN,2021,4
 136,jq,programming,CN,2021,4
 132,ReScript,programming,CN,2021,4
 124,eC,programming,CN,2021,4
-123,G-code,programming,CN,2021,4
 123,RenderScript,programming,CN,2021,4
+123,G-code,programming,CN,2021,4
 122,Limbo,programming,CN,2021,4
 116,Terra,programming,CN,2021,4
-113,Cap'n Proto,programming,CN,2021,4
 113,RobotFramework,programming,CN,2021,4
 113,CodeQL,programming,CN,2021,4
+113,Cap'n Proto,programming,CN,2021,4
 108,Nim,programming,CN,2021,4
 32261,HTML,markup,CO,2021,4
 25848,CSS,markup,CO,2021,4
@@ -41017,8 +41163,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 402,Shell,programming,CY,2021,4
 362,Python,programming,CY,2021,4
 204,Dockerfile,programming,CY,2021,4
-169,Java,programming,CY,2021,4
 169,TypeScript,programming,CY,2021,4
+169,Java,programming,CY,2021,4
 161,Makefile,programming,CY,2021,4
 155,PHP,programming,CY,2021,4
 138,C#,programming,CY,2021,4
@@ -41039,9 +41185,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 194,Latte,markup,CZ,2021,4
 182,Sass,markup,CZ,2021,4
 148,Twig,markup,CZ,2021,4
-134,Pug,markup,CZ,2021,4
-134,Rich Text Format,markup,CZ,2021,4
 134,Blade,markup,CZ,2021,4
+134,Rich Text Format,markup,CZ,2021,4
+134,Pug,markup,CZ,2021,4
 108,Nunjucks,markup,CZ,2021,4
 102,Svelte,markup,CZ,2021,4
 7855,JavaScript,programming,CZ,2021,4
@@ -41050,8 +41196,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 3044,Makefile,programming,CZ,2021,4
 2955,Dockerfile,programming,CZ,2021,4
 2561,C,programming,CZ,2021,4
-2523,TypeScript,programming,CZ,2021,4
 2523,Java,programming,CZ,2021,4
+2523,TypeScript,programming,CZ,2021,4
 2301,C++,programming,CZ,2021,4
 1969,PHP,programming,CZ,2021,4
 1889,C#,programming,CZ,2021,4
@@ -41089,8 +41235,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 170,Haskell,programming,CZ,2021,4
 168,Gherkin,programming,CZ,2021,4
 167,Nix,programming,CZ,2021,4
-163,Starlark,programming,CZ,2021,4
 163,Scala,programming,CZ,2021,4
+163,Starlark,programming,CZ,2021,4
 141,Raku,programming,CZ,2021,4
 141,TSQL,programming,CZ,2021,4
 133,ShaderLab,programming,CZ,2021,4
@@ -41216,13 +41362,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 536,PLSQL,programming,DE,2021,4
 535,Mathematica,programming,DE,2021,4
 525,Erlang,programming,DE,2021,4
-457,VBScript,programming,DE,2021,4
 457,SmPL,programming,DE,2021,4
+457,VBScript,programming,DE,2021,4
 450,Pawn,programming,DE,2021,4
 439,OpenSCAD,programming,DE,2021,4
 432,ASP.NET,programming,DE,2021,4
-424,AutoHotkey,programming,DE,2021,4
 424,DIGITAL Command Language,programming,DE,2021,4
+424,AutoHotkey,programming,DE,2021,4
 417,Jsonnet,programming,DE,2021,4
 415,Verilog,programming,DE,2021,4
 413,XS,programming,DE,2021,4
@@ -41230,8 +41376,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 399,Processing,programming,DE,2021,4
 397,AppleScript,programming,DE,2021,4
 394,Visual Basic .NET,programming,DE,2021,4
-368,OCaml,programming,DE,2021,4
 368,Nim,programming,DE,2021,4
+368,OCaml,programming,DE,2021,4
 365,G-code,programming,DE,2021,4
 361,M,programming,DE,2021,4
 359,GDScript,programming,DE,2021,4
@@ -41242,13 +41388,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 299,UnrealScript,programming,DE,2021,4
 289,PureScript,programming,DE,2021,4
 286,Forth,programming,DE,2021,4
-282,Puppet,programming,DE,2021,4
 282,Standard ML,programming,DE,2021,4
+282,Puppet,programming,DE,2021,4
 272,Jasmin,programming,DE,2021,4
-267,Xtend,programming,DE,2021,4
 267,Reason,programming,DE,2021,4
-261,VBA,programming,DE,2021,4
+267,Xtend,programming,DE,2021,4
 261,POV-Ray SDL,programming,DE,2021,4
+261,VBA,programming,DE,2021,4
 259,Scilab,programming,DE,2021,4
 254,Elm,programming,DE,2021,4
 237,Ada,programming,DE,2021,4
@@ -41268,9 +41414,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 159,RenderScript,programming,DE,2021,4
 158,SAS,programming,DE,2021,4
 151,Haxe,programming,DE,2021,4
-149,ASL,programming,DE,2021,4
-149,XQuery,programming,DE,2021,4
 149,Brainfuck,programming,DE,2021,4
+149,XQuery,programming,DE,2021,4
+149,ASL,programming,DE,2021,4
 149,Stata,programming,DE,2021,4
 146,ABAP,programming,DE,2021,4
 144,SuperCollider,programming,DE,2021,4
@@ -41280,30 +41426,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Ragel,programming,DE,2021,4
 137,Sage,programming,DE,2021,4
 134,Metal,programming,DE,2021,4
-134,jq,programming,DE,2021,4
 134,SaltStack,programming,DE,2021,4
+134,jq,programming,DE,2021,4
 133,Limbo,programming,DE,2021,4
 132,Racket,programming,DE,2021,4
-127,Vala,programming,DE,2021,4
 127,NewLisp,programming,DE,2021,4
+127,Vala,programming,DE,2021,4
 126,Classic ASP,programming,DE,2021,4
 125,Cap'n Proto,programming,DE,2021,4
 125,Nextflow,programming,DE,2021,4
+118,Zig,programming,DE,2021,4
 118,EmberScript,programming,DE,2021,4
 118,Max,programming,DE,2021,4
-118,Zig,programming,DE,2021,4
-117,Apex,programming,DE,2021,4
 117,xBase,programming,DE,2021,4
+117,Apex,programming,DE,2021,4
 117,Isabelle,programming,DE,2021,4
 112,COBOL,programming,DE,2021,4
 111,SQLPL,programming,DE,2021,4
 109,Arc,programming,DE,2021,4
-109,Coq,programming,DE,2021,4
 109,BASIC,programming,DE,2021,4
+109,Coq,programming,DE,2021,4
 107,Qt Script,programming,DE,2021,4
 104,Open Policy Agent,programming,DE,2021,4
-103,Sieve,programming,DE,2021,4
 103,VCL,programming,DE,2021,4
+103,Sieve,programming,DE,2021,4
 102,Modelica,programming,DE,2021,4
 101,BlitzBasic,programming,DE,2021,4
 9127,HTML,markup,DK,2021,4
@@ -41367,11 +41513,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 136,Tcl,programming,DK,2021,4
 135,Smalltalk,programming,DK,2021,4
 126,PLpgSQL,programming,DK,2021,4
-125,Awk,programming,DK,2021,4
 125,Starlark,programming,DK,2021,4
+125,Awk,programming,DK,2021,4
 121,Nix,programming,DK,2021,4
-118,Mathematica,programming,DK,2021,4
 118,Groovy,programming,DK,2021,4
+118,Mathematica,programming,DK,2021,4
 114,Yacc,programming,DK,2021,4
 108,F#,programming,DK,2021,4
 107,Gherkin,programming,DK,2021,4
@@ -41395,8 +41541,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,Kotlin,programming,DO,2021,4
 135,C++,programming,DO,2021,4
 131,Swift,programming,DO,2021,4
-106,Dart,programming,DO,2021,4
 106,C,programming,DO,2021,4
+106,Dart,programming,DO,2021,4
 105,Makefile,programming,DO,2021,4
 104,ASP.NET,programming,DO,2021,4
 2319,HTML,markup,DZ,2021,4
@@ -41620,14 +41766,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,PureBasic,programming,ES,2021,4
 146,Prolog,programming,ES,2021,4
 145,VHDL,programming,ES,2021,4
-141,Julia,programming,ES,2021,4
 141,NASL,programming,ES,2021,4
+141,Julia,programming,ES,2021,4
 139,Erlang,programming,ES,2021,4
 135,DIGITAL Command Language,programming,ES,2021,4
 133,Visual Basic .NET,programming,ES,2021,4
 127,Common Lisp,programming,ES,2021,4
-126,VBScript,programming,ES,2021,4
 126,Verilog,programming,ES,2021,4
+126,VBScript,programming,ES,2021,4
 123,GDScript,programming,ES,2021,4
 118,Ada,programming,ES,2021,4
 116,Inno Setup,programming,ES,2021,4
@@ -41657,6 +41803,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 157,Dockerfile,programming,ET,2021,4
 145,C++,programming,ET,2021,4
 134,C#,programming,ET,2021,4
+347781,HTML,markup,EU,2021,4
+273312,CSS,markup,EU,2021,4
+87359,SCSS,markup,EU,2021,4
+45914,Jupyter Notebook,markup,EU,2021,4
+24950,Vue,markup,EU,2021,4
+18683,TeX,markup,EU,2021,4
+17263,Roff,markup,EU,2021,4
+11529,Less,markup,EU,2021,4
+8390,Twig,markup,EU,2021,4
+7926,Blade,markup,EU,2021,4
+7924,EJS,markup,EU,2021,4
+7511,Handlebars,markup,EU,2021,4
+7109,Jinja,markup,EU,2021,4
+5918,Mustache,markup,EU,2021,4
+4245,Pug,markup,EU,2021,4
+4119,Rich Text Format,markup,EU,2021,4
+3593,Sass,markup,EU,2021,4
+3331,Svelte,markup,EU,2021,4
+1214,Vim Snippet,markup,EU,2021,4
+1173,Stylus,markup,EU,2021,4
+960,Nunjucks,markup,EU,2021,4
+939,PostScript,markup,EU,2021,4
+495,Liquid,markup,EU,2021,4
+348,Haml,markup,EU,2021,4
+194,Latte,markup,EU,2021,4
+158,YASnippet,markup,EU,2021,4
+123,Slim,markup,EU,2021,4
 309362,JavaScript,programming,EU,2021,4
 210639,Shell,programming,EU,2021,4
 210502,Python,programming,EU,2021,4
@@ -41796,19 +41969,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 177,Module Management System,programming,EU,2021,4
 159,RenderScript,programming,EU,2021,4
 158,SAS,programming,EU,2021,4
-149,Brainfuck,programming,EU,2021,4
-149,ASL,programming,EU,2021,4
 149,XQuery,programming,EU,2021,4
+149,ASL,programming,EU,2021,4
+149,Brainfuck,programming,EU,2021,4
 146,ABAP,programming,EU,2021,4
 144,SuperCollider,programming,EU,2021,4
-142,Logos,programming,EU,2021,4
 142,Fluent,programming,EU,2021,4
+142,Logos,programming,EU,2021,4
 140,AGS Script,programming,EU,2021,4
 138,Ragel,programming,EU,2021,4
 137,Sage,programming,EU,2021,4
 134,Metal,programming,EU,2021,4
-134,SaltStack,programming,EU,2021,4
 134,jq,programming,EU,2021,4
+134,SaltStack,programming,EU,2021,4
 133,Limbo,programming,EU,2021,4
 132,Racket,programming,EU,2021,4
 127,Vala,programming,EU,2021,4
@@ -41816,19 +41989,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,Classic ASP,programming,EU,2021,4
 125,Cap'n Proto,programming,EU,2021,4
 125,Nextflow,programming,EU,2021,4
-118,Zig,programming,EU,2021,4
-118,Max,programming,EU,2021,4
 118,EmberScript,programming,EU,2021,4
+118,Max,programming,EU,2021,4
+118,Zig,programming,EU,2021,4
 117,Isabelle,programming,EU,2021,4
 117,xBase,programming,EU,2021,4
 111,SQLPL,programming,EU,2021,4
-109,BASIC,programming,EU,2021,4
 109,Arc,programming,EU,2021,4
+109,BASIC,programming,EU,2021,4
 107,Qt Script,programming,EU,2021,4
 106,Papyrus,programming,EU,2021,4
 104,Open Policy Agent,programming,EU,2021,4
-103,VCL,programming,EU,2021,4
 103,Sieve,programming,EU,2021,4
+103,VCL,programming,EU,2021,4
 102,Modelica,programming,EU,2021,4
 101,BlitzBasic,programming,EU,2021,4
 8839,HTML,markup,FI,2021,4
@@ -41961,8 +42134,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1085,Groovy,programming,FR,2021,4
 1064,Emacs Lisp,programming,FR,2021,4
 1005,QMake,programming,FR,2021,4
-996,PLpgSQL,programming,FR,2021,4
 996,Objective-C++,programming,FR,2021,4
+996,PLpgSQL,programming,FR,2021,4
 956,Starlark,programming,FR,2021,4
 930,Solidity,programming,FR,2021,4
 911,Awk,programming,FR,2021,4
@@ -42027,8 +42200,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 175,AMPL,programming,FR,2021,4
 174,OpenSCAD,programming,FR,2021,4
 170,Elm,programming,FR,2021,4
-168,DTrace,programming,FR,2021,4
 168,Scilab,programming,FR,2021,4
+168,DTrace,programming,FR,2021,4
 168,Nim,programming,FR,2021,4
 167,Coq,programming,FR,2021,4
 160,LLVM,programming,FR,2021,4
@@ -42116,8 +42289,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1383,ShaderLab,programming,GB,2021,4
 1165,Haskell,programming,GB,2021,4
 1148,PLpgSQL,programming,GB,2021,4
-1140,Objective-C++,programming,GB,2021,4
 1140,Starlark,programming,GB,2021,4
+1140,Objective-C++,programming,GB,2021,4
 1105,Awk,programming,GB,2021,4
 1054,Solidity,programming,GB,2021,4
 1019,Nix,programming,GB,2021,4
@@ -42154,12 +42327,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 425,SWIG,programming,GB,2021,4
 398,SourcePawn,programming,GB,2021,4
 391,VBScript,programming,GB,2021,4
-373,Gnuplot,programming,GB,2021,4
 373,DIGITAL Command Language,programming,GB,2021,4
+373,Gnuplot,programming,GB,2021,4
 372,Inno Setup,programming,GB,2021,4
 371,Erlang,programming,GB,2021,4
-366,ANTLR,programming,GB,2021,4
 366,Visual Basic .NET,programming,GB,2021,4
+366,ANTLR,programming,GB,2021,4
 366,OCaml,programming,GB,2021,4
 365,Processing,programming,GB,2021,4
 363,D,programming,GB,2021,4
@@ -42197,13 +42370,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 167,Haxe,programming,GB,2021,4
 165,Apex,programming,GB,2021,4
 161,Stata,programming,GB,2021,4
-159,Nextflow,programming,GB,2021,4
 159,Bicep,programming,GB,2021,4
-157,UnrealScript,programming,GB,2021,4
+159,Nextflow,programming,GB,2021,4
 157,Rebol,programming,GB,2021,4
+157,UnrealScript,programming,GB,2021,4
+149,Module Management System,programming,GB,2021,4
 149,RPC,programming,GB,2021,4
 149,SystemVerilog,programming,GB,2021,4
-149,Module Management System,programming,GB,2021,4
 145,Logos,programming,GB,2021,4
 144,Racket,programming,GB,2021,4
 144,POV-Ray SDL,programming,GB,2021,4
@@ -42223,8 +42396,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,Zig,programming,GB,2021,4
 117,DM,programming,GB,2021,4
 114,Stan,programming,GB,2021,4
-106,Brainfuck,programming,GB,2021,4
 106,Coq,programming,GB,2021,4
+106,Brainfuck,programming,GB,2021,4
 105,VCL,programming,GB,2021,4
 101,COBOL,programming,GB,2021,4
 2239,HTML,markup,GE,2021,4
@@ -42466,8 +42639,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Ragel,programming,HK,2021,4
 112,Visual Basic .NET,programming,HK,2021,4
 109,AutoHotkey,programming,HK,2021,4
-102,Elixir,programming,HK,2021,4
 102,Forth,programming,HK,2021,4
+102,Elixir,programming,HK,2021,4
 101,Coq,programming,HK,2021,4
 1248,HTML,markup,HN,2021,4
 993,CSS,markup,HN,2021,4
@@ -42535,8 +42708,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1696,Dockerfile,programming,HU,2021,4
 1575,C++,programming,HU,2021,4
 1510,C,programming,HU,2021,4
-1325,PHP,programming,HU,2021,4
 1325,Makefile,programming,HU,2021,4
+1325,PHP,programming,HU,2021,4
 897,Batchfile,programming,HU,2021,4
 720,Ruby,programming,HU,2021,4
 705,CMake,programming,HU,2021,4
@@ -42636,8 +42809,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 229,Lex,programming,ID,2021,4
 220,Fortran,programming,ID,2021,4
 202,TSQL,programming,ID,2021,4
-201,sed,programming,ID,2021,4
 201,PLpgSQL,programming,ID,2021,4
+201,sed,programming,ID,2021,4
 194,XS,programming,ID,2021,4
 193,DM,programming,ID,2021,4
 192,HCL,programming,ID,2021,4
@@ -42654,22 +42827,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 146,Julia,programming,ID,2021,4
 140,Elixir,programming,ID,2021,4
 136,Scheme,programming,ID,2021,4
-133,Emacs Lisp,programming,ID,2021,4
 133,Processing,programming,ID,2021,4
+133,Emacs Lisp,programming,ID,2021,4
 130,Tcl,programming,ID,2021,4
 130,Mathematica,programming,ID,2021,4
 127,Brainfuck,programming,ID,2021,4
 126,Cuda,programming,ID,2021,4
 122,Crystal,programming,ID,2021,4
-121,M,programming,ID,2021,4
 121,VBScript,programming,ID,2021,4
+121,M,programming,ID,2021,4
 120,Mako,programming,ID,2021,4
 119,ActionScript,programming,ID,2021,4
 117,Common Lisp,programming,ID,2021,4
 112,QMake,programming,ID,2021,4
 111,OCaml,programming,ID,2021,4
-106,AIDL,programming,ID,2021,4
 106,COBOL,programming,ID,2021,4
+106,AIDL,programming,ID,2021,4
 104,F#,programming,ID,2021,4
 104,Nim,programming,ID,2021,4
 103,Erlang,programming,ID,2021,4
@@ -42716,8 +42889,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 228,HCL,programming,IE,2021,4
 219,Swift,programming,IE,2021,4
 212,XSLT,programming,IE,2021,4
-181,Cython,programming,IE,2021,4
 181,Objective-C++,programming,IE,2021,4
+181,Cython,programming,IE,2021,4
 168,M4,programming,IE,2021,4
 164,Emacs Lisp,programming,IE,2021,4
 162,Solidity,programming,IE,2021,4
@@ -42777,8 +42950,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 369,Vim Script,programming,IL,2021,4
 357,MATLAB,programming,IL,2021,4
 356,Dart,programming,IL,2021,4
-354,ASP.NET,programming,IL,2021,4
 354,Starlark,programming,IL,2021,4
+354,ASP.NET,programming,IL,2021,4
 321,ShaderLab,programming,IL,2021,4
 308,HLSL,programming,IL,2021,4
 300,XSLT,programming,IL,2021,4
@@ -42791,8 +42964,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 188,Gherkin,programming,IL,2021,4
 188,GLSL,programming,IL,2021,4
 187,Objective-C++,programming,IL,2021,4
-184,Emacs Lisp,programming,IL,2021,4
 184,PLpgSQL,programming,IL,2021,4
+184,Emacs Lisp,programming,IL,2021,4
 180,Awk,programming,IL,2021,4
 176,Lex,programming,IL,2021,4
 175,Yacc,programming,IL,2021,4
@@ -42941,8 +43114,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 528,AIDL,programming,IN,2021,4
 525,DIGITAL Command Language,programming,IN,2021,4
 456,Beef,programming,IN,2021,4
-439,Classic ASP,programming,IN,2021,4
 439,SWIG,programming,IN,2021,4
+439,Classic ASP,programming,IN,2021,4
 432,Mathematica,programming,IN,2021,4
 429,Racket,programming,IN,2021,4
 415,NASL,programming,IN,2021,4
@@ -42963,8 +43136,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 265,ActionScript,programming,IN,2021,4
 261,VBA,programming,IN,2021,4
 232,Gnuplot,programming,IN,2021,4
-230,QML,programming,IN,2021,4
 230,Pawn,programming,IN,2021,4
+230,QML,programming,IN,2021,4
 225,SystemVerilog,programming,IN,2021,4
 225,V,programming,IN,2021,4
 220,SourcePawn,programming,IN,2021,4
@@ -42982,14 +43155,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,Open Policy Agent,programming,IN,2021,4
 120,Vala,programming,IN,2021,4
 119,Zig,programming,IN,2021,4
-113,Io,programming,IN,2021,4
 113,Fluent,programming,IN,2021,4
+113,Io,programming,IN,2021,4
 112,jq,programming,IN,2021,4
 110,PigLatin,programming,IN,2021,4
 109,Ballerina,programming,IN,2021,4
 109,AMPL,programming,IN,2021,4
-106,CUE,programming,IN,2021,4
 106,Smali,programming,IN,2021,4
+106,CUE,programming,IN,2021,4
 1336,HTML,markup,IQ,2021,4
 954,CSS,markup,IQ,2021,4
 178,SCSS,markup,IQ,2021,4
@@ -43004,8 +43177,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 248,Objective-C,programming,IQ,2021,4
 237,Swift,programming,IQ,2021,4
 172,Java,programming,IQ,2021,4
-151,TypeScript,programming,IQ,2021,4
 151,Batchfile,programming,IQ,2021,4
+151,TypeScript,programming,IQ,2021,4
 145,Ruby,programming,IQ,2021,4
 113,C++,programming,IQ,2021,4
 7944,HTML,markup,IR,2021,4
@@ -43049,8 +43222,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Vim Script,programming,IR,2021,4
 114,TSQL,programming,IR,2021,4
 107,Rust,programming,IR,2021,4
-104,Starlark,programming,IR,2021,4
 104,Gherkin,programming,IR,2021,4
+104,Starlark,programming,IR,2021,4
 102,Smarty,programming,IR,2021,4
 683,HTML,markup,IS,2021,4
 566,CSS,markup,IS,2021,4
@@ -43058,8 +43231,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 622,JavaScript,programming,IS,2021,4
 487,Python,programming,IS,2021,4
 439,Shell,programming,IS,2021,4
-198,Makefile,programming,IS,2021,4
 198,TypeScript,programming,IS,2021,4
+198,Makefile,programming,IS,2021,4
 187,Dockerfile,programming,IS,2021,4
 142,C++,programming,IS,2021,4
 136,Java,programming,IS,2021,4
@@ -43080,8 +43253,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 327,Rich Text Format,markup,IT,2021,4
 267,Mustache,markup,IT,2021,4
 235,Pug,markup,IT,2021,4
-219,Sass,markup,IT,2021,4
 219,Svelte,markup,IT,2021,4
+219,Sass,markup,IT,2021,4
 195,Twig,markup,IT,2021,4
 17027,JavaScript,programming,IT,2021,4
 13234,Python,programming,IT,2021,4
@@ -43142,26 +43315,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 226,Haskell,programming,IT,2021,4
 219,GDB,programming,IT,2021,4
 212,VHDL,programming,IT,2021,4
-186,Raku,programming,IT,2021,4
 186,NASL,programming,IT,2021,4
+186,Raku,programming,IT,2021,4
 185,PLSQL,programming,IT,2021,4
-183,NSIS,programming,IT,2021,4
 183,ANTLR,programming,IT,2021,4
+183,NSIS,programming,IT,2021,4
 182,ASP.NET,programming,IT,2021,4
 178,Gnuplot,programming,IT,2021,4
 173,Meson,programming,IT,2021,4
-171,Nix,programming,IT,2021,4
 171,Clojure,programming,IT,2021,4
+171,Nix,programming,IT,2021,4
 168,Julia,programming,IT,2021,4
-161,Scheme,programming,IT,2021,4
 161,SWIG,programming,IT,2021,4
+161,Scheme,programming,IT,2021,4
 142,Smalltalk,programming,IT,2021,4
 141,CoffeeScript,programming,IT,2021,4
 140,Elixir,programming,IT,2021,4
 138,Processing,programming,IT,2021,4
-134,QML,programming,IT,2021,4
 134,Verilog,programming,IT,2021,4
 134,PureBasic,programming,IT,2021,4
+134,QML,programming,IT,2021,4
 131,Common Lisp,programming,IT,2021,4
 125,Inno Setup,programming,IT,2021,4
 122,OCaml,programming,IT,2021,4
@@ -43319,9 +43492,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 162,AIDL,programming,JP,2021,4
 161,LLVM,programming,JP,2021,4
 159,Inno Setup,programming,JP,2021,4
-157,Pawn,programming,JP,2021,4
-157,DTrace,programming,JP,2021,4
 157,F#,programming,JP,2021,4
+157,DTrace,programming,JP,2021,4
+157,Pawn,programming,JP,2021,4
 150,Thrift,programming,JP,2021,4
 147,Elm,programming,JP,2021,4
 146,Erlang,programming,JP,2021,4
@@ -43333,8 +43506,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,Nim,programming,JP,2021,4
 135,POV-Ray SDL,programming,JP,2021,4
 123,PureBasic,programming,JP,2021,4
-121,AMPL,programming,JP,2021,4
 121,Metal,programming,JP,2021,4
+121,AMPL,programming,JP,2021,4
 120,UnrealScript,programming,JP,2021,4
 118,M,programming,JP,2021,4
 113,QML,programming,JP,2021,4
@@ -43362,8 +43535,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 490,Objective-C,programming,KE,2021,4
 485,Hack,programming,KE,2021,4
 443,PowerShell,programming,KE,2021,4
-431,Swift,programming,KE,2021,4
 431,Dart,programming,KE,2021,4
+431,Swift,programming,KE,2021,4
 365,Batchfile,programming,KE,2021,4
 337,C#,programming,KE,2021,4
 250,Go,programming,KE,2021,4
@@ -43492,11 +43665,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 210,NSIS,programming,KR,2021,4
 209,Mathematica,programming,KR,2021,4
 204,PLpgSQL,programming,KR,2021,4
-198,GDB,programming,KR,2021,4
-198,Verilog,programming,KR,2021,4
 198,Pascal,programming,KR,2021,4
-190,AIDL,programming,KR,2021,4
+198,Verilog,programming,KR,2021,4
+198,GDB,programming,KR,2021,4
 190,CoffeeScript,programming,KR,2021,4
+190,AIDL,programming,KR,2021,4
 187,SWIG,programming,KR,2021,4
 178,QML,programming,KR,2021,4
 157,Processing,programming,KR,2021,4
@@ -43611,8 +43784,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 180,Rust,programming,LK,2021,4
 170,Perl,programming,LK,2021,4
 166,Lua,programming,LK,2021,4
-155,Groovy,programming,LK,2021,4
 155,Assembly,programming,LK,2021,4
+155,Groovy,programming,LK,2021,4
 152,Scala,programming,LK,2021,4
 133,PLSQL,programming,LK,2021,4
 113,SQLPL,programming,LK,2021,4
@@ -43678,8 +43851,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 351,C++,programming,LV,2021,4
 294,C,programming,LV,2021,4
 282,Makefile,programming,LV,2021,4
-217,Batchfile,programming,LV,2021,4
 217,Ruby,programming,LV,2021,4
+217,Batchfile,programming,LV,2021,4
 154,Go,programming,LV,2021,4
 118,CMake,programming,LV,2021,4
 187,HTML,markup,LY,2021,4
@@ -43866,8 +44039,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 313,GLSL,programming,MX,2021,4
 287,Perl,programming,MX,2021,4
 281,Objective-C++,programming,MX,2021,4
-271,XSLT,programming,MX,2021,4
 271,Rust,programming,MX,2021,4
+271,XSLT,programming,MX,2021,4
 263,Smarty,programming,MX,2021,4
 236,HCL,programming,MX,2021,4
 212,Solidity,programming,MX,2021,4
@@ -43877,10 +44050,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 154,PLpgSQL,programming,MX,2021,4
 141,Groovy,programming,MX,2021,4
 139,Emacs Lisp,programming,MX,2021,4
-131,Scala,programming,MX,2021,4
 131,Lex,programming,MX,2021,4
-125,Haskell,programming,MX,2021,4
+131,Scala,programming,MX,2021,4
 125,Awk,programming,MX,2021,4
+125,Haskell,programming,MX,2021,4
 120,Visual Basic .NET,programming,MX,2021,4
 119,M4,programming,MX,2021,4
 118,Processing,programming,MX,2021,4
@@ -44048,8 +44221,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 816,ShaderLab,programming,NL,2021,4
 761,HCL,programming,NL,2021,4
 744,GLSL,programming,NL,2021,4
-721,M4,programming,NL,2021,4
 721,MATLAB,programming,NL,2021,4
+721,M4,programming,NL,2021,4
 537,Scala,programming,NL,2021,4
 536,Gherkin,programming,NL,2021,4
 523,Emacs Lisp,programming,NL,2021,4
@@ -44100,8 +44273,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 148,GAP,programming,NL,2021,4
 145,D,programming,NL,2021,4
 142,Erlang,programming,NL,2021,4
-139,Gnuplot,programming,NL,2021,4
 139,DIGITAL Command Language,programming,NL,2021,4
+139,Gnuplot,programming,NL,2021,4
 131,VBScript,programming,NL,2021,4
 126,VHDL,programming,NL,2021,4
 121,AutoHotkey,programming,NL,2021,4
@@ -44178,8 +44351,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Clojure,programming,NO,2021,4
 108,Lex,programming,NO,2021,4
 108,sed,programming,NO,2021,4
-105,Julia,programming,NO,2021,4
 105,TSQL,programming,NO,2021,4
+105,Julia,programming,NO,2021,4
 103,Starlark,programming,NO,2021,4
 6405,HTML,markup,NP,2021,4
 5177,CSS,markup,NP,2021,4
@@ -44264,8 +44437,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,TSQL,programming,NZ,2021,4
 118,Objective-C++,programming,NZ,2021,4
 113,MATLAB,programming,NZ,2021,4
-111,Solidity,programming,NZ,2021,4
 111,Starlark,programming,NZ,2021,4
+111,Solidity,programming,NZ,2021,4
 104,Nix,programming,NZ,2021,4
 102,PLpgSQL,programming,NZ,2021,4
 102,Groovy,programming,NZ,2021,4
@@ -44371,8 +44544,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 167,Solidity,programming,PH,2021,4
 166,Perl,programming,PH,2021,4
 151,ASP.NET,programming,PH,2021,4
-126,Smarty,programming,PH,2021,4
 126,XSLT,programming,PH,2021,4
+126,Smarty,programming,PH,2021,4
 124,Rust,programming,PH,2021,4
 111,CoffeeScript,programming,PH,2021,4
 104,Gherkin,programming,PH,2021,4
@@ -44429,8 +44602,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,HLSL,programming,PK,2021,4
 105,HCL,programming,PK,2021,4
 101,Verilog,programming,PK,2021,4
-101,Visual Basic .NET,programming,PK,2021,4
 101,Gherkin,programming,PK,2021,4
+101,Visual Basic .NET,programming,PK,2021,4
 29457,HTML,markup,PL,2021,4
 22055,CSS,markup,PL,2021,4
 7520,SCSS,markup,PL,2021,4
@@ -44528,8 +44701,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,Mathematica,programming,PL,2021,4
 141,PureBasic,programming,PL,2021,4
 140,Scheme,programming,PL,2021,4
-137,GDScript,programming,PL,2021,4
 137,SmPL,programming,PL,2021,4
+137,GDScript,programming,PL,2021,4
 136,Verilog,programming,PL,2021,4
 131,ANTLR,programming,PL,2021,4
 129,QML,programming,PL,2021,4
@@ -44577,8 +44750,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 223,Handlebars,markup,PT,2021,4
 190,EJS,markup,PT,2021,4
 122,Mustache,markup,PT,2021,4
-118,Jinja,markup,PT,2021,4
 118,Pug,markup,PT,2021,4
+118,Jinja,markup,PT,2021,4
 7454,JavaScript,programming,PT,2021,4
 4671,Shell,programming,PT,2021,4
 4405,Python,programming,PT,2021,4
@@ -44699,8 +44872,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 200,XSLT,programming,RO,2021,4
 197,M4,programming,RO,2021,4
 194,Gherkin,programming,RO,2021,4
-188,HLSL,programming,RO,2021,4
 188,ShaderLab,programming,RO,2021,4
+188,HLSL,programming,RO,2021,4
 172,Starlark,programming,RO,2021,4
 165,HCL,programming,RO,2021,4
 145,Haskell,programming,RO,2021,4
@@ -44745,8 +44918,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 124,Assembly,programming,RS,2021,4
 122,Lua,programming,RS,2021,4
 105,TSQL,programming,RS,2021,4
-101,Solidity,programming,RS,2021,4
 101,GLSL,programming,RS,2021,4
+101,Solidity,programming,RS,2021,4
 81583,HTML,markup,RU,2021,4
 60075,CSS,markup,RU,2021,4
 17795,SCSS,markup,RU,2021,4
@@ -44845,8 +45018,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 354,Prolog,programming,RU,2021,4
 346,Inno Setup,programming,RU,2021,4
 345,SourcePawn,programming,RU,2021,4
-342,Mathematica,programming,RU,2021,4
 342,Pawn,programming,RU,2021,4
+342,Mathematica,programming,RU,2021,4
 341,F#,programming,RU,2021,4
 334,Scheme,programming,RU,2021,4
 315,VBScript,programming,RU,2021,4
@@ -44888,9 +45061,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,AutoHotkey,programming,RU,2021,4
 133,Module Management System,programming,RU,2021,4
 130,Haxe,programming,RU,2021,4
-124,OpenSCAD,programming,RU,2021,4
 124,Ada,programming,RU,2021,4
 124,Metal,programming,RU,2021,4
+124,OpenSCAD,programming,RU,2021,4
 120,SystemVerilog,programming,RU,2021,4
 118,Cap'n Proto,programming,RU,2021,4
 116,Xonsh,programming,RU,2021,4
@@ -44907,8 +45080,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 940,JavaScript,programming,RW,2021,4
 391,Shell,programming,RW,2021,4
 345,Python,programming,RW,2021,4
-233,Java,programming,RW,2021,4
 233,PHP,programming,RW,2021,4
+233,Java,programming,RW,2021,4
 162,TypeScript,programming,RW,2021,4
 152,Ruby,programming,RW,2021,4
 115,Dockerfile,programming,RW,2021,4
@@ -44932,15 +45105,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 426,TypeScript,programming,SA,2021,4
 344,Objective-C,programming,SA,2021,4
 316,C#,programming,SA,2021,4
-290,Dart,programming,SA,2021,4
 290,C++,programming,SA,2021,4
+290,Dart,programming,SA,2021,4
 265,C,programming,SA,2021,4
 261,Makefile,programming,SA,2021,4
 179,Batchfile,programming,SA,2021,4
 125,Hack,programming,SA,2021,4
 122,Lua,programming,SA,2021,4
-110,PowerShell,programming,SA,2021,4
 110,Go,programming,SA,2021,4
+110,PowerShell,programming,SA,2021,4
 105,CMake,programming,SA,2021,4
 325,HTML,markup,SD,2021,4
 231,CSS,markup,SD,2021,4
@@ -45007,8 +45180,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 351,Hack,programming,SE,2021,4
 325,Dart,programming,SE,2021,4
 322,Awk,programming,SE,2021,4
-302,Groovy,programming,SE,2021,4
 302,Starlark,programming,SE,2021,4
+302,Groovy,programming,SE,2021,4
 298,Gherkin,programming,SE,2021,4
 284,Yacc,programming,SE,2021,4
 272,ASP.NET,programming,SE,2021,4
@@ -45027,18 +45200,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 181,Smalltalk,programming,SE,2021,4
 164,Tcl,programming,SE,2021,4
 160,SourcePawn,programming,SE,2021,4
-159,Scheme,programming,SE,2021,4
 159,Raku,programming,SE,2021,4
+159,Scheme,programming,SE,2021,4
 156,Prolog,programming,SE,2021,4
 154,NSIS,programming,SE,2021,4
 153,Pascal,programming,SE,2021,4
 142,Cuda,programming,SE,2021,4
-141,AutoHotkey,programming,SE,2021,4
 141,CoffeeScript,programming,SE,2021,4
+141,AutoHotkey,programming,SE,2021,4
 138,Solidity,programming,SE,2021,4
 136,Meson,programming,SE,2021,4
-132,F#,programming,SE,2021,4
 132,Cython,programming,SE,2021,4
+132,F#,programming,SE,2021,4
 130,GAP,programming,SE,2021,4
 129,Common Lisp,programming,SE,2021,4
 125,GDScript,programming,SE,2021,4
@@ -45129,8 +45302,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,Fortran,programming,SG,2021,4
 113,CoffeeScript,programming,SG,2021,4
 109,Verilog,programming,SG,2021,4
-101,SWIG,programming,SG,2021,4
 101,GAP,programming,SG,2021,4
+101,SWIG,programming,SG,2021,4
 1584,HTML,markup,SI,2021,4
 1205,CSS,markup,SI,2021,4
 401,SCSS,markup,SI,2021,4
@@ -45265,8 +45438,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 2410,Dockerfile,programming,TH,2021,4
 2356,Java,programming,TH,2021,4
 1663,C++,programming,TH,2021,4
-1480,Objective-C,programming,TH,2021,4
 1480,Kotlin,programming,TH,2021,4
+1480,Objective-C,programming,TH,2021,4
 1457,C#,programming,TH,2021,4
 1417,Ruby,programming,TH,2021,4
 1377,Swift,programming,TH,2021,4
@@ -45406,8 +45579,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,Emacs Lisp,programming,TR,2021,4
 108,Lex,programming,TR,2021,4
 105,Awk,programming,TR,2021,4
-104,Smalltalk,programming,TR,2021,4
 104,Pascal,programming,TR,2021,4
+104,Smalltalk,programming,TR,2021,4
 246,HTML,markup,TT,2021,4
 203,CSS,markup,TT,2021,4
 214,JavaScript,programming,TT,2021,4
@@ -45454,8 +45627,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 673,PowerShell,programming,TW,2021,4
 518,R,programming,TW,2021,4
 509,Lua,programming,TW,2021,4
-486,ShaderLab,programming,TW,2021,4
 486,Hack,programming,TW,2021,4
+486,ShaderLab,programming,TW,2021,4
 482,ASP.NET,programming,TW,2021,4
 459,M4,programming,TW,2021,4
 448,MATLAB,programming,TW,2021,4
@@ -45467,8 +45640,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 361,Solidity,programming,TW,2021,4
 331,Cuda,programming,TW,2021,4
 323,Yacc,programming,TW,2021,4
-312,Objective-C++,programming,TW,2021,4
 312,XSLT,programming,TW,2021,4
+312,Objective-C++,programming,TW,2021,4
 298,Lex,programming,TW,2021,4
 290,Awk,programming,TW,2021,4
 259,Verilog,programming,TW,2021,4
@@ -45583,8 +45756,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 160,Raku,programming,UA,2021,4
 158,R,programming,UA,2021,4
 150,FreeMarker,programming,UA,2021,4
-146,ANTLR,programming,UA,2021,4
 146,Lex,programming,UA,2021,4
+146,ANTLR,programming,UA,2021,4
 144,MATLAB,programming,UA,2021,4
 139,Nix,programming,UA,2021,4
 137,PLSQL,programming,UA,2021,4
@@ -45716,18 +45889,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 2777,Scheme,programming,US,2021,4
 2514,Elixir,programming,US,2021,4
 2408,SourcePawn,programming,US,2021,4
-2392,SWIG,programming,US,2021,4
 2392,Common Lisp,programming,US,2021,4
+2392,SWIG,programming,US,2021,4
 2372,NSIS,programming,US,2021,4
 2332,GAP,programming,US,2021,4
-2280,PLSQL,programming,US,2021,4
 2280,Prolog,programming,US,2021,4
+2280,PLSQL,programming,US,2021,4
 2218,Verilog,programming,US,2021,4
 2208,VBScript,programming,US,2021,4
 2160,Gnuplot,programming,US,2021,4
 1970,Meson,programming,US,2021,4
-1923,Processing,programming,US,2021,4
 1923,AutoHotkey,programming,US,2021,4
+1923,Processing,programming,US,2021,4
 1857,F#,programming,US,2021,4
 1845,PureBasic,programming,US,2021,4
 1801,FreeMarker,programming,US,2021,4
@@ -45788,9 +45961,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 543,ASL,programming,US,2021,4
 530,Cap'n Proto,programming,US,2021,4
 524,SuperCollider,programming,US,2021,4
-523,Coq,programming,US,2021,4
-523,Reason,programming,US,2021,4
 523,Brainfuck,programming,US,2021,4
+523,Reason,programming,US,2021,4
+523,Coq,programming,US,2021,4
 505,Crystal,programming,US,2021,4
 504,BASIC,programming,US,2021,4
 493,RobotFramework,programming,US,2021,4
@@ -45824,8 +45997,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 309,Xonsh,programming,US,2021,4
 307,Rascal,programming,US,2021,4
 307,ColdFusion,programming,US,2021,4
-293,SMT,programming,US,2021,4
 293,xBase,programming,US,2021,4
+293,SMT,programming,US,2021,4
 282,SQLPL,programming,US,2021,4
 280,Io,programming,US,2021,4
 278,Modelica,programming,US,2021,4
@@ -45833,8 +46006,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 270,CodeQL,programming,US,2021,4
 268,Terra,programming,US,2021,4
 260,Vala,programming,US,2021,4
-256,mcfunction,programming,US,2021,4
 256,nesC,programming,US,2021,4
+256,mcfunction,programming,US,2021,4
 255,VCL,programming,US,2021,4
 252,E,programming,US,2021,4
 245,FreeBasic,programming,US,2021,4
@@ -45846,8 +46019,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 219,Objective-J,programming,US,2021,4
 216,eC,programming,US,2021,4
 215,MAXScript,programming,US,2021,4
-214,PigLatin,programming,US,2021,4
 214,YARA,programming,US,2021,4
+214,PigLatin,programming,US,2021,4
 210,AspectJ,programming,US,2021,4
 200,Qt Script,programming,US,2021,4
 199,Lean,programming,US,2021,4
@@ -45874,8 +46047,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,Ren'Py,programming,US,2021,4
 149,Clean,programming,US,2021,4
 148,Agda,programming,US,2021,4
-145,mIRC Script,programming,US,2021,4
 145,ZenScript,programming,US,2021,4
+145,mIRC Script,programming,US,2021,4
 143,CartoCSS,programming,US,2021,4
 142,Nearley,programming,US,2021,4
 141,P4,programming,US,2021,4
@@ -45884,23 +46057,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,F*,programming,US,2021,4
 129,Sieve,programming,US,2021,4
 125,LOLCODE,programming,US,2021,4
-125,Modula-3,programming,US,2021,4
 125,SQF,programming,US,2021,4
+125,Modula-3,programming,US,2021,4
 124,Xtend,programming,US,2021,4
 123,Boogie,programming,US,2021,4
-121,Faust,programming,US,2021,4
 121,KakouneScript,programming,US,2021,4
+121,Faust,programming,US,2021,4
 120,Zeek,programming,US,2021,4
 116,Turing,programming,US,2021,4
 111,OpenQASM,programming,US,2021,4
-109,Filebench WML,programming,US,2021,4
 109,JSONiq,programming,US,2021,4
-108,ABAP,programming,US,2021,4
+109,Filebench WML,programming,US,2021,4
 108,Idris,programming,US,2021,4
+108,ABAP,programming,US,2021,4
 107,GAMS,programming,US,2021,4
-104,ChucK,programming,US,2021,4
-104,IGOR Pro,programming,US,2021,4
 104,LSL,programming,US,2021,4
+104,IGOR Pro,programming,US,2021,4
+104,ChucK,programming,US,2021,4
 103,XC,programming,US,2021,4
 101,MoonScript,programming,US,2021,4
 162,Markdown,prose,US,2021,4
@@ -46041,8 +46214,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Mako,programming,VN,2021,4
 134,Nix,programming,VN,2021,4
 127,Awk,programming,VN,2021,4
-126,QMake,programming,VN,2021,4
 126,Classic ASP,programming,VN,2021,4
+126,QMake,programming,VN,2021,4
 123,Scala,programming,VN,2021,4
 118,PLSQL,programming,VN,2021,4
 107,Raku,programming,VN,2021,4
@@ -46412,8 +46585,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 240,Pascal,programming,AU,2022,1
 225,Scheme,programming,AU,2022,1
 224,Smalltalk,programming,AU,2022,1
-223,Tcl,programming,AU,2022,1
 223,Cython,programming,AU,2022,1
+223,Tcl,programming,AU,2022,1
 220,QMake,programming,AU,2022,1
 214,GDB,programming,AU,2022,1
 205,Inno Setup,programming,AU,2022,1
@@ -46443,8 +46616,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,CUE,programming,AU,2022,1
 124,Bicep,programming,AU,2022,1
 122,D,programming,AU,2022,1
-110,Pawn,programming,AU,2022,1
 110,Gnuplot,programming,AU,2022,1
+110,Pawn,programming,AU,2022,1
 107,QML,programming,AU,2022,1
 105,AppleScript,programming,AU,2022,1
 104,DIGITAL Command Language,programming,AU,2022,1
@@ -46593,11 +46766,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 220,ShaderLab,programming,BE,2022,1
 214,HLSL,programming,BE,2022,1
 205,Groovy,programming,BE,2022,1
-197,TSQL,programming,BE,2022,1
 197,Fortran,programming,BE,2022,1
-166,Emacs Lisp,programming,BE,2022,1
+197,TSQL,programming,BE,2022,1
 166,Scala,programming,BE,2022,1
 166,Nix,programming,BE,2022,1
+166,Emacs Lisp,programming,BE,2022,1
 160,PLpgSQL,programming,BE,2022,1
 151,Objective-C++,programming,BE,2022,1
 144,Haskell,programming,BE,2022,1
@@ -46660,8 +46833,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 143,XSLT,programming,BG,2022,1
 138,Procfile,programming,BG,2022,1
 128,ASP.NET,programming,BG,2022,1
-116,PLpgSQL,programming,BG,2022,1
 116,HCL,programming,BG,2022,1
+116,PLpgSQL,programming,BG,2022,1
 109,Dart,programming,BG,2022,1
 468,HTML,markup,BH,2022,1
 219,CSS,markup,BH,2022,1
@@ -46797,13 +46970,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 275,Julia,programming,BR,2022,1
 266,VBScript,programming,BR,2022,1
 261,Haxe,programming,BR,2022,1
-250,Mathematica,programming,BR,2022,1
 250,Raku,programming,BR,2022,1
+250,Mathematica,programming,BR,2022,1
 248,Scheme,programming,BR,2022,1
 226,Visual Basic .NET,programming,BR,2022,1
 218,GDB,programming,BR,2022,1
-194,Cuda,programming,BR,2022,1
 194,Verilog,programming,BR,2022,1
+194,Cuda,programming,BR,2022,1
 189,NSIS,programming,BR,2022,1
 186,Standard ML,programming,BR,2022,1
 185,Meson,programming,BR,2022,1
@@ -46811,23 +46984,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 177,Processing,programming,BR,2022,1
 175,NASL,programming,BR,2022,1
 174,Inno Setup,programming,BR,2022,1
-166,Erlang,programming,BR,2022,1
 166,Stata,programming,BR,2022,1
 166,AppleScript,programming,BR,2022,1
+166,Erlang,programming,BR,2022,1
 165,Common Lisp,programming,BR,2022,1
 164,SmPL,programming,BR,2022,1
 161,AIDL,programming,BR,2022,1
 158,Gnuplot,programming,BR,2022,1
-153,xBase,programming,BR,2022,1
 153,Pawn,programming,BR,2022,1
+153,xBase,programming,BR,2022,1
 151,XS,programming,BR,2022,1
 146,QML,programming,BR,2022,1
 145,SWIG,programming,BR,2022,1
 138,Apex,programming,BR,2022,1
 130,UnrealScript,programming,BR,2022,1
 128,SourcePawn,programming,BR,2022,1
-122,D,programming,BR,2022,1
 122,DIGITAL Command Language,programming,BR,2022,1
+122,D,programming,BR,2022,1
 120,F#,programming,BR,2022,1
 119,Scilab,programming,BR,2022,1
 117,AutoHotkey,programming,BR,2022,1
@@ -46892,8 +47065,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 151,Perl,programming,BY,2022,1
 135,Smarty,programming,BY,2022,1
 130,Rust,programming,BY,2022,1
-129,QMake,programming,BY,2022,1
 129,HCL,programming,BY,2022,1
+129,QMake,programming,BY,2022,1
 125,XSLT,programming,BY,2022,1
 113,Vim Script,programming,BY,2022,1
 109,PLpgSQL,programming,BY,2022,1
@@ -47033,16 +47206,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,AMPL,programming,CA,2022,1
 137,Bicep,programming,CA,2022,1
 136,SmPL,programming,CA,2022,1
-131,Forth,programming,CA,2022,1
 131,OCaml,programming,CA,2022,1
+131,Forth,programming,CA,2022,1
 129,Racket,programming,CA,2022,1
 128,AIDL,programming,CA,2022,1
 125,Jasmin,programming,CA,2022,1
 124,VBA,programming,CA,2022,1
 120,Thrift,programming,CA,2022,1
 115,OpenEdge ABL,programming,CA,2022,1
-111,Sage,programming,CA,2022,1
 111,Elm,programming,CA,2022,1
+111,Sage,programming,CA,2022,1
 110,Scilab,programming,CA,2022,1
 109,POV-Ray SDL,programming,CA,2022,1
 104,SAS,programming,CA,2022,1
@@ -47134,8 +47307,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 164,Mako,programming,CH,2022,1
 161,PLSQL,programming,CH,2022,1
 158,CoffeeScript,programming,CH,2022,1
-157,NSIS,programming,CH,2022,1
 157,Raku,programming,CH,2022,1
+157,NSIS,programming,CH,2022,1
 156,Julia,programming,CH,2022,1
 156,Clojure,programming,CH,2022,1
 153,Scheme,programming,CH,2022,1
@@ -47144,8 +47317,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,VHDL,programming,CH,2022,1
 131,Meson,programming,CH,2022,1
 129,Jsonnet,programming,CH,2022,1
-128,Prolog,programming,CH,2022,1
 128,SourcePawn,programming,CH,2022,1
+128,Prolog,programming,CH,2022,1
 126,Elixir,programming,CH,2022,1
 119,Common Lisp,programming,CH,2022,1
 117,M,programming,CH,2022,1
@@ -47297,8 +47470,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 863,Tcl,programming,CN,2022,1
 848,GDB,programming,CN,2022,1
 820,TSQL,programming,CN,2022,1
-788,GAP,programming,CN,2022,1
 788,ANTLR,programming,CN,2022,1
+788,GAP,programming,CN,2022,1
 779,Hack,programming,CN,2022,1
 756,ShaderLab,programming,CN,2022,1
 725,Raku,programming,CN,2022,1
@@ -47324,8 +47497,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 441,UnrealScript,programming,CN,2022,1
 439,AspectJ,programming,CN,2022,1
 433,PLSQL,programming,CN,2022,1
-422,VBScript,programming,CN,2022,1
 422,DIGITAL Command Language,programming,CN,2022,1
+422,VBScript,programming,CN,2022,1
 406,ASL,programming,CN,2022,1
 383,RPC,programming,CN,2022,1
 368,Smalltalk,programming,CN,2022,1
@@ -47336,8 +47509,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 265,Mathematica,programming,CN,2022,1
 261,LLVM,programming,CN,2022,1
 254,M,programming,CN,2022,1
-251,Meson,programming,CN,2022,1
 251,Visual Basic .NET,programming,CN,2022,1
+251,Meson,programming,CN,2022,1
 248,DTrace,programming,CN,2022,1
 246,Nix,programming,CN,2022,1
 243,Scilab,programming,CN,2022,1
@@ -47363,8 +47536,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 177,PureBasic,programming,CN,2022,1
 175,ActionScript,programming,CN,2022,1
 173,Forth,programming,CN,2022,1
-170,VHDL,programming,CN,2022,1
 170,AutoHotkey,programming,CN,2022,1
+170,VHDL,programming,CN,2022,1
 167,Erlang,programming,CN,2022,1
 165,Stata,programming,CN,2022,1
 161,D,programming,CN,2022,1
@@ -47376,16 +47549,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 134,Logos,programming,CN,2022,1
 127,1C Enterprise,programming,CN,2022,1
 123,Standard ML,programming,CN,2022,1
-116,AMPL,programming,CN,2022,1
 116,WebAssembly,programming,CN,2022,1
+116,AMPL,programming,CN,2022,1
 115,jq,programming,CN,2022,1
 113,SAS,programming,CN,2022,1
 108,RobotFramework,programming,CN,2022,1
 107,Sage,programming,CN,2022,1
-106,Elixir,programming,CN,2022,1
 106,OpenEdge ABL,programming,CN,2022,1
-105,Processing,programming,CN,2022,1
+106,Elixir,programming,CN,2022,1
 105,CodeQL,programming,CN,2022,1
+105,Processing,programming,CN,2022,1
 101,Nim,programming,CN,2022,1
 26899,HTML,markup,CO,2022,1
 21188,CSS,markup,CO,2022,1
@@ -47558,9 +47731,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 223,QMake,programming,CZ,2022,1
 223,Tcl,programming,CZ,2022,1
 209,MATLAB,programming,CZ,2022,1
-203,Lex,programming,CZ,2022,1
 203,Procfile,programming,CZ,2022,1
 203,sed,programming,CZ,2022,1
+203,Lex,programming,CZ,2022,1
 199,Gherkin,programming,CZ,2022,1
 193,Dart,programming,CZ,2022,1
 186,Nix,programming,CZ,2022,1
@@ -47577,13 +47750,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 134,FreeMarker,programming,CZ,2022,1
 132,GDB,programming,CZ,2022,1
 124,Meson,programming,CZ,2022,1
-120,PLSQL,programming,CZ,2022,1
 120,Mako,programming,CZ,2022,1
+120,PLSQL,programming,CZ,2022,1
 117,ANTLR,programming,CZ,2022,1
 115,NASL,programming,CZ,2022,1
 109,SourcePawn,programming,CZ,2022,1
-106,ASP.NET,programming,CZ,2022,1
 106,Clojure,programming,CZ,2022,1
+106,ASP.NET,programming,CZ,2022,1
 105,OpenSCAD,programming,CZ,2022,1
 103,NSIS,programming,CZ,2022,1
 68156,HTML,markup,DE,2022,1
@@ -47665,8 +47838,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1177,Cuda,programming,DE,2022,1
 1133,Tcl,programming,DE,2022,1
 1108,Cython,programming,DE,2022,1
-1083,Fortran,programming,DE,2022,1
 1083,Pascal,programming,DE,2022,1
+1083,Fortran,programming,DE,2022,1
 1082,Meson,programming,DE,2022,1
 1076,NASL,programming,DE,2022,1
 1060,Raku,programming,DE,2022,1
@@ -47717,8 +47890,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 340,LLVM,programming,DE,2022,1
 339,M,programming,DE,2022,1
 332,OCaml,programming,DE,2022,1
-320,AMPL,programming,DE,2022,1
 320,UnrealScript,programming,DE,2022,1
+320,AMPL,programming,DE,2022,1
 318,PureScript,programming,DE,2022,1
 311,PureBasic,programming,DE,2022,1
 298,Jasmin,programming,DE,2022,1
@@ -47727,8 +47900,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 293,Forth,programming,DE,2022,1
 283,AIDL,programming,DE,2022,1
 282,Standard ML,programming,DE,2022,1
-266,Xtend,programming,DE,2022,1
 266,Scilab,programming,DE,2022,1
+266,Xtend,programming,DE,2022,1
 265,POV-Ray SDL,programming,DE,2022,1
 260,VBA,programming,DE,2022,1
 223,Elm,programming,DE,2022,1
@@ -47738,8 +47911,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 214,WebAssembly,programming,DE,2022,1
 206,Ada,programming,DE,2022,1
 202,BitBake,programming,DE,2022,1
-199,SystemVerilog,programming,DE,2022,1
 199,CUE,programming,DE,2022,1
+199,SystemVerilog,programming,DE,2022,1
 191,ActionScript,programming,DE,2022,1
 187,Module Management System,programming,DE,2022,1
 181,Stata,programming,DE,2022,1
@@ -47759,8 +47932,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 151,AGS Script,programming,DE,2022,1
 145,SaltStack,programming,DE,2022,1
 142,Cap'n Proto,programming,DE,2022,1
-139,Max,programming,DE,2022,1
 139,Limbo,programming,DE,2022,1
+139,Max,programming,DE,2022,1
 137,Ragel,programming,DE,2022,1
 137,Bicep,programming,DE,2022,1
 137,Classic ASP,programming,DE,2022,1
@@ -47771,18 +47944,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,Racket,programming,DE,2022,1
 124,Brainfuck,programming,DE,2022,1
 120,Vala,programming,DE,2022,1
-119,ABAP,programming,DE,2022,1
 119,Nextflow,programming,DE,2022,1
+119,ABAP,programming,DE,2022,1
 117,Apex,programming,DE,2022,1
 115,Coq,programming,DE,2022,1
 112,Terra,programming,DE,2022,1
-111,Isabelle,programming,DE,2022,1
 111,EmberScript,programming,DE,2022,1
+111,Isabelle,programming,DE,2022,1
 109,SQLPL,programming,DE,2022,1
 107,ImageJ Macro,programming,DE,2022,1
 104,VCL,programming,DE,2022,1
-103,Modelica,programming,DE,2022,1
 103,Zig,programming,DE,2022,1
+103,Modelica,programming,DE,2022,1
 9000,HTML,markup,DK,2022,1
 7268,CSS,markup,DK,2022,1
 1946,SCSS,markup,DK,2022,1
@@ -47853,8 +48026,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Awk,programming,DK,2022,1
 116,Cython,programming,DK,2022,1
 115,Groovy,programming,DK,2022,1
-110,Lex,programming,DK,2022,1
 110,Mathematica,programming,DK,2022,1
+110,Lex,programming,DK,2022,1
 106,Fortran,programming,DK,2022,1
 2409,HTML,markup,DO,2022,1
 1987,CSS,markup,DO,2022,1
@@ -48005,8 +48178,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 175,Starlark,programming,EG,2022,1
 135,XSLT,programming,EG,2022,1
 127,Verilog,programming,EG,2022,1
-115,Gherkin,programming,EG,2022,1
 115,HCL,programming,EG,2022,1
+115,Gherkin,programming,EG,2022,1
 112,GLSL,programming,EG,2022,1
 110,VHDL,programming,EG,2022,1
 108,HLSL,programming,EG,2022,1
@@ -48079,8 +48252,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 438,ASP.NET,programming,ES,2022,1
 436,Emacs Lisp,programming,ES,2022,1
 431,PLpgSQL,programming,ES,2022,1
-404,Fortran,programming,ES,2022,1
 404,Yacc,programming,ES,2022,1
+404,Fortran,programming,ES,2022,1
 393,Lex,programming,ES,2022,1
 371,Awk,programming,ES,2022,1
 371,Tcl,programming,ES,2022,1
@@ -48091,8 +48264,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 312,CoffeeScript,programming,ES,2022,1
 301,Pascal,programming,ES,2022,1
 292,Haskell,programming,ES,2022,1
-288,QMake,programming,ES,2022,1
 288,Mako,programming,ES,2022,1
+288,QMake,programming,ES,2022,1
 286,sed,programming,ES,2022,1
 286,Cython,programming,ES,2022,1
 253,GAP,programming,ES,2022,1
@@ -48118,13 +48291,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 139,DIGITAL Command Language,programming,ES,2022,1
 139,NASL,programming,ES,2022,1
 138,Inno Setup,programming,ES,2022,1
-134,CLIPS,programming,ES,2022,1
 134,SourcePawn,programming,ES,2022,1
+134,CLIPS,programming,ES,2022,1
 131,VBScript,programming,ES,2022,1
 124,VBA,programming,ES,2022,1
 123,Verilog,programming,ES,2022,1
-122,Common Lisp,programming,ES,2022,1
 122,Erlang,programming,ES,2022,1
+122,Common Lisp,programming,ES,2022,1
 117,Ada,programming,ES,2022,1
 115,QML,programming,ES,2022,1
 107,D,programming,ES,2022,1
@@ -48155,6 +48328,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,C#,programming,ET,2022,1
 143,Puppet,programming,ET,2022,1
 101,CMake,programming,ET,2022,1
+393437,HTML,markup,EU,2022,1
+314591,CSS,markup,EU,2022,1
+97621,SCSS,markup,EU,2022,1
+52429,Jupyter Notebook,markup,EU,2022,1
+27946,Vue,markup,EU,2022,1
+20402,TeX,markup,EU,2022,1
+18621,Roff,markup,EU,2022,1
+12418,Less,markup,EU,2022,1
+9783,Blade,markup,EU,2022,1
+9469,Twig,markup,EU,2022,1
+8912,EJS,markup,EU,2022,1
+8464,Handlebars,markup,EU,2022,1
+8332,Jinja,markup,EU,2022,1
+6582,Mustache,markup,EU,2022,1
+4512,Pug,markup,EU,2022,1
+4453,Rich Text Format,markup,EU,2022,1
+4062,Sass,markup,EU,2022,1
+4048,Svelte,markup,EU,2022,1
+1324,PostScript,markup,EU,2022,1
+1253,Stylus,markup,EU,2022,1
+1119,Vim Snippet,markup,EU,2022,1
+980,Nunjucks,markup,EU,2022,1
+532,Liquid,markup,EU,2022,1
+357,Haml,markup,EU,2022,1
+215,Latte,markup,EU,2022,1
+147,YASnippet,markup,EU,2022,1
+104,Slim,markup,EU,2022,1
 353269,JavaScript,programming,EU,2022,1
 233783,Shell,programming,EU,2022,1
 232906,Python,programming,EU,2022,1
@@ -48265,8 +48465,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 575,CUE,programming,EU,2022,1
 557,DTrace,programming,EU,2022,1
 539,Scilab,programming,EU,2022,1
-538,UnrealScript,programming,EU,2022,1
 538,G-code,programming,EU,2022,1
+538,UnrealScript,programming,EU,2022,1
 537,POV-Ray SDL,programming,EU,2022,1
 533,Nim,programming,EU,2022,1
 519,LLVM,programming,EU,2022,1
@@ -48305,10 +48505,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 151,AGS Script,programming,EU,2022,1
 145,SaltStack,programming,EU,2022,1
 142,Cap'n Proto,programming,EU,2022,1
-139,Limbo,programming,EU,2022,1
 139,Max,programming,EU,2022,1
-137,Ragel,programming,EU,2022,1
+139,Limbo,programming,EU,2022,1
 137,Classic ASP,programming,EU,2022,1
+137,Ragel,programming,EU,2022,1
 135,SuperCollider,programming,EU,2022,1
 134,CLIPS,programming,EU,2022,1
 133,XQuery,programming,EU,2022,1
@@ -48328,6 +48528,7 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,VCL,programming,EU,2022,1
 103,Modelica,programming,EU,2022,1
 103,Zig,programming,EU,2022,1
+102,Markdown,prose,EU,2022,1
 9798,HTML,markup,FI,2022,1
 7849,CSS,markup,FI,2022,1
 1854,SCSS,markup,FI,2022,1
@@ -48498,8 +48699,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 400,Standard ML,programming,FR,2022,1
 392,ANTLR,programming,FR,2022,1
 390,FreeMarker,programming,FR,2022,1
-374,Common Lisp,programming,FR,2022,1
 374,QML,programming,FR,2022,1
+374,Common Lisp,programming,FR,2022,1
 347,VHDL,programming,FR,2022,1
 347,SourcePawn,programming,FR,2022,1
 334,Clojure,programming,FR,2022,1
@@ -48519,13 +48720,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 212,Jsonnet,programming,FR,2022,1
 207,AMPL,programming,FR,2022,1
 204,M,programming,FR,2022,1
-198,Visual Basic .NET,programming,FR,2022,1
 198,CUE,programming,FR,2022,1
+198,Visual Basic .NET,programming,FR,2022,1
 189,Ada,programming,FR,2022,1
 184,AppleScript,programming,FR,2022,1
 183,Coq,programming,FR,2022,1
-179,LLVM,programming,FR,2022,1
 179,XS,programming,FR,2022,1
+179,LLVM,programming,FR,2022,1
 175,OpenSCAD,programming,FR,2022,1
 168,Elm,programming,FR,2022,1
 166,AutoHotkey,programming,FR,2022,1
@@ -48538,8 +48739,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Reason,programming,FR,2022,1
 132,AIDL,programming,FR,2022,1
 131,Stata,programming,FR,2022,1
-129,Haxe,programming,FR,2022,1
 129,Thrift,programming,FR,2022,1
+129,Haxe,programming,FR,2022,1
 122,OpenEdge ABL,programming,FR,2022,1
 121,Apex,programming,FR,2022,1
 120,Puppet,programming,FR,2022,1
@@ -48655,16 +48856,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 442,Prolog,programming,GB,2022,1
 429,SWIG,programming,GB,2022,1
 416,Visual Basic .NET,programming,GB,2022,1
-386,VBScript,programming,GB,2022,1
 386,Inno Setup,programming,GB,2022,1
-384,ANTLR,programming,GB,2022,1
+386,VBScript,programming,GB,2022,1
 384,Gnuplot,programming,GB,2022,1
+384,ANTLR,programming,GB,2022,1
 380,OCaml,programming,GB,2022,1
 371,DIGITAL Command Language,programming,GB,2022,1
 364,FreeMarker,programming,GB,2022,1
 363,Pawn,programming,GB,2022,1
-354,D,programming,GB,2022,1
 354,AutoHotkey,programming,GB,2022,1
+354,D,programming,GB,2022,1
 337,Verilog,programming,GB,2022,1
 329,DTrace,programming,GB,2022,1
 317,Erlang,programming,GB,2022,1
@@ -48680,8 +48881,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 261,Jsonnet,programming,GB,2022,1
 256,CUE,programming,GB,2022,1
 252,VHDL,programming,GB,2022,1
-251,QML,programming,GB,2022,1
 251,Forth,programming,GB,2022,1
+251,QML,programming,GB,2022,1
 250,Puppet,programming,GB,2022,1
 240,LLVM,programming,GB,2022,1
 231,OpenSCAD,programming,GB,2022,1
@@ -48773,8 +48974,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 151,CMake,programming,GH,2022,1
 128,Procfile,programming,GH,2022,1
 125,C#,programming,GH,2022,1
-112,Batchfile,programming,GH,2022,1
 112,Makefile,programming,GH,2022,1
+112,Batchfile,programming,GH,2022,1
 5010,HTML,markup,GR,2022,1
 4087,CSS,markup,GR,2022,1
 1181,SCSS,markup,GR,2022,1
@@ -48819,8 +49020,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 124,GLSL,programming,GR,2022,1
 116,Solidity,programming,GR,2022,1
 112,Dart,programming,GR,2022,1
-109,ASP.NET,programming,GR,2022,1
 109,M4,programming,GR,2022,1
+109,ASP.NET,programming,GR,2022,1
 105,HLSL,programming,GR,2022,1
 104,ShaderLab,programming,GR,2022,1
 103,Lex,programming,GR,2022,1
@@ -48910,8 +49111,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 885,PLpgSQL,programming,HK,2022,1
 834,Emacs Lisp,programming,HK,2022,1
 808,FreeMarker,programming,HK,2022,1
-681,sed,programming,HK,2022,1
 681,Cython,programming,HK,2022,1
+681,sed,programming,HK,2022,1
 677,QMake,programming,HK,2022,1
 652,ANTLR,programming,HK,2022,1
 630,ShaderLab,programming,HK,2022,1
@@ -48942,8 +49143,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 316,UnrealScript,programming,HK,2022,1
 267,VBScript,programming,HK,2022,1
 262,PLSQL,programming,HK,2022,1
-241,AppleScript,programming,HK,2022,1
 241,DIGITAL Command Language,programming,HK,2022,1
+241,AppleScript,programming,HK,2022,1
 229,Haskell,programming,HK,2022,1
 228,ASP.NET,programming,HK,2022,1
 220,DTrace,programming,HK,2022,1
@@ -48967,8 +49168,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 172,Sage,programming,HK,2022,1
 162,AspectJ,programming,HK,2022,1
 156,Inno Setup,programming,HK,2022,1
-155,Coq,programming,HK,2022,1
 155,RPC,programming,HK,2022,1
+155,Coq,programming,HK,2022,1
 154,Erlang,programming,HK,2022,1
 149,Common Lisp,programming,HK,2022,1
 148,M,programming,HK,2022,1
@@ -48977,8 +49178,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Gnuplot,programming,HK,2022,1
 137,AutoHotkey,programming,HK,2022,1
 135,WebAssembly,programming,HK,2022,1
-133,Scilab,programming,HK,2022,1
 133,Brainfuck,programming,HK,2022,1
+133,Scilab,programming,HK,2022,1
 127,Forth,programming,HK,2022,1
 124,F#,programming,HK,2022,1
 120,SystemVerilog,programming,HK,2022,1
@@ -49007,8 +49208,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Roff,markup,HR,2022,1
 101,EJS,markup,HR,2022,1
 3219,JavaScript,programming,HR,2022,1
-1474,Shell,programming,HR,2022,1
 1474,Python,programming,HR,2022,1
+1474,Shell,programming,HR,2022,1
 1004,C#,programming,HR,2022,1
 863,TypeScript,programming,HR,2022,1
 847,Java,programming,HR,2022,1
@@ -49083,16 +49284,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 166,GLSL,programming,HU,2022,1
 155,Gherkin,programming,HU,2022,1
 143,Procfile,programming,HU,2022,1
-136,Scala,programming,HU,2022,1
 136,PLpgSQL,programming,HU,2022,1
+136,Scala,programming,HU,2022,1
 129,HLSL,programming,HU,2022,1
 127,HCL,programming,HU,2022,1
 113,ShaderLab,programming,HU,2022,1
 111,Awk,programming,HU,2022,1
 109,Objective-C++,programming,HU,2022,1
 107,Yacc,programming,HU,2022,1
-105,Nix,programming,HU,2022,1
 105,MATLAB,programming,HU,2022,1
+105,Nix,programming,HU,2022,1
 101,FreeMarker,programming,HU,2022,1
 52200,HTML,markup,ID,2022,1
 42908,CSS,markup,ID,2022,1
@@ -49164,8 +49365,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 200,Raku,programming,ID,2022,1
 196,sed,programming,ID,2022,1
 187,Groovy,programming,ID,2022,1
-186,PLpgSQL,programming,ID,2022,1
 186,TSQL,programming,ID,2022,1
+186,PLpgSQL,programming,ID,2022,1
 182,XS,programming,ID,2022,1
 181,SmPL,programming,ID,2022,1
 174,UnrealScript,programming,ID,2022,1
@@ -49208,8 +49409,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 443,Kotlin,programming,IE,2022,1
 401,Objective-C,programming,IE,2022,1
 386,R,programming,IE,2022,1
-365,Procfile,programming,IE,2022,1
 365,Assembly,programming,IE,2022,1
+365,Procfile,programming,IE,2022,1
 341,Perl,programming,IE,2022,1
 281,Swift,programming,IE,2022,1
 272,Lua,programming,IE,2022,1
@@ -49283,8 +49484,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 355,MATLAB,programming,IL,2022,1
 354,ShaderLab,programming,IL,2022,1
 351,Vim Script,programming,IL,2022,1
-338,HLSL,programming,IL,2022,1
 338,Groovy,programming,IL,2022,1
+338,HLSL,programming,IL,2022,1
 325,M4,programming,IL,2022,1
 323,ASP.NET,programming,IL,2022,1
 308,R,programming,IL,2022,1
@@ -49299,8 +49500,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 207,Hack,programming,IL,2022,1
 195,Emacs Lisp,programming,IL,2022,1
 191,Gherkin,programming,IL,2022,1
-179,Lex,programming,IL,2022,1
 179,Cython,programming,IL,2022,1
+179,Lex,programming,IL,2022,1
 175,Awk,programming,IL,2022,1
 173,Yacc,programming,IL,2022,1
 145,Tcl,programming,IL,2022,1
@@ -49309,8 +49510,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,Mako,programming,IL,2022,1
 114,CoffeeScript,programming,IL,2022,1
 110,Nix,programming,IL,2022,1
-105,ActionScript,programming,IL,2022,1
 105,ANTLR,programming,IL,2022,1
+105,ActionScript,programming,IL,2022,1
 102,YARA,programming,IL,2022,1
 101,Jsonnet,programming,IL,2022,1
 301795,HTML,markup,IN,2022,1
@@ -49411,8 +49612,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 629,PLSQL,programming,IN,2022,1
 606,Verilog,programming,IN,2022,1
 570,Smalltalk,programming,IN,2022,1
-543,AIDL,programming,IN,2022,1
 543,UnrealScript,programming,IN,2022,1
+543,AIDL,programming,IN,2022,1
 483,VBScript,programming,IN,2022,1
 480,Visual Basic .NET,programming,IN,2022,1
 475,NASL,programming,IN,2022,1
@@ -49447,15 +49648,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 237,F#,programming,IN,2022,1
 231,SourcePawn,programming,IN,2022,1
 231,Pawn,programming,IN,2022,1
+228,OpenEdge ABL,programming,IN,2022,1
 228,Processing,programming,IN,2022,1
 228,Xonsh,programming,IN,2022,1
-228,OpenEdge ABL,programming,IN,2022,1
 222,VBA,programming,IN,2022,1
 217,Gnuplot,programming,IN,2022,1
 210,QML,programming,IN,2022,1
 204,Open Policy Agent,programming,IN,2022,1
-197,Scilab,programming,IN,2022,1
 197,Puppet,programming,IN,2022,1
+197,Scilab,programming,IN,2022,1
 188,SystemVerilog,programming,IN,2022,1
 182,GDScript,programming,IN,2022,1
 182,M,programming,IN,2022,1
@@ -49645,36 +49846,36 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,ASP.NET,programming,IT,2022,1
 184,SWIG,programming,IT,2022,1
 177,QML,programming,IT,2022,1
-175,Verilog,programming,IT,2022,1
 175,Scheme,programming,IT,2022,1
+175,Verilog,programming,IT,2022,1
 174,Smalltalk,programming,IT,2022,1
 173,Meson,programming,IT,2022,1
 170,Julia,programming,IT,2022,1
 166,PLSQL,programming,IT,2022,1
 166,Clojure,programming,IT,2022,1
-160,Inno Setup,programming,IT,2022,1
 160,Common Lisp,programming,IT,2022,1
+160,Inno Setup,programming,IT,2022,1
 157,CoffeeScript,programming,IT,2022,1
 143,Processing,programming,IT,2022,1
 141,Mathematica,programming,IT,2022,1
-139,PureBasic,programming,IT,2022,1
 139,GAP,programming,IT,2022,1
+139,PureBasic,programming,IT,2022,1
 132,Pawn,programming,IT,2022,1
 132,SmPL,programming,IT,2022,1
-126,M,programming,IT,2022,1
 126,Forth,programming,IT,2022,1
+126,M,programming,IT,2022,1
 124,VBScript,programming,IT,2022,1
-122,Mako,programming,IT,2022,1
 122,Elixir,programming,IT,2022,1
+122,Mako,programming,IT,2022,1
 116,XS,programming,IT,2022,1
 111,Visual Basic .NET,programming,IT,2022,1
 109,AMPL,programming,IT,2022,1
 108,Stata,programming,IT,2022,1
-105,Erlang,programming,IT,2022,1
 105,AIDL,programming,IT,2022,1
-101,UnrealScript,programming,IT,2022,1
+105,Erlang,programming,IT,2022,1
 101,Thrift,programming,IT,2022,1
 101,D,programming,IT,2022,1
+101,UnrealScript,programming,IT,2022,1
 611,HTML,markup,JM,2022,1
 539,CSS,markup,JM,2022,1
 539,JavaScript,programming,JM,2022,1
@@ -49791,8 +49992,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 406,Gherkin,programming,JP,2022,1
 379,QMake,programming,JP,2022,1
 365,ASP.NET,programming,JP,2022,1
-360,Clojure,programming,JP,2022,1
 360,Pascal,programming,JP,2022,1
+360,Clojure,programming,JP,2022,1
 353,Scheme,programming,JP,2022,1
 352,NSIS,programming,JP,2022,1
 350,SourcePawn,programming,JP,2022,1
@@ -49829,9 +50030,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,D,programming,JP,2022,1
 167,DTrace,programming,JP,2022,1
 165,Pawn,programming,JP,2022,1
-156,UnrealScript,programming,JP,2022,1
-156,Thrift,programming,JP,2022,1
 156,Scilab,programming,JP,2022,1
+156,Thrift,programming,JP,2022,1
+156,UnrealScript,programming,JP,2022,1
 152,Erlang,programming,JP,2022,1
 146,Standard ML,programming,JP,2022,1
 142,POV-Ray SDL,programming,JP,2022,1
@@ -49881,8 +50082,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 506,Batchfile,programming,KE,2022,1
 463,Swift,programming,KE,2022,1
 434,Dart,programming,KE,2022,1
-353,C#,programming,KE,2022,1
 353,Assembly,programming,KE,2022,1
+353,C#,programming,KE,2022,1
 288,Go,programming,KE,2022,1
 235,Mako,programming,KE,2022,1
 217,CMake,programming,KE,2022,1
@@ -50002,8 +50203,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 271,QMake,programming,KR,2022,1
 269,Tcl,programming,KR,2022,1
 259,PLpgSQL,programming,KR,2022,1
-250,Smalltalk,programming,KR,2022,1
 250,Mathematica,programming,KR,2022,1
+250,Smalltalk,programming,KR,2022,1
 228,NSIS,programming,KR,2022,1
 214,Nix,programming,KR,2022,1
 210,sed,programming,KR,2022,1
@@ -50459,8 +50660,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,HLSL,programming,MY,2022,1
 110,Vim Script,programming,MY,2022,1
 109,M4,programming,MY,2022,1
-103,Smarty,programming,MY,2022,1
 103,ASP.NET,programming,MY,2022,1
+103,Smarty,programming,MY,2022,1
 404,HTML,markup,MZ,2022,1
 342,CSS,markup,MZ,2022,1
 107,SCSS,markup,MZ,2022,1
@@ -50587,8 +50788,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 514,Scala,programming,NL,2022,1
 478,Nix,programming,NL,2022,1
 456,Starlark,programming,NL,2022,1
-435,Solidity,programming,NL,2022,1
 435,PLpgSQL,programming,NL,2022,1
+435,Solidity,programming,NL,2022,1
 426,Awk,programming,NL,2022,1
 421,Haskell,programming,NL,2022,1
 409,Yacc,programming,NL,2022,1
@@ -50615,8 +50816,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 223,SWIG,programming,NL,2022,1
 217,ANTLR,programming,NL,2022,1
 212,Processing,programming,NL,2022,1
-195,QML,programming,NL,2022,1
 195,CoffeeScript,programming,NL,2022,1
+195,QML,programming,NL,2022,1
 191,Meson,programming,NL,2022,1
 188,Elixir,programming,NL,2022,1
 185,Inno Setup,programming,NL,2022,1
@@ -50632,8 +50833,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,F#,programming,NL,2022,1
 133,VBScript,programming,NL,2022,1
 131,D,programming,NL,2022,1
-129,VHDL,programming,NL,2022,1
 129,Verilog,programming,NL,2022,1
+129,VHDL,programming,NL,2022,1
 128,Erlang,programming,NL,2022,1
 125,AppleScript,programming,NL,2022,1
 124,Bicep,programming,NL,2022,1
@@ -50982,8 +51183,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 358,Pug,markup,PL,2022,1
 271,Rich Text Format,markup,PL,2022,1
 248,Svelte,markup,PL,2022,1
-113,Stylus,markup,PL,2022,1
 113,Vim Snippet,markup,PL,2022,1
+113,Stylus,markup,PL,2022,1
 109,PostScript,markup,PL,2022,1
 30226,JavaScript,programming,PL,2022,1
 19328,Python,programming,PL,2022,1
@@ -51027,8 +51228,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 518,TSQL,programming,PL,2022,1
 501,Objective-C++,programming,PL,2022,1
 498,MATLAB,programming,PL,2022,1
-489,Nix,programming,PL,2022,1
 489,QMake,programming,PL,2022,1
+489,Nix,programming,PL,2022,1
 463,PLpgSQL,programming,PL,2022,1
 434,Solidity,programming,PL,2022,1
 415,Emacs Lisp,programming,PL,2022,1
@@ -51048,27 +51249,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 228,Cuda,programming,PL,2022,1
 215,Elixir,programming,PL,2022,1
 196,Prolog,programming,PL,2022,1
-190,Meson,programming,PL,2022,1
 190,GAP,programming,PL,2022,1
-185,NASL,programming,PL,2022,1
+190,Meson,programming,PL,2022,1
 185,NSIS,programming,PL,2022,1
+185,NASL,programming,PL,2022,1
 182,VBScript,programming,PL,2022,1
 178,Mathematica,programming,PL,2022,1
 176,Fortran,programming,PL,2022,1
-164,Pawn,programming,PL,2022,1
 164,QML,programming,PL,2022,1
+164,Pawn,programming,PL,2022,1
 163,GDScript,programming,PL,2022,1
 159,Verilog,programming,PL,2022,1
-157,Raku,programming,PL,2022,1
-157,Clojure,programming,PL,2022,1
 157,Scheme,programming,PL,2022,1
+157,Clojure,programming,PL,2022,1
+157,Raku,programming,PL,2022,1
 153,CoffeeScript,programming,PL,2022,1
 152,ANTLR,programming,PL,2022,1
 150,SourcePawn,programming,PL,2022,1
 149,SmPL,programming,PL,2022,1
 141,VBA,programming,PL,2022,1
-140,Inno Setup,programming,PL,2022,1
 140,VHDL,programming,PL,2022,1
+140,Inno Setup,programming,PL,2022,1
 137,Gnuplot,programming,PL,2022,1
 133,Julia,programming,PL,2022,1
 126,SWIG,programming,PL,2022,1
@@ -51076,8 +51277,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,FreeMarker,programming,PL,2022,1
 113,AIDL,programming,PL,2022,1
 112,F#,programming,PL,2022,1
-108,Erlang,programming,PL,2022,1
 108,Common Lisp,programming,PL,2022,1
+108,Erlang,programming,PL,2022,1
 106,DIGITAL Command Language,programming,PL,2022,1
 105,AutoHotkey,programming,PL,2022,1
 102,Jsonnet,programming,PL,2022,1
@@ -51155,8 +51356,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 283,HLSL,programming,PT,2022,1
 275,MATLAB,programming,PT,2022,1
 271,Hack,programming,PT,2022,1
-270,Solidity,programming,PT,2022,1
 270,R,programming,PT,2022,1
+270,Solidity,programming,PT,2022,1
 269,Procfile,programming,PT,2022,1
 249,GLSL,programming,PT,2022,1
 230,Prolog,programming,PT,2022,1
@@ -51173,8 +51374,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,Objective-C++,programming,PT,2022,1
 141,Gherkin,programming,PT,2022,1
 136,Nix,programming,PT,2022,1
-135,Emacs Lisp,programming,PT,2022,1
 135,Scala,programming,PT,2022,1
+135,Emacs Lisp,programming,PT,2022,1
 134,Yacc,programming,PT,2022,1
 114,ASP.NET,programming,PT,2022,1
 106,Lex,programming,PT,2022,1
@@ -51185,8 +51386,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 297,Shell,programming,PY,2022,1
 263,Python,programming,PY,2022,1
 183,TypeScript,programming,PY,2022,1
-175,Java,programming,PY,2022,1
 175,PHP,programming,PY,2022,1
+175,Java,programming,PY,2022,1
 106,Dockerfile,programming,PY,2022,1
 598,HTML,markup,QA,2022,1
 479,CSS,markup,QA,2022,1
@@ -51312,8 +51513,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,ASP.NET,programming,RS,2022,1
 110,Procfile,programming,RS,2022,1
 109,Rust,programming,RS,2022,1
-105,Dart,programming,RS,2022,1
 105,TSQL,programming,RS,2022,1
+105,Dart,programming,RS,2022,1
 103,Vim Script,programming,RS,2022,1
 85773,HTML,markup,RU,2022,1
 63997,CSS,markup,RU,2022,1
@@ -51390,8 +51591,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 799,Emacs Lisp,programming,RU,2022,1
 787,ASP.NET,programming,RU,2022,1
 774,Mako,programming,RU,2022,1
-762,Lex,programming,RU,2022,1
 762,R,programming,RU,2022,1
+762,Lex,programming,RU,2022,1
 733,Haskell,programming,RU,2022,1
 684,MATLAB,programming,RU,2022,1
 635,Nix,programming,RU,2022,1
@@ -51428,10 +51629,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 240,SWIG,programming,RU,2022,1
 232,Verilog,programming,RU,2022,1
 232,XS,programming,RU,2022,1
-225,AIDL,programming,RU,2022,1
 225,DIGITAL Command Language,programming,RU,2022,1
-221,D,programming,RU,2022,1
+225,AIDL,programming,RU,2022,1
 221,LLVM,programming,RU,2022,1
+221,D,programming,RU,2022,1
 218,Elixir,programming,RU,2022,1
 213,Jsonnet,programming,RU,2022,1
 210,SmPL,programming,RU,2022,1
@@ -51448,14 +51649,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 162,AppleScript,programming,RU,2022,1
 154,Processing,programming,RU,2022,1
 151,Module Management System,programming,RU,2022,1
-150,UnrealScript,programming,RU,2022,1
 150,AMPL,programming,RU,2022,1
+150,UnrealScript,programming,RU,2022,1
 149,Forth,programming,RU,2022,1
 140,PureBasic,programming,RU,2022,1
 136,AutoHotkey,programming,RU,2022,1
 131,SAS,programming,RU,2022,1
-129,Thrift,programming,RU,2022,1
 129,VHDL,programming,RU,2022,1
+129,Thrift,programming,RU,2022,1
 126,Standard ML,programming,RU,2022,1
 124,Nim,programming,RU,2022,1
 123,Metal,programming,RU,2022,1
@@ -51593,8 +51794,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 195,Mathematica,programming,SE,2022,1
 189,Smalltalk,programming,SE,2022,1
 188,GDB,programming,SE,2022,1
-185,Elixir,programming,SE,2022,1
 185,Erlang,programming,SE,2022,1
+185,Elixir,programming,SE,2022,1
 183,Tcl,programming,SE,2022,1
 179,Julia,programming,SE,2022,1
 171,Cython,programming,SE,2022,1
@@ -51708,8 +51909,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,NSIS,programming,SG,2022,1
 111,NASL,programming,SG,2022,1
 106,SmPL,programming,SG,2022,1
-103,XS,programming,SG,2022,1
 103,SourcePawn,programming,SG,2022,1
+103,XS,programming,SG,2022,1
 1788,HTML,markup,SI,2022,1
 1402,CSS,markup,SI,2022,1
 437,SCSS,markup,SI,2022,1
@@ -52081,8 +52282,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,SWIG,programming,TW,2022,1
 108,Haskell,programming,TW,2022,1
 106,Processing,programming,TW,2022,1
-102,Meson,programming,TW,2022,1
 102,Mako,programming,TW,2022,1
+102,Meson,programming,TW,2022,1
 842,HTML,markup,TZ,2022,1
 758,CSS,markup,TZ,2022,1
 311,SCSS,markup,TZ,2022,1
@@ -52171,12 +52372,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 145,Haskell,programming,UA,2022,1
 141,R,programming,UA,2022,1
 137,Smalltalk,programming,UA,2022,1
-131,FreeMarker,programming,UA,2022,1
 131,Clojure,programming,UA,2022,1
-125,sed,programming,UA,2022,1
+131,FreeMarker,programming,UA,2022,1
 125,Raku,programming,UA,2022,1
-111,Cython,programming,UA,2022,1
+125,sed,programming,UA,2022,1
 111,PLSQL,programming,UA,2022,1
+111,Cython,programming,UA,2022,1
 104,GDB,programming,UA,2022,1
 1730,HTML,markup,UG,2022,1
 1502,CSS,markup,UG,2022,1
@@ -52333,8 +52534,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1564,Jsonnet,programming,US,2022,1
 1548,Thrift,programming,US,2022,1
 1442,XS,programming,US,2022,1
-1403,VHDL,programming,US,2022,1
 1403,Erlang,programming,US,2022,1
+1403,VHDL,programming,US,2022,1
 1363,Forth,programming,US,2022,1
 1341,Standard ML,programming,US,2022,1
 1339,SmPL,programming,US,2022,1
@@ -52349,8 +52550,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1052,OpenEdge ABL,programming,US,2022,1
 1048,Puppet,programming,US,2022,1
 990,Bicep,programming,US,2022,1
-919,Scilab,programming,US,2022,1
 919,SAS,programming,US,2022,1
+919,Scilab,programming,US,2022,1
 904,Rebol,programming,US,2022,1
 900,Racket,programming,US,2022,1
 899,UnrealScript,programming,US,2022,1
@@ -52376,8 +52577,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 590,Reason,programming,US,2022,1
 586,Open Policy Agent,programming,US,2022,1
 573,Cap'n Proto,programming,US,2022,1
-567,Classic ASP,programming,US,2022,1
 567,Coq,programming,US,2022,1
+567,Classic ASP,programming,US,2022,1
 562,BASIC,programming,US,2022,1
 553,SuperCollider,programming,US,2022,1
 545,RobotFramework,programming,US,2022,1
@@ -52396,8 +52597,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 442,Jasmin,programming,US,2022,1
 439,q,programming,US,2022,1
 428,Max,programming,US,2022,1
-422,ReScript,programming,US,2022,1
 422,PEG.js,programming,US,2022,1
+422,ReScript,programming,US,2022,1
 401,EmberScript,programming,US,2022,1
 399,Nextflow,programming,US,2022,1
 398,COBOL,programming,US,2022,1
@@ -52407,17 +52608,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 355,LookML,programming,US,2022,1
 343,XQuery,programming,US,2022,1
 337,Terra,programming,US,2022,1
-323,Vala,programming,US,2022,1
 323,Fluent,programming,US,2022,1
+323,Vala,programming,US,2022,1
 323,V,programming,US,2022,1
 316,SaltStack,programming,US,2022,1
 312,Io,programming,US,2022,1
 309,SMT,programming,US,2022,1
-297,ImageJ Macro,programming,US,2022,1
 297,Rascal,programming,US,2022,1
+297,ImageJ Macro,programming,US,2022,1
 296,CodeQL,programming,US,2022,1
-295,mcfunction,programming,US,2022,1
 295,Xonsh,programming,US,2022,1
+295,mcfunction,programming,US,2022,1
 285,Mercury,programming,US,2022,1
 281,1C Enterprise,programming,US,2022,1
 273,xBase,programming,US,2022,1
@@ -52425,9 +52626,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 263,Modelica,programming,US,2022,1
 262,Dhall,programming,US,2022,1
 258,LilyPond,programming,US,2022,1
-257,FreeBasic,programming,US,2022,1
 257,YARA,programming,US,2022,1
 257,VCL,programming,US,2022,1
+257,FreeBasic,programming,US,2022,1
 252,AspectJ,programming,US,2022,1
 249,LabVIEW,programming,US,2022,1
 248,MAXScript,programming,US,2022,1
@@ -52446,19 +52647,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 200,Nu,programming,US,2022,1
 197,LiveScript,programming,US,2022,1
 195,Clean,programming,US,2022,1
-194,NetLogo,programming,US,2022,1
 194,AutoIt,programming,US,2022,1
+194,NetLogo,programming,US,2022,1
 185,E,programming,US,2022,1
 181,REXX,programming,US,2022,1
 179,ZenScript,programming,US,2022,1
 171,Cool,programming,US,2022,1
-169,mIRC Script,programming,US,2022,1
 169,Eiffel,programming,US,2022,1
-166,Ren'Py,programming,US,2022,1
-166,CLIPS,programming,US,2022,1
+169,mIRC Script,programming,US,2022,1
 166,Clarion,programming,US,2022,1
-163,Lean,programming,US,2022,1
+166,CLIPS,programming,US,2022,1
+166,Ren'Py,programming,US,2022,1
 163,AngelScript,programming,US,2022,1
+163,Lean,programming,US,2022,1
 161,SQF,programming,US,2022,1
 160,Hy,programming,US,2022,1
 159,Singularity,programming,US,2022,1
@@ -52469,26 +52670,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 150,CartoCSS,programming,US,2022,1
 149,CWeb,programming,US,2022,1
 145,Isabelle,programming,US,2022,1
-144,Agda,programming,US,2022,1
 144,Zeek,programming,US,2022,1
+144,Agda,programming,US,2022,1
 141,Sieve,programming,US,2022,1
 140,Faust,programming,US,2022,1
 135,F*,programming,US,2022,1
 134,Harbour,programming,US,2022,1
 133,LSL,programming,US,2022,1
-130,Xtend,programming,US,2022,1
-130,OpenQASM,programming,US,2022,1
 130,P4,programming,US,2022,1
+130,OpenQASM,programming,US,2022,1
+130,Xtend,programming,US,2022,1
 126,Modula-3,programming,US,2022,1
 124,Squirrel,programming,US,2022,1
 123,Promela,programming,US,2022,1
 121,KRL,programming,US,2022,1
 116,Q#,programming,US,2022,1
 113,MoonScript,programming,US,2022,1
-112,Filebench WML,programming,US,2022,1
 112,Turing,programming,US,2022,1
-111,XC,programming,US,2022,1
+112,Filebench WML,programming,US,2022,1
 111,Fennel,programming,US,2022,1
+111,XC,programming,US,2022,1
 110,Asymptote,programming,US,2022,1
 108,Earthly,programming,US,2022,1
 107,KakouneScript,programming,US,2022,1
@@ -52565,8 +52766,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 348,Dockerfile,programming,VE,2022,1
 239,Ruby,programming,VE,2022,1
 202,Hack,programming,VE,2022,1
-189,Makefile,programming,VE,2022,1
 189,C++,programming,VE,2022,1
+189,Makefile,programming,VE,2022,1
 173,Objective-C,programming,VE,2022,1
 170,C,programming,VE,2022,1
 162,Batchfile,programming,VE,2022,1
@@ -52884,8 +53085,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Visual Basic .NET,programming,AR,2022,2
 119,Groovy,programming,AR,2022,2
 109,GAP,programming,AR,2022,2
-104,GDScript,programming,AR,2022,2
 104,Scala,programming,AR,2022,2
+104,GDScript,programming,AR,2022,2
 102,Emacs Lisp,programming,AR,2022,2
 101,Awk,programming,AR,2022,2
 8371,HTML,markup,AT,2022,2
@@ -52931,8 +53132,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 492,Assembly,programming,AT,2022,2
 478,Swift,programming,AT,2022,2
 365,Vim Script,programming,AT,2022,2
-351,XSLT,programming,AT,2022,2
 351,Smarty,programming,AT,2022,2
+351,XSLT,programming,AT,2022,2
 312,GLSL,programming,AT,2022,2
 302,HLSL,programming,AT,2022,2
 295,ShaderLab,programming,AT,2022,2
@@ -52953,15 +53154,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 154,sed,programming,AT,2022,2
 153,Yacc,programming,AT,2022,2
 148,Starlark,programming,AT,2022,2
-144,Lex,programming,AT,2022,2
 144,Scala,programming,AT,2022,2
+144,Lex,programming,AT,2022,2
 142,Tcl,programming,AT,2022,2
 132,Haskell,programming,AT,2022,2
 129,Solidity,programming,AT,2022,2
 121,Fortran,programming,AT,2022,2
 116,Cuda,programming,AT,2022,2
-114,Smalltalk,programming,AT,2022,2
 114,NSIS,programming,AT,2022,2
+114,Smalltalk,programming,AT,2022,2
 109,Cython,programming,AT,2022,2
 106,Meson,programming,AT,2022,2
 104,ANTLR,programming,AT,2022,2
@@ -53039,8 +53240,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 360,Awk,programming,AU,2022,2
 345,ASP.NET,programming,AU,2022,2
 332,Yacc,programming,AU,2022,2
-275,Fortran,programming,AU,2022,2
 275,CoffeeScript,programming,AU,2022,2
+275,Fortran,programming,AU,2022,2
 274,Cython,programming,AU,2022,2
 271,sed,programming,AU,2022,2
 270,Lex,programming,AU,2022,2
@@ -53062,8 +53263,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 186,Clojure,programming,AU,2022,2
 186,GAP,programming,AU,2022,2
 180,Meson,programming,AU,2022,2
-175,VBScript,programming,AU,2022,2
 175,NASL,programming,AU,2022,2
+175,VBScript,programming,AU,2022,2
 174,SWIG,programming,AU,2022,2
 163,Common Lisp,programming,AU,2022,2
 153,Prolog,programming,AU,2022,2
@@ -53074,8 +53275,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 148,Elixir,programming,AU,2022,2
 147,F#,programming,AU,2022,2
 140,D,programming,AU,2022,2
-134,Bicep,programming,AU,2022,2
 134,Visual Basic .NET,programming,AU,2022,2
+134,Bicep,programming,AU,2022,2
 131,G-code,programming,AU,2022,2
 131,Gnuplot,programming,AU,2022,2
 129,FreeMarker,programming,AU,2022,2
@@ -53172,8 +53373,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 172,Solidity,programming,BD,2022,2
 165,MATLAB,programming,BD,2022,2
 155,Objective-C++,programming,BD,2022,2
-149,Smarty,programming,BD,2022,2
 149,Lua,programming,BD,2022,2
+149,Smarty,programming,BD,2022,2
 147,CoffeeScript,programming,BD,2022,2
 146,TSQL,programming,BD,2022,2
 119,Vim Script,programming,BD,2022,2
@@ -53251,8 +53452,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,Tcl,programming,BE,2022,2
 116,Pascal,programming,BE,2022,2
 113,Yacc,programming,BE,2022,2
-111,Cython,programming,BE,2022,2
 111,NSIS,programming,BE,2022,2
+111,Cython,programming,BE,2022,2
 109,sed,programming,BE,2022,2
 108,ASP.NET,programming,BE,2022,2
 107,Scheme,programming,BE,2022,2
@@ -53439,8 +53640,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 488,Awk,programming,BR,2022,2
 481,CoffeeScript,programming,BR,2022,2
 464,Clojure,programming,BR,2022,2
-452,Scala,programming,BR,2022,2
 452,Cython,programming,BR,2022,2
+452,Scala,programming,BR,2022,2
 431,Tcl,programming,BR,2022,2
 415,VHDL,programming,BR,2022,2
 413,sed,programming,BR,2022,2
@@ -53459,8 +53660,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 279,Raku,programming,BR,2022,2
 273,Verilog,programming,BR,2022,2
 247,Cuda,programming,BR,2022,2
-234,Visual Basic .NET,programming,BR,2022,2
 234,GDB,programming,BR,2022,2
+234,Visual Basic .NET,programming,BR,2022,2
 221,Stata,programming,BR,2022,2
 214,Processing,programming,BR,2022,2
 213,Haxe,programming,BR,2022,2
@@ -53481,15 +53682,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,PureBasic,programming,BR,2022,2
 144,QML,programming,BR,2022,2
 141,SourcePawn,programming,BR,2022,2
-138,UnrealScript,programming,BR,2022,2
 138,Pawn,programming,BR,2022,2
+138,UnrealScript,programming,BR,2022,2
 134,D,programming,BR,2022,2
 133,F#,programming,BR,2022,2
 130,Game Maker Language,programming,BR,2022,2
 130,AutoHotkey,programming,BR,2022,2
 127,Apex,programming,BR,2022,2
-122,AppleScript,programming,BR,2022,2
 122,DTrace,programming,BR,2022,2
+122,AppleScript,programming,BR,2022,2
 114,Scilab,programming,BR,2022,2
 113,DIGITAL Command Language,programming,BR,2022,2
 103,M,programming,BR,2022,2
@@ -53545,12 +53746,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,Gherkin,programming,BY,2022,2
 142,GLSL,programming,BY,2022,2
 133,Perl,programming,BY,2022,2
-119,XSLT,programming,BY,2022,2
 119,Smarty,programming,BY,2022,2
-116,PLpgSQL,programming,BY,2022,2
+119,XSLT,programming,BY,2022,2
 116,Groovy,programming,BY,2022,2
-112,HCL,programming,BY,2022,2
+116,PLpgSQL,programming,BY,2022,2
 112,Rust,programming,BY,2022,2
+112,HCL,programming,BY,2022,2
 101,Pascal,programming,BY,2022,2
 62921,HTML,markup,CA,2022,2
 51128,CSS,markup,CA,2022,2
@@ -53633,8 +53834,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 535,Cuda,programming,CA,2022,2
 511,Mako,programming,CA,2022,2
 487,Lex,programming,CA,2022,2
-461,Processing,programming,CA,2022,2
 461,Mathematica,programming,CA,2022,2
+461,Processing,programming,CA,2022,2
 458,Scheme,programming,CA,2022,2
 448,CoffeeScript,programming,CA,2022,2
 444,Smalltalk,programming,CA,2022,2
@@ -53677,37 +53878,37 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,M,programming,CA,2022,2
 162,Standard ML,programming,CA,2022,2
 161,LLVM,programming,CA,2022,2
-159,XS,programming,CA,2022,2
 159,Bicep,programming,CA,2022,2
+159,XS,programming,CA,2022,2
 158,OCaml,programming,CA,2022,2
-142,Stata,programming,CA,2022,2
 142,G-code,programming,CA,2022,2
+142,Stata,programming,CA,2022,2
 141,Jasmin,programming,CA,2022,2
 138,AMPL,programming,CA,2022,2
 132,SmPL,programming,CA,2022,2
 131,CUE,programming,CA,2022,2
 129,Nim,programming,CA,2022,2
-127,Forth,programming,CA,2022,2
 127,OpenSCAD,programming,CA,2022,2
+127,Forth,programming,CA,2022,2
 122,Apex,programming,CA,2022,2
 121,Racket,programming,CA,2022,2
-117,Thrift,programming,CA,2022,2
-117,AIDL,programming,CA,2022,2
 117,Sage,programming,CA,2022,2
 117,Metal,programming,CA,2022,2
+117,AIDL,programming,CA,2022,2
+117,Thrift,programming,CA,2022,2
 114,Open Policy Agent,programming,CA,2022,2
 108,Elm,programming,CA,2022,2
+107,POV-Ray SDL,programming,CA,2022,2
 107,Classic ASP,programming,CA,2022,2
 107,OpenEdge ABL,programming,CA,2022,2
-107,POV-Ray SDL,programming,CA,2022,2
 107,SAS,programming,CA,2022,2
 107,Fluent,programming,CA,2022,2
 106,VBA,programming,CA,2022,2
-103,Reason,programming,CA,2022,2
 103,DM,programming,CA,2022,2
+103,Reason,programming,CA,2022,2
 103,Puppet,programming,CA,2022,2
-101,PureScript,programming,CA,2022,2
 101,Module Management System,programming,CA,2022,2
+101,PureScript,programming,CA,2022,2
 566,HTML,markup,CD,2022,2
 482,CSS,markup,CD,2022,2
 138,SCSS,markup,CD,2022,2
@@ -53771,8 +53972,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 442,Scala,programming,CH,2022,2
 436,GLSL,programming,CH,2022,2
 434,Hack,programming,CH,2022,2
-421,Tcl,programming,CH,2022,2
 421,Groovy,programming,CH,2022,2
+421,Tcl,programming,CH,2022,2
 410,Fortran,programming,CH,2022,2
 350,Starlark,programming,CH,2022,2
 348,Awk,programming,CH,2022,2
@@ -53803,16 +54004,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,NSIS,programming,CH,2022,2
 168,SourcePawn,programming,CH,2022,2
 166,Raku,programming,CH,2022,2
-150,Clojure,programming,CH,2022,2
 150,Smalltalk,programming,CH,2022,2
 150,CoffeeScript,programming,CH,2022,2
+150,Clojure,programming,CH,2022,2
 144,Meson,programming,CH,2022,2
 136,Prolog,programming,CH,2022,2
 134,Verilog,programming,CH,2022,2
 130,ANTLR,programming,CH,2022,2
+126,Jsonnet,programming,CH,2022,2
 126,ASP.NET,programming,CH,2022,2
 126,Pawn,programming,CH,2022,2
-126,Jsonnet,programming,CH,2022,2
 125,PureBasic,programming,CH,2022,2
 125,Forth,programming,CH,2022,2
 121,SystemVerilog,programming,CH,2022,2
@@ -53901,8 +54102,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 188,C++,programming,CM,2022,2
 148,Ruby,programming,CM,2022,2
 137,Procfile,programming,CM,2022,2
-134,Makefile,programming,CM,2022,2
 134,Hack,programming,CM,2022,2
+134,Makefile,programming,CM,2022,2
 107,CMake,programming,CM,2022,2
 79070,HTML,markup,CN,2022,2
 52608,CSS,markup,CN,2022,2
@@ -53989,8 +54190,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 536,XS,programming,CN,2022,2
 535,Pascal,programming,CN,2022,2
 514,SmPL,programming,CN,2022,2
-498,Fortran,programming,CN,2022,2
 498,Clojure,programming,CN,2022,2
+498,Fortran,programming,CN,2022,2
 496,Gherkin,programming,CN,2022,2
 473,NASL,programming,CN,2022,2
 471,SourcePawn,programming,CN,2022,2
@@ -54026,8 +54227,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 215,VBA,programming,CN,2022,2
 212,SystemVerilog,programming,CN,2022,2
 210,Scilab,programming,CN,2022,2
-208,AMPL,programming,CN,2022,2
 208,q,programming,CN,2022,2
+208,AMPL,programming,CN,2022,2
 204,HiveQL,programming,CN,2022,2
 201,Coq,programming,CN,2022,2
 192,Erlang,programming,CN,2022,2
@@ -54144,8 +54345,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 202,ASP.NET,programming,CR,2022,2
 165,Batchfile,programming,CR,2022,2
 130,Hack,programming,CR,2022,2
-119,PowerShell,programming,CR,2022,2
 119,Go,programming,CR,2022,2
+119,PowerShell,programming,CR,2022,2
 115,Procfile,programming,CR,2022,2
 107,Objective-C,programming,CR,2022,2
 727,HTML,markup,CU,2022,2
@@ -54381,8 +54582,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 594,Erlang,programming,DE,2022,2
 585,QML,programming,DE,2022,2
 542,Elixir,programming,DE,2022,2
-484,SmPL,programming,DE,2022,2
 484,Pawn,programming,DE,2022,2
+484,SmPL,programming,DE,2022,2
 470,VBScript,programming,DE,2022,2
 465,AutoHotkey,programming,DE,2022,2
 462,Verilog,programming,DE,2022,2
@@ -54390,8 +54591,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 458,DIGITAL Command Language,programming,DE,2022,2
 436,XS,programming,DE,2022,2
 419,Jsonnet,programming,DE,2022,2
-418,Nim,programming,DE,2022,2
 418,GDScript,programming,DE,2022,2
+418,Nim,programming,DE,2022,2
 414,OpenSCAD,programming,DE,2022,2
 407,DTrace,programming,DE,2022,2
 379,M,programming,DE,2022,2
@@ -54419,11 +54620,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 221,Ada,programming,DE,2022,2
 219,WebAssembly,programming,DE,2022,2
 212,SystemVerilog,programming,DE,2022,2
-209,Xtend,programming,DE,2022,2
 209,Fluent,programming,DE,2022,2
+209,Xtend,programming,DE,2022,2
 207,BitBake,programming,DE,2022,2
-203,Elm,programming,DE,2022,2
 203,Thrift,programming,DE,2022,2
+203,Elm,programming,DE,2022,2
 190,Module Management System,programming,DE,2022,2
 189,RenderScript,programming,DE,2022,2
 188,Open Policy Agent,programming,DE,2022,2
@@ -54441,20 +54642,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 158,Cap'n Proto,programming,DE,2022,2
 157,jq,programming,DE,2022,2
 153,AGS Script,programming,DE,2022,2
-151,Bicep,programming,DE,2022,2
 151,Haxe,programming,DE,2022,2
+151,Bicep,programming,DE,2022,2
 140,Classic ASP,programming,DE,2022,2
 139,SuperCollider,programming,DE,2022,2
 138,Logos,programming,DE,2022,2
 137,Nextflow,programming,DE,2022,2
 136,Ragel,programming,DE,2022,2
 131,Brainfuck,programming,DE,2022,2
-131,SaltStack,programming,DE,2022,2
 131,ABAP,programming,DE,2022,2
+131,SaltStack,programming,DE,2022,2
 128,NewLisp,programming,DE,2022,2
 121,EmberScript,programming,DE,2022,2
-120,BASIC,programming,DE,2022,2
 120,Zig,programming,DE,2022,2
+120,BASIC,programming,DE,2022,2
 120,Apex,programming,DE,2022,2
 120,Max,programming,DE,2022,2
 119,XQuery,programming,DE,2022,2
@@ -54529,12 +54730,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,Haskell,programming,DK,2022,2
 128,Smalltalk,programming,DK,2022,2
 127,Cython,programming,DK,2022,2
-125,Awk,programming,DK,2022,2
 125,Starlark,programming,DK,2022,2
+125,Awk,programming,DK,2022,2
 124,Tcl,programming,DK,2022,2
 123,Fortran,programming,DK,2022,2
-122,ANTLR,programming,DK,2022,2
 122,Yacc,programming,DK,2022,2
+122,ANTLR,programming,DK,2022,2
 118,Groovy,programming,DK,2022,2
 118,Processing,programming,DK,2022,2
 109,Lex,programming,DK,2022,2
@@ -54553,14 +54754,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 306,Dockerfile,programming,DO,2022,2
 187,C++,programming,DO,2022,2
 177,Kotlin,programming,DO,2022,2
-165,C,programming,DO,2022,2
 165,Ruby,programming,DO,2022,2
+165,C,programming,DO,2022,2
 159,Objective-C,programming,DO,2022,2
 137,Makefile,programming,DO,2022,2
 128,Swift,programming,DO,2022,2
 113,Dart,programming,DO,2022,2
-112,ASP.NET,programming,DO,2022,2
 112,Procfile,programming,DO,2022,2
+112,ASP.NET,programming,DO,2022,2
 2926,HTML,markup,DZ,2022,2
 2509,CSS,markup,DZ,2022,2
 530,SCSS,markup,DZ,2022,2
@@ -54573,8 +54774,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 639,Java,programming,DZ,2022,2
 629,PHP,programming,DZ,2022,2
 423,C,programming,DZ,2022,2
-402,TypeScript,programming,DZ,2022,2
 402,Kotlin,programming,DZ,2022,2
+402,TypeScript,programming,DZ,2022,2
 397,C++,programming,DZ,2022,2
 362,Objective-C,programming,DZ,2022,2
 355,Dart,programming,DZ,2022,2
@@ -54585,8 +54786,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 187,Ruby,programming,DZ,2022,2
 186,Makefile,programming,DZ,2022,2
 174,Batchfile,programming,DZ,2022,2
-147,Hack,programming,DZ,2022,2
 147,C#,programming,DZ,2022,2
+147,Hack,programming,DZ,2022,2
 5124,HTML,markup,EC,2022,2
 4282,CSS,markup,EC,2022,2
 1219,SCSS,markup,EC,2022,2
@@ -54807,8 +55008,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 154,Inno Setup,programming,ES,2022,2
 150,DIGITAL Command Language,programming,ES,2022,2
 143,Processing,programming,ES,2022,2
-142,NASL,programming,ES,2022,2
 142,VHDL,programming,ES,2022,2
+142,NASL,programming,ES,2022,2
 140,Prolog,programming,ES,2022,2
 135,SourcePawn,programming,ES,2022,2
 134,Erlang,programming,ES,2022,2
@@ -54856,6 +55057,35 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,M,programming,ET,2022,2
 120,Puppet,programming,ET,2022,2
 113,Forth,programming,ET,2022,2
+396607,HTML,markup,EU,2022,2
+320563,CSS,markup,EU,2022,2
+100587,SCSS,markup,EU,2022,2
+54574,Jupyter Notebook,markup,EU,2022,2
+28423,Vue,markup,EU,2022,2
+20268,TeX,markup,EU,2022,2
+17966,Roff,markup,EU,2022,2
+11987,Less,markup,EU,2022,2
+10285,Blade,markup,EU,2022,2
+9501,EJS,markup,EU,2022,2
+9311,Twig,markup,EU,2022,2
+8545,Handlebars,markup,EU,2022,2
+8489,Jinja,markup,EU,2022,2
+6532,Mustache,markup,EU,2022,2
+4554,Svelte,markup,EU,2022,2
+4267,Pug,markup,EU,2022,2
+4153,Rich Text Format,markup,EU,2022,2
+3988,Sass,markup,EU,2022,2
+1255,PostScript,markup,EU,2022,2
+1134,Stylus,markup,EU,2022,2
+997,Vim Snippet,markup,EU,2022,2
+903,Nunjucks,markup,EU,2022,2
+530,Liquid,markup,EU,2022,2
+367,Haml,markup,EU,2022,2
+239,Latte,markup,EU,2022,2
+136,YASnippet,markup,EU,2022,2
+116,Slim,markup,EU,2022,2
+112,kvlang,markup,EU,2022,2
+112,Astro,markup,EU,2022,2
 363773,JavaScript,programming,EU,2022,2
 236138,Shell,programming,EU,2022,2
 235714,Python,programming,EU,2022,2
@@ -54933,8 +55163,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1863,VHDL,programming,EU,2022,2
 1851,SWIG,programming,EU,2022,2
 1840,Inno Setup,programming,EU,2022,2
-1800,Elixir,programming,EU,2022,2
 1800,Common Lisp,programming,EU,2022,2
+1800,Elixir,programming,EU,2022,2
 1790,Gnuplot,programming,EU,2022,2
 1789,CoffeeScript,programming,EU,2022,2
 1761,SourcePawn,programming,EU,2022,2
@@ -54979,8 +55209,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 342,Elm,programming,EU,2022,2
 341,RobotFramework,programming,EU,2022,2
 323,SystemVerilog,programming,EU,2022,2
-322,CUE,programming,EU,2022,2
 322,Fluent,programming,EU,2022,2
+322,CUE,programming,EU,2022,2
 318,Stata,programming,EU,2022,2
 316,Jasmin,programming,EU,2022,2
 305,ActionScript,programming,EU,2022,2
@@ -55010,9 +55240,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Logos,programming,EU,2022,2
 137,Nextflow,programming,EU,2022,2
 136,Ragel,programming,EU,2022,2
+131,ABAP,programming,EU,2022,2
 131,Brainfuck,programming,EU,2022,2
 131,SaltStack,programming,EU,2022,2
-131,ABAP,programming,EU,2022,2
 128,NewLisp,programming,EU,2022,2
 121,EmberScript,programming,EU,2022,2
 120,BASIC,programming,EU,2022,2
@@ -55025,6 +55255,7 @@ num_pushers,language,language_type,iso2_code,year,quarter
 105,Isabelle,programming,EU,2022,2
 102,Qt Script,programming,EU,2022,2
 101,Papyrus,programming,EU,2022,2
+110,Markdown,prose,EU,2022,2
 9241,HTML,markup,FI,2022,2
 7611,CSS,markup,FI,2022,2
 1892,SCSS,markup,FI,2022,2
@@ -55219,8 +55450,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 187,F#,programming,FR,2022,2
 185,Coq,programming,FR,2022,2
 184,Visual Basic .NET,programming,FR,2022,2
-182,XS,programming,FR,2022,2
 182,LLVM,programming,FR,2022,2
+182,XS,programming,FR,2022,2
 173,AMPL,programming,FR,2022,2
 170,DTrace,programming,FR,2022,2
 162,CUE,programming,FR,2022,2
@@ -55232,8 +55463,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 143,Stata,programming,FR,2022,2
 140,AutoHotkey,programming,FR,2022,2
 140,Puppet,programming,FR,2022,2
-139,Elm,programming,FR,2022,2
 139,Scilab,programming,FR,2022,2
+139,Elm,programming,FR,2022,2
 134,POV-Ray SDL,programming,FR,2022,2
 133,Reason,programming,FR,2022,2
 132,Haxe,programming,FR,2022,2
@@ -55241,8 +55472,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,AIDL,programming,FR,2022,2
 126,OpenEdge ABL,programming,FR,2022,2
 119,UnrealScript,programming,FR,2022,2
-118,G-code,programming,FR,2022,2
 118,ActionScript,programming,FR,2022,2
+118,G-code,programming,FR,2022,2
 113,Fluent,programming,FR,2022,2
 111,SystemVerilog,programming,FR,2022,2
 107,Apex,programming,FR,2022,2
@@ -55256,8 +55487,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 3896,TeX,markup,GB,2022,2
 3270,Vue,markup,GB,2022,2
 3241,Roff,markup,GB,2022,2
-1888,Less,markup,GB,2022,2
 1888,EJS,markup,GB,2022,2
+1888,Less,markup,GB,2022,2
 1806,Handlebars,markup,GB,2022,2
 1755,Jinja,markup,GB,2022,2
 1418,Mustache,markup,GB,2022,2
@@ -55405,12 +55636,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,Nim,programming,GB,2022,2
 155,POV-Ray SDL,programming,GB,2022,2
 152,RenderScript,programming,GB,2022,2
-147,Apex,programming,GB,2022,2
 147,Logos,programming,GB,2022,2
+147,Apex,programming,GB,2022,2
 145,WebAssembly,programming,GB,2022,2
 144,Module Management System,programming,GB,2022,2
-137,RPC,programming,GB,2022,2
 137,Fluent,programming,GB,2022,2
+137,RPC,programming,GB,2022,2
 134,SAS,programming,GB,2022,2
 133,Stan,programming,GB,2022,2
 128,SuperCollider,programming,GB,2022,2
@@ -55471,8 +55702,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1688,Shell,programming,GH,2022,2
 1407,Python,programming,GH,2022,2
 840,C,programming,GH,2022,2
-612,PHP,programming,GH,2022,2
 612,TypeScript,programming,GH,2022,2
+612,PHP,programming,GH,2022,2
 438,Kotlin,programming,GH,2022,2
 434,Objective-C,programming,GH,2022,2
 426,C++,programming,GH,2022,2
@@ -55532,10 +55763,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,GLSL,programming,GR,2022,2
 126,Solidity,programming,GR,2022,2
 122,HLSL,programming,GR,2022,2
-111,Dart,programming,GR,2022,2
 111,ShaderLab,programming,GR,2022,2
-109,Lex,programming,GR,2022,2
+111,Dart,programming,GR,2022,2
 109,HCL,programming,GR,2022,2
+109,Lex,programming,GR,2022,2
 105,M4,programming,GR,2022,2
 104,Yacc,programming,GR,2022,2
 3137,HTML,markup,GT,2022,2
@@ -55560,8 +55791,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,Go,programming,GT,2022,2
 115,Kotlin,programming,GT,2022,2
 105,Objective-C,programming,GT,2022,2
-103,Procfile,programming,GT,2022,2
 103,ASP.NET,programming,GT,2022,2
+103,Procfile,programming,GT,2022,2
 48397,HTML,markup,HK,2022,2
 34314,CSS,markup,HK,2022,2
 11258,SCSS,markup,HK,2022,2
@@ -55643,8 +55874,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 542,NSIS,programming,HK,2022,2
 527,Raku,programming,HK,2022,2
 502,Clojure,programming,HK,2022,2
-494,TSQL,programming,HK,2022,2
 494,Gherkin,programming,HK,2022,2
+494,TSQL,programming,HK,2022,2
 483,AIDL,programming,HK,2022,2
 470,SWIG,programming,HK,2022,2
 451,GAP,programming,HK,2022,2
@@ -55669,9 +55900,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 270,AppleScript,programming,HK,2022,2
 260,LLVM,programming,HK,2022,2
 251,QML,programming,HK,2022,2
-247,Meson,programming,HK,2022,2
-247,Julia,programming,HK,2022,2
 247,Smalltalk,programming,HK,2022,2
+247,Julia,programming,HK,2022,2
+247,Meson,programming,HK,2022,2
 241,Scheme,programming,HK,2022,2
 234,DTrace,programming,HK,2022,2
 225,Metal,programming,HK,2022,2
@@ -55695,15 +55926,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,Forth,programming,HK,2022,2
 144,D,programming,HK,2022,2
 140,Elixir,programming,HK,2022,2
-138,Brainfuck,programming,HK,2022,2
 138,VHDL,programming,HK,2022,2
+138,Brainfuck,programming,HK,2022,2
 136,Prolog,programming,HK,2022,2
 135,F#,programming,HK,2022,2
 133,Ada,programming,HK,2022,2
 129,RenderScript,programming,HK,2022,2
 129,WebAssembly,programming,HK,2022,2
-124,Ragel,programming,HK,2022,2
 124,Module Management System,programming,HK,2022,2
+124,Ragel,programming,HK,2022,2
 123,ActionScript,programming,HK,2022,2
 119,OCaml,programming,HK,2022,2
 118,Scilab,programming,HK,2022,2
@@ -55715,8 +55946,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,MLIR,programming,HK,2022,2
 108,Standard ML,programming,HK,2022,2
 106,Terra,programming,HK,2022,2
-105,G-code,programming,HK,2022,2
 105,CUE,programming,HK,2022,2
+105,G-code,programming,HK,2022,2
 104,Nim,programming,HK,2022,2
 101,Stata,programming,HK,2022,2
 120,Markdown,prose,HK,2022,2
@@ -55814,8 +56045,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 265,Assembly,programming,HU,2022,2
 242,Rust,programming,HU,2022,2
 225,Smarty,programming,HU,2022,2
-222,Dart,programming,HU,2022,2
 222,XSLT,programming,HU,2022,2
+222,Dart,programming,HU,2022,2
 190,Groovy,programming,HU,2022,2
 187,GLSL,programming,HU,2022,2
 183,R,programming,HU,2022,2
@@ -55828,8 +56059,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,ShaderLab,programming,HU,2022,2
 126,PLpgSQL,programming,HU,2022,2
 117,HCL,programming,HU,2022,2
-109,Solidity,programming,HU,2022,2
 109,Nix,programming,HU,2022,2
+109,Solidity,programming,HU,2022,2
 101,Yacc,programming,HU,2022,2
 55058,HTML,markup,ID,2022,2
 48226,CSS,markup,ID,2022,2
@@ -55972,15 +56203,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 136,M4,programming,IE,2022,2
 136,Scala,programming,IE,2022,2
 129,Emacs Lisp,programming,IE,2022,2
-121,Yacc,programming,IE,2022,2
 121,Starlark,programming,IE,2022,2
+121,Yacc,programming,IE,2022,2
 115,Dart,programming,IE,2022,2
 115,Lex,programming,IE,2022,2
 114,MATLAB,programming,IE,2022,2
 110,Awk,programming,IE,2022,2
 107,Nix,programming,IE,2022,2
-101,QMake,programming,IE,2022,2
 101,Tcl,programming,IE,2022,2
+101,QMake,programming,IE,2022,2
 15678,HTML,markup,IL,2022,2
 12398,CSS,markup,IL,2022,2
 3425,SCSS,markup,IL,2022,2
@@ -56030,15 +56261,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 324,Vim Script,programming,IL,2022,2
 324,HLSL,programming,IL,2022,2
 306,XSLT,programming,IL,2022,2
-303,Groovy,programming,IL,2022,2
 303,ASP.NET,programming,IL,2022,2
+303,Groovy,programming,IL,2022,2
 295,M4,programming,IL,2022,2
 289,Objective-C++,programming,IL,2022,2
 250,Emacs Lisp,programming,IL,2022,2
 243,TSQL,programming,IL,2022,2
 240,Scala,programming,IL,2022,2
-225,PLpgSQL,programming,IL,2022,2
 225,Hack,programming,IL,2022,2
+225,PLpgSQL,programming,IL,2022,2
 216,Solidity,programming,IL,2022,2
 208,GLSL,programming,IL,2022,2
 194,Gherkin,programming,IL,2022,2
@@ -56184,8 +56415,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 251,Inno Setup,programming,IN,2022,2
 249,Bicep,programming,IN,2022,2
 245,D,programming,IN,2022,2
-237,QML,programming,IN,2022,2
 237,SystemVerilog,programming,IN,2022,2
+237,QML,programming,IN,2022,2
 236,Xonsh,programming,IN,2022,2
 235,AppleScript,programming,IN,2022,2
 234,SourcePawn,programming,IN,2022,2
@@ -56206,8 +56437,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,Fluent,programming,IN,2022,2
 161,HiveQL,programming,IN,2022,2
 159,Elm,programming,IN,2022,2
-155,Rebol,programming,IN,2022,2
 155,PigLatin,programming,IN,2022,2
+155,Rebol,programming,IN,2022,2
 148,Sage,programming,IN,2022,2
 137,Ada,programming,IN,2022,2
 136,jq,programming,IN,2022,2
@@ -56224,8 +56455,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,PEG.js,programming,IN,2022,2
 113,Jasmin,programming,IN,2022,2
 112,Objective-J,programming,IN,2022,2
-111,RPC,programming,IN,2022,2
 111,POV-Ray SDL,programming,IN,2022,2
+111,RPC,programming,IN,2022,2
 109,Motoko,programming,IN,2022,2
 107,DataWeave,programming,IN,2022,2
 106,ASL,programming,IN,2022,2
@@ -56262,8 +56493,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 649,Vue,markup,IR,2022,2
 385,Less,markup,IR,2022,2
 163,TeX,markup,IR,2022,2
-162,Roff,markup,IR,2022,2
 162,EJS,markup,IR,2022,2
+162,Roff,markup,IR,2022,2
 112,Handlebars,markup,IR,2022,2
 7785,JavaScript,programming,IR,2022,2
 4740,Python,programming,IR,2022,2
@@ -56326,8 +56557,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 335,Mustache,markup,IT,2022,2
 302,Pug,markup,IT,2022,2
 299,Rich Text Format,markup,IT,2022,2
-239,Svelte,markup,IT,2022,2
 239,Sass,markup,IT,2022,2
+239,Svelte,markup,IT,2022,2
 182,Twig,markup,IT,2022,2
 109,PostScript,markup,IT,2022,2
 20758,JavaScript,programming,IT,2022,2
@@ -56371,8 +56602,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 389,Awk,programming,IT,2022,2
 387,Groovy,programming,IT,2022,2
 381,Emacs Lisp,programming,IT,2022,2
-372,Starlark,programming,IT,2022,2
 372,Fortran,programming,IT,2022,2
+372,Starlark,programming,IT,2022,2
 365,Yacc,programming,IT,2022,2
 357,Scala,programming,IT,2022,2
 352,QMake,programming,IT,2022,2
@@ -56407,11 +56638,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 159,QML,programming,IT,2022,2
 153,GAP,programming,IT,2022,2
 150,PLSQL,programming,IT,2022,2
-149,Processing,programming,IT,2022,2
 149,Common Lisp,programming,IT,2022,2
+149,Processing,programming,IT,2022,2
 145,Inno Setup,programming,IT,2022,2
-140,CoffeeScript,programming,IT,2022,2
 140,Verilog,programming,IT,2022,2
+140,CoffeeScript,programming,IT,2022,2
 139,M,programming,IT,2022,2
 139,Mako,programming,IT,2022,2
 137,Elixir,programming,IT,2022,2
@@ -56554,15 +56785,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 369,NSIS,programming,JP,2022,2
 356,SourcePawn,programming,JP,2022,2
 350,PLSQL,programming,JP,2022,2
-347,Julia,programming,JP,2022,2
 347,ASP.NET,programming,JP,2022,2
+347,Julia,programming,JP,2022,2
 336,TSQL,programming,JP,2022,2
 312,ANTLR,programming,JP,2022,2
 311,FreeMarker,programming,JP,2022,2
 307,Smalltalk,programming,JP,2022,2
 307,VBScript,programming,JP,2022,2
-295,Mathematica,programming,JP,2022,2
 295,NASL,programming,JP,2022,2
+295,Mathematica,programming,JP,2022,2
 294,VBA,programming,JP,2022,2
 283,Verilog,programming,JP,2022,2
 277,Mako,programming,JP,2022,2
@@ -56579,11 +56810,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 220,GAP,programming,JP,2022,2
 213,AppleScript,programming,JP,2022,2
 212,DTrace,programming,JP,2022,2
-204,AIDL,programming,JP,2022,2
 204,SmPL,programming,JP,2022,2
+204,AIDL,programming,JP,2022,2
 201,D,programming,JP,2022,2
-191,Inno Setup,programming,JP,2022,2
 191,Visual Basic .NET,programming,JP,2022,2
+191,Inno Setup,programming,JP,2022,2
 184,Pawn,programming,JP,2022,2
 182,LLVM,programming,JP,2022,2
 173,Thrift,programming,JP,2022,2
@@ -56607,9 +56838,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 108,RPC,programming,JP,2022,2
 107,PureBasic,programming,JP,2022,2
 104,Ada,programming,JP,2022,2
-103,WebAssembly,programming,JP,2022,2
-103,Sage,programming,JP,2022,2
 103,Coq,programming,JP,2022,2
+103,Sage,programming,JP,2022,2
+103,WebAssembly,programming,JP,2022,2
 9927,HTML,markup,KE,2022,2
 8599,CSS,markup,KE,2022,2
 2232,SCSS,markup,KE,2022,2
@@ -56628,8 +56859,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 2027,PHP,programming,KE,2022,2
 1744,TypeScript,programming,KE,2022,2
 1552,Java,programming,KE,2022,2
-1208,Procfile,programming,KE,2022,2
 1208,Dockerfile,programming,KE,2022,2
+1208,Procfile,programming,KE,2022,2
 1091,Kotlin,programming,KE,2022,2
 1067,Assembly,programming,KE,2022,2
 970,Ruby,programming,KE,2022,2
@@ -56766,8 +56997,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 343,Yacc,programming,KR,2022,2
 328,Fortran,programming,KR,2022,2
 311,Mako,programming,KR,2022,2
-310,Awk,programming,KR,2022,2
 310,Lex,programming,KR,2022,2
+310,Awk,programming,KR,2022,2
 298,Mathematica,programming,KR,2022,2
 286,NSIS,programming,KR,2022,2
 273,Smalltalk,programming,KR,2022,2
@@ -57206,8 +57437,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 319,Solidity,programming,MX,2022,2
 309,XSLT,programming,MX,2022,2
 287,Rust,programming,MX,2022,2
-281,HCL,programming,MX,2022,2
 281,Perl,programming,MX,2022,2
+281,HCL,programming,MX,2022,2
 245,PLpgSQL,programming,MX,2022,2
 207,Gherkin,programming,MX,2022,2
 203,CoffeeScript,programming,MX,2022,2
@@ -57257,8 +57488,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 588,Batchfile,programming,MY,2022,2
 315,Go,programming,MY,2022,2
 290,PowerShell,programming,MY,2022,2
-230,Solidity,programming,MY,2022,2
 230,R,programming,MY,2022,2
+230,Solidity,programming,MY,2022,2
 225,Assembly,programming,MY,2022,2
 183,Lua,programming,MY,2022,2
 175,Perl,programming,MY,2022,2
@@ -57392,8 +57623,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1256,Procfile,programming,NL,2022,2
 1230,Assembly,programming,NL,2022,2
 1091,Vim Script,programming,NL,2022,2
-1007,HLSL,programming,NL,2022,2
 1007,ShaderLab,programming,NL,2022,2
+1007,HLSL,programming,NL,2022,2
 960,Smarty,programming,NL,2022,2
 914,XSLT,programming,NL,2022,2
 902,GLSL,programming,NL,2022,2
@@ -57417,8 +57648,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 351,QMake,programming,NL,2022,2
 349,Cython,programming,NL,2022,2
 342,Lex,programming,NL,2022,2
-303,Pascal,programming,NL,2022,2
 303,sed,programming,NL,2022,2
+303,Pascal,programming,NL,2022,2
 297,Fortran,programming,NL,2022,2
 285,Scheme,programming,NL,2022,2
 283,Cuda,programming,NL,2022,2
@@ -57444,8 +57675,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,SWIG,programming,NL,2022,2
 170,Elixir,programming,NL,2022,2
 167,FreeMarker,programming,NL,2022,2
-164,Common Lisp,programming,NL,2022,2
 164,Prolog,programming,NL,2022,2
+164,Common Lisp,programming,NL,2022,2
 148,Gnuplot,programming,NL,2022,2
 145,SourcePawn,programming,NL,2022,2
 137,D,programming,NL,2022,2
@@ -57457,11 +57688,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Verilog,programming,NL,2022,2
 117,DIGITAL Command Language,programming,NL,2022,2
 115,VHDL,programming,NL,2022,2
-114,SmPL,programming,NL,2022,2
 114,AppleScript,programming,NL,2022,2
+114,SmPL,programming,NL,2022,2
 111,OCaml,programming,NL,2022,2
-109,Visual Basic .NET,programming,NL,2022,2
 109,AutoHotkey,programming,NL,2022,2
+109,Visual Basic .NET,programming,NL,2022,2
 107,GDScript,programming,NL,2022,2
 107,M,programming,NL,2022,2
 106,LLVM,programming,NL,2022,2
@@ -57613,8 +57844,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 154,XSLT,programming,NZ,2022,2
 152,Gherkin,programming,NZ,2022,2
 150,Objective-C++,programming,NZ,2022,2
-143,Emacs Lisp,programming,NZ,2022,2
 143,M4,programming,NZ,2022,2
+143,Emacs Lisp,programming,NZ,2022,2
 141,Scheme,programming,NZ,2022,2
 136,Hack,programming,NZ,2022,2
 111,Dart,programming,NZ,2022,2
@@ -57775,8 +58006,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 468,Objective-C++,programming,PK,2022,2
 419,Go,programming,PK,2022,2
 373,PowerShell,programming,PK,2022,2
-284,ASP.NET,programming,PK,2022,2
 284,Assembly,programming,PK,2022,2
+284,ASP.NET,programming,PK,2022,2
 201,R,programming,PK,2022,2
 181,Smarty,programming,PK,2022,2
 174,CoffeeScript,programming,PK,2022,2
@@ -57784,8 +58015,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 151,HLSL,programming,PK,2022,2
 149,Perl,programming,PK,2022,2
 143,Lua,programming,PK,2022,2
-139,Rust,programming,PK,2022,2
 139,MATLAB,programming,PK,2022,2
+139,Rust,programming,PK,2022,2
 136,TSQL,programming,PK,2022,2
 131,HCL,programming,PK,2022,2
 105,Gherkin,programming,PK,2022,2
@@ -57851,8 +58082,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 627,TSQL,programming,PL,2022,2
 574,XSLT,programming,PL,2022,2
 535,MATLAB,programming,PL,2022,2
-529,QMake,programming,PL,2022,2
 529,Nix,programming,PL,2022,2
+529,QMake,programming,PL,2022,2
 493,PLpgSQL,programming,PL,2022,2
 438,Solidity,programming,PL,2022,2
 436,Emacs Lisp,programming,PL,2022,2
@@ -57883,16 +58114,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 191,NSIS,programming,PL,2022,2
 188,Clojure,programming,PL,2022,2
 185,Prolog,programming,PL,2022,2
+181,SourcePawn,programming,PL,2022,2
 181,QML,programming,PL,2022,2
 181,Raku,programming,PL,2022,2
-181,SourcePawn,programming,PL,2022,2
 180,VBScript,programming,PL,2022,2
 179,PureBasic,programming,PL,2022,2
 170,GDScript,programming,PL,2022,2
 157,CoffeeScript,programming,PL,2022,2
 155,VBA,programming,PL,2022,2
-146,Inno Setup,programming,PL,2022,2
 146,Pawn,programming,PL,2022,2
+146,Inno Setup,programming,PL,2022,2
 139,Julia,programming,PL,2022,2
 131,Gnuplot,programming,PL,2022,2
 128,VHDL,programming,PL,2022,2
@@ -58094,8 +58325,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,Scala,programming,RO,2022,2
 131,Groovy,programming,RO,2022,2
 115,Verilog,programming,RO,2022,2
-113,sed,programming,RO,2022,2
 113,Tcl,programming,RO,2022,2
+113,sed,programming,RO,2022,2
 112,QMake,programming,RO,2022,2
 109,VHDL,programming,RO,2022,2
 107,Prolog,programming,RO,2022,2
@@ -58234,8 +58465,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 484,Fortran,programming,RU,2022,2
 470,sed,programming,RU,2022,2
 464,Clojure,programming,RU,2022,2
-400,ANTLR,programming,RU,2022,2
 400,Raku,programming,RU,2022,2
+400,ANTLR,programming,RU,2022,2
 394,GAP,programming,RU,2022,2
 392,Mathematica,programming,RU,2022,2
 388,NSIS,programming,RU,2022,2
@@ -58262,20 +58493,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 230,XS,programming,RU,2022,2
 224,GDScript,programming,RU,2022,2
 223,Verilog,programming,RU,2022,2
-215,Elixir,programming,RU,2022,2
 215,DM,programming,RU,2022,2
+215,Elixir,programming,RU,2022,2
 209,Visual Basic .NET,programming,RU,2022,2
 208,D,programming,RU,2022,2
 207,Gnuplot,programming,RU,2022,2
 192,Jsonnet,programming,RU,2022,2
 191,SmPL,programming,RU,2022,2
 186,Julia,programming,RU,2022,2
-184,OCaml,programming,RU,2022,2
 184,Erlang,programming,RU,2022,2
+184,OCaml,programming,RU,2022,2
 172,G-code,programming,RU,2022,2
 158,Standard ML,programming,RU,2022,2
-151,SystemVerilog,programming,RU,2022,2
 151,UnrealScript,programming,RU,2022,2
+151,SystemVerilog,programming,RU,2022,2
 150,VBA,programming,RU,2022,2
 149,Module Management System,programming,RU,2022,2
 144,AutoHotkey,programming,RU,2022,2
@@ -58345,8 +58576,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 248,Hack,programming,SA,2022,2
 242,Batchfile,programming,SA,2022,2
 151,PowerShell,programming,SA,2022,2
-104,Go,programming,SA,2022,2
 104,R,programming,SA,2022,2
+104,Go,programming,SA,2022,2
 499,HTML,markup,SD,2022,2
 394,CSS,markup,SD,2022,2
 103,SCSS,markup,SD,2022,2
@@ -58469,8 +58700,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 500,Handlebars,markup,SG,2022,2
 353,Blade,markup,SG,2022,2
 342,Jinja,markup,SG,2022,2
-326,Mustache,markup,SG,2022,2
 326,Pug,markup,SG,2022,2
+326,Mustache,markup,SG,2022,2
 289,Rich Text Format,markup,SG,2022,2
 248,Stylus,markup,SG,2022,2
 170,Svelte,markup,SG,2022,2
@@ -58488,8 +58719,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 3315,Ruby,programming,SG,2022,2
 2856,Go,programming,SG,2022,2
 2694,Batchfile,programming,SG,2022,2
-2209,CMake,programming,SG,2022,2
 2209,C#,programming,SG,2022,2
+2209,CMake,programming,SG,2022,2
 2082,PHP,programming,SG,2022,2
 1519,Procfile,programming,SG,2022,2
 1455,Objective-C,programming,SG,2022,2
@@ -58644,8 +58875,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 661,Java,programming,SV,2022,2
 425,C#,programming,SV,2022,2
 344,Python,programming,SV,2022,2
-335,TypeScript,programming,SV,2022,2
 335,Hack,programming,SV,2022,2
+335,TypeScript,programming,SV,2022,2
 253,Kotlin,programming,SV,2022,2
 196,Dockerfile,programming,SV,2022,2
 174,C++,programming,SV,2022,2
@@ -58729,8 +58960,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Nix,programming,TH,2022,2
 132,GLSL,programming,TH,2022,2
 127,ASP.NET,programming,TH,2022,2
-117,M4,programming,TH,2022,2
 117,XSLT,programming,TH,2022,2
+117,M4,programming,TH,2022,2
 320,HTML,markup,TJ,2022,2
 252,CSS,markup,TJ,2022,2
 251,JavaScript,programming,TJ,2022,2
@@ -58838,13 +59069,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 184,Nix,programming,TR,2022,2
 158,Emacs Lisp,programming,TR,2022,2
 158,Scala,programming,TR,2022,2
-156,Pascal,programming,TR,2022,2
 156,Yacc,programming,TR,2022,2
+156,Pascal,programming,TR,2022,2
 151,Groovy,programming,TR,2022,2
 142,Tcl,programming,TR,2022,2
 140,GAP,programming,TR,2022,2
-139,Cuda,programming,TR,2022,2
 139,Cython,programming,TR,2022,2
+139,Cuda,programming,TR,2022,2
 129,CoffeeScript,programming,TR,2022,2
 127,Fortran,programming,TR,2022,2
 123,Lex,programming,TR,2022,2
@@ -58938,8 +59169,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 182,PLpgSQL,programming,TW,2022,2
 177,Scala,programming,TW,2022,2
 174,Raku,programming,TW,2022,2
-155,NASL,programming,TW,2022,2
 155,Smalltalk,programming,TW,2022,2
+155,NASL,programming,TW,2022,2
 153,CoffeeScript,programming,TW,2022,2
 150,Clojure,programming,TW,2022,2
 137,SmPL,programming,TW,2022,2
@@ -59006,8 +59237,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1890,Kotlin,programming,UA,2022,2
 1640,Go,programming,UA,2022,2
 1623,Swift,programming,UA,2022,2
-1596,Objective-C,programming,UA,2022,2
 1596,CMake,programming,UA,2022,2
+1596,Objective-C,programming,UA,2022,2
 1388,Procfile,programming,UA,2022,2
 898,PowerShell,programming,UA,2022,2
 861,Hack,programming,UA,2022,2
@@ -59272,8 +59503,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 442,NCL,programming,US,2022,2
 438,PEG.js,programming,US,2022,2
 434,ReScript,programming,US,2022,2
-425,EmberScript,programming,US,2022,2
 425,Crystal,programming,US,2022,2
+425,EmberScript,programming,US,2022,2
 423,Arc,programming,US,2022,2
 412,MLIR,programming,US,2022,2
 411,V,programming,US,2022,2
@@ -59313,16 +59544,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 226,Red,programming,US,2022,2
 225,Qt Script,programming,US,2022,2
 223,Clean,programming,US,2022,2
-218,Common Workflow Language,programming,US,2022,2
 218,MAXScript,programming,US,2022,2
+218,Common Workflow Language,programming,US,2022,2
 216,BlitzBasic,programming,US,2022,2
 210,Cadence,programming,US,2022,2
 209,ZenScript,programming,US,2022,2
 206,PigLatin,programming,US,2022,2
 199,AutoIt,programming,US,2022,2
 191,REXX,programming,US,2022,2
-187,LilyPond,programming,US,2022,2
 187,Vyper,programming,US,2022,2
+187,LilyPond,programming,US,2022,2
 185,Lean,programming,US,2022,2
 183,CLIPS,programming,US,2022,2
 182,KRL,programming,US,2022,2
@@ -59334,43 +59565,43 @@ num_pushers,language,language_type,iso2_code,year,quarter
 174,Ren'Py,programming,US,2022,2
 167,AngelScript,programming,US,2022,2
 167,P4,programming,US,2022,2
-166,Eiffel,programming,US,2022,2
 166,CartoCSS,programming,US,2022,2
+166,Eiffel,programming,US,2022,2
 165,JetBrains MPS,programming,US,2022,2
-164,Harbour,programming,US,2022,2
 164,mIRC Script,programming,US,2022,2
+164,Harbour,programming,US,2022,2
 162,Agda,programming,US,2022,2
 158,Cool,programming,US,2022,2
 157,SQF,programming,US,2022,2
 156,Alloy,programming,US,2022,2
 155,Witcher Script,programming,US,2022,2
 152,Clarion,programming,US,2022,2
-151,Zeek,programming,US,2022,2
 151,J,programming,US,2022,2
+151,Zeek,programming,US,2022,2
 148,Modula-3,programming,US,2022,2
 147,Earthly,programming,US,2022,2
 147,Isabelle,programming,US,2022,2
 147,Pike,programming,US,2022,2
 146,GSC,programming,US,2022,2
 145,Monkey C,programming,US,2022,2
-144,Hy,programming,US,2022,2
 144,Slash,programming,US,2022,2
+144,Hy,programming,US,2022,2
 138,Nearley,programming,US,2022,2
 136,Sieve,programming,US,2022,2
 132,Faust,programming,US,2022,2
 131,F*,programming,US,2022,2
-128,Filebench WML,programming,US,2022,2
 128,E,programming,US,2022,2
+128,Filebench WML,programming,US,2022,2
 126,Turing,programming,US,2022,2
 124,Squirrel,programming,US,2022,2
 124,Berry,programming,US,2022,2
 123,OpenQASM,programming,US,2022,2
 122,XC,programming,US,2022,2
-119,Xtend,programming,US,2022,2
 119,KakouneScript,programming,US,2022,2
+119,Xtend,programming,US,2022,2
 118,Chapel,programming,US,2022,2
-117,LSL,programming,US,2022,2
 117,Promela,programming,US,2022,2
+117,LSL,programming,US,2022,2
 115,Lasso,programming,US,2022,2
 113,Asymptote,programming,US,2022,2
 112,Odin,programming,US,2022,2
@@ -59503,15 +59734,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1796,TSQL,programming,VN,2022,2
 1441,Starlark,programming,VN,2022,2
 1075,Objective-C++,programming,VN,2022,2
-1051,Solidity,programming,VN,2022,2
 1051,PowerShell,programming,VN,2022,2
+1051,Solidity,programming,VN,2022,2
 851,Assembly,programming,VN,2022,2
 711,Lua,programming,VN,2022,2
 700,ShaderLab,programming,VN,2022,2
 686,Rust,programming,VN,2022,2
 681,HLSL,programming,VN,2022,2
-581,Vim Script,programming,VN,2022,2
 581,XSLT,programming,VN,2022,2
+581,Vim Script,programming,VN,2022,2
 508,Smarty,programming,VN,2022,2
 498,Perl,programming,VN,2022,2
 374,HCL,programming,VN,2022,2
@@ -59528,8 +59759,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 195,Nix,programming,VN,2022,2
 186,Cuda,programming,VN,2022,2
 154,Pascal,programming,VN,2022,2
-151,NSIS,programming,VN,2022,2
 151,QMake,programming,VN,2022,2
+151,NSIS,programming,VN,2022,2
 136,Awk,programming,VN,2022,2
 133,Emacs Lisp,programming,VN,2022,2
 133,Scala,programming,VN,2022,2
@@ -59562,8 +59793,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 212,Blade,markup,ZA,2022,2
 181,Roff,markup,ZA,2022,2
 169,TeX,markup,ZA,2022,2
-153,Handlebars,markup,ZA,2022,2
 153,Sass,markup,ZA,2022,2
+153,Handlebars,markup,ZA,2022,2
 110,Pug,markup,ZA,2022,2
 8523,JavaScript,programming,ZA,2022,2
 3987,Shell,programming,ZA,2022,2
@@ -59769,8 +60000,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 177,Yacc,programming,AR,2022,3
 167,Papyrus,programming,AR,2022,3
 165,Visual Basic .NET,programming,AR,2022,3
-164,Processing,programming,AR,2022,3
 164,Pascal,programming,AR,2022,3
+164,Processing,programming,AR,2022,3
 154,Julia,programming,AR,2022,3
 150,Wollok,programming,AR,2022,3
 145,Mako,programming,AR,2022,3
@@ -59841,15 +60072,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 187,Awk,programming,AT,2022,3
 182,HLSL,programming,AT,2022,3
 177,Gherkin,programming,AT,2022,3
-166,Starlark,programming,AT,2022,3
 166,ShaderLab,programming,AT,2022,3
+166,Starlark,programming,AT,2022,3
 165,PLpgSQL,programming,AT,2022,3
 148,QMake,programming,AT,2022,3
 144,Yacc,programming,AT,2022,3
 132,Tcl,programming,AT,2022,3
 125,Scala,programming,AT,2022,3
-124,sed,programming,AT,2022,3
 124,Haskell,programming,AT,2022,3
+124,sed,programming,AT,2022,3
 123,Solidity,programming,AT,2022,3
 119,Lex,programming,AT,2022,3
 117,NSIS,programming,AT,2022,3
@@ -59967,9 +60198,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 129,Pawn,programming,AU,2022,3
 122,Gnuplot,programming,AU,2022,3
 118,Visual Basic .NET,programming,AU,2022,3
-117,D,programming,AU,2022,3
-117,Processing,programming,AU,2022,3
 117,DIGITAL Command Language,programming,AU,2022,3
+117,Processing,programming,AU,2022,3
+117,D,programming,AU,2022,3
 114,AppleScript,programming,AU,2022,3
 108,SmPL,programming,AU,2022,3
 107,Jsonnet,programming,AU,2022,3
@@ -60135,9 +60366,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Haskell,programming,BE,2022,3
 110,Starlark,programming,BE,2022,3
 107,Tcl,programming,BE,2022,3
-105,Mako,programming,BE,2022,3
-105,QMake,programming,BE,2022,3
 105,Pascal,programming,BE,2022,3
+105,QMake,programming,BE,2022,3
+105,Mako,programming,BE,2022,3
 104,Yacc,programming,BE,2022,3
 103,Cython,programming,BE,2022,3
 102,Lex,programming,BE,2022,3
@@ -60358,8 +60589,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 188,NSIS,programming,BR,2022,3
 181,Inno Setup,programming,BR,2022,3
 180,xBase,programming,BR,2022,3
-177,Stata,programming,BR,2022,3
 177,QML,programming,BR,2022,3
+177,Stata,programming,BR,2022,3
 168,SmPL,programming,BR,2022,3
 167,SourcePawn,programming,BR,2022,3
 147,PureBasic,programming,BR,2022,3
@@ -60368,8 +60599,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Pawn,programming,BR,2022,3
 136,Classic ASP,programming,BR,2022,3
 135,D,programming,BR,2022,3
-130,Apex,programming,BR,2022,3
 130,AutoHotkey,programming,BR,2022,3
+130,Apex,programming,BR,2022,3
 128,XS,programming,BR,2022,3
 127,DIGITAL Command Language,programming,BR,2022,3
 119,UnrealScript,programming,BR,2022,3
@@ -60530,11 +60761,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 369,Pascal,programming,CA,2022,3
 357,SourcePawn,programming,CA,2022,3
 353,Raku,programming,CA,2022,3
-314,PLSQL,programming,CA,2022,3
 314,Elixir,programming,CA,2022,3
+314,PLSQL,programming,CA,2022,3
 304,FreeMarker,programming,CA,2022,3
-301,AutoHotkey,programming,CA,2022,3
 301,Processing,programming,CA,2022,3
+301,AutoHotkey,programming,CA,2022,3
 292,GDScript,programming,CA,2022,3
 285,ANTLR,programming,CA,2022,3
 271,Common Lisp,programming,CA,2022,3
@@ -60544,8 +60775,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 247,VBScript,programming,CA,2022,3
 245,Inno Setup,programming,CA,2022,3
 238,Verilog,programming,CA,2022,3
-224,AppleScript,programming,CA,2022,3
 224,PureBasic,programming,CA,2022,3
+224,AppleScript,programming,CA,2022,3
 215,D,programming,CA,2022,3
 213,Gnuplot,programming,CA,2022,3
 211,Jsonnet,programming,CA,2022,3
@@ -60581,9 +60812,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,G-code,programming,CA,2022,3
 104,Reason,programming,CA,2022,3
 103,Elm,programming,CA,2022,3
+102,VBA,programming,CA,2022,3
 102,OpenEdge ABL,programming,CA,2022,3
 102,Apex,programming,CA,2022,3
-102,VBA,programming,CA,2022,3
 757,HTML,markup,CD,2022,3
 647,CSS,markup,CD,2022,3
 163,SCSS,markup,CD,2022,3
@@ -60668,21 +60899,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 204,PLSQL,programming,CH,2022,3
 196,HLSL,programming,CH,2022,3
 192,Pascal,programming,CH,2022,3
-191,ShaderLab,programming,CH,2022,3
 191,Lex,programming,CH,2022,3
+191,ShaderLab,programming,CH,2022,3
 184,Julia,programming,CH,2022,3
-183,VHDL,programming,CH,2022,3
 183,Gnuplot,programming,CH,2022,3
+183,VHDL,programming,CH,2022,3
 176,Raku,programming,CH,2022,3
 174,GDB,programming,CH,2022,3
 168,Mako,programming,CH,2022,3
 164,SourcePawn,programming,CH,2022,3
 161,TSQL,programming,CH,2022,3
-157,Meson,programming,CH,2022,3
 157,Scheme,programming,CH,2022,3
+157,Meson,programming,CH,2022,3
 156,Smalltalk,programming,CH,2022,3
-155,NSIS,programming,CH,2022,3
 155,Clojure,programming,CH,2022,3
+155,NSIS,programming,CH,2022,3
 136,CoffeeScript,programming,CH,2022,3
 136,POV-Ray SDL,programming,CH,2022,3
 128,ANTLR,programming,CH,2022,3
@@ -60749,8 +60980,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 288,Swift,programming,CL,2022,3
 241,Lua,programming,CL,2022,3
 193,Dart,programming,CL,2022,3
-176,ShaderLab,programming,CL,2022,3
 176,HLSL,programming,CL,2022,3
+176,ShaderLab,programming,CL,2022,3
 162,Assembly,programming,CL,2022,3
 149,Vim Script,programming,CL,2022,3
 144,ASP.NET,programming,CL,2022,3
@@ -60759,10 +60990,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,Perl,programming,CL,2022,3
 114,Smarty,programming,CL,2022,3
 111,Rust,programming,CL,2022,3
-104,GLSL,programming,CL,2022,3
 104,GDScript,programming,CL,2022,3
-103,Starlark,programming,CL,2022,3
+104,GLSL,programming,CL,2022,3
 103,HCL,programming,CL,2022,3
+103,Starlark,programming,CL,2022,3
 2127,HTML,markup,CM,2022,3
 1867,CSS,markup,CM,2022,3
 633,SCSS,markup,CM,2022,3
@@ -60837,9 +61068,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1910,Swift,programming,CN,2022,3
 1857,FreeMarker,programming,CN,2022,3
 1702,Yacc,programming,CN,2022,3
+1648,XSLT,programming,CN,2022,3
 1648,Lex,programming,CN,2022,3
 1648,Cuda,programming,CN,2022,3
-1648,XSLT,programming,CN,2022,3
 1543,QMake,programming,CN,2022,3
 1524,GLSL,programming,CN,2022,3
 1517,R,programming,CN,2022,3
@@ -60864,8 +61095,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 689,Verilog,programming,CN,2022,3
 683,Hack,programming,CN,2022,3
 672,Procfile,programming,CN,2022,3
-597,SWIG,programming,CN,2022,3
 597,NASL,programming,CN,2022,3
+597,SWIG,programming,CN,2022,3
 594,Thrift,programming,CN,2022,3
 588,ASP.NET,programming,CN,2022,3
 581,AIDL,programming,CN,2022,3
@@ -60912,12 +61143,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 217,Metal,programming,CN,2022,3
 210,Common Lisp,programming,CN,2022,3
 209,q,programming,CN,2022,3
-208,HiveQL,programming,CN,2022,3
 208,Forth,programming,CN,2022,3
+208,HiveQL,programming,CN,2022,3
 206,AppleScript,programming,CN,2022,3
 205,Brainfuck,programming,CN,2022,3
-204,VHDL,programming,CN,2022,3
 204,Logos,programming,CN,2022,3
+204,VHDL,programming,CN,2022,3
 199,Module Management System,programming,CN,2022,3
 197,Haskell,programming,CN,2022,3
 184,VBA,programming,CN,2022,3
@@ -61029,8 +61260,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 175,CMake,programming,CR,2022,3
 173,Batchfile,programming,CR,2022,3
 159,ASP.NET,programming,CR,2022,3
-141,TSQL,programming,CR,2022,3
 141,Procfile,programming,CR,2022,3
+141,TSQL,programming,CR,2022,3
 120,Hack,programming,CR,2022,3
 112,Go,programming,CR,2022,3
 791,HTML,markup,CU,2022,3
@@ -61143,8 +61374,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,Solidity,programming,CZ,2022,3
 126,Mako,programming,CZ,2022,3
 125,ShaderLab,programming,CZ,2022,3
-120,Tcl,programming,CZ,2022,3
 120,Raku,programming,CZ,2022,3
+120,Tcl,programming,CZ,2022,3
 118,NASL,programming,CZ,2022,3
 114,GDB,programming,CZ,2022,3
 105,Pascal,programming,CZ,2022,3
@@ -61268,8 +61499,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 456,VBScript,programming,DE,2022,3
 455,ASP.NET,programming,DE,2022,3
 428,Nim,programming,DE,2022,3
-425,Verilog,programming,DE,2022,3
 425,DIGITAL Command Language,programming,DE,2022,3
+425,Verilog,programming,DE,2022,3
 412,GDScript,programming,DE,2022,3
 408,XS,programming,DE,2022,3
 369,LLVM,programming,DE,2022,3
@@ -61279,8 +61510,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 364,AppleScript,programming,DE,2022,3
 359,POV-Ray SDL,programming,DE,2022,3
 359,OCaml,programming,DE,2022,3
-342,Visual Basic .NET,programming,DE,2022,3
 342,PureScript,programming,DE,2022,3
+342,Visual Basic .NET,programming,DE,2022,3
 336,Reason,programming,DE,2022,3
 335,Forth,programming,DE,2022,3
 334,PureBasic,programming,DE,2022,3
@@ -61301,8 +61532,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 228,Fluent,programming,DE,2022,3
 215,Xtend,programming,DE,2022,3
 213,Thrift,programming,DE,2022,3
-213,RPC,programming,DE,2022,3
 213,Ada,programming,DE,2022,3
+213,RPC,programming,DE,2022,3
 208,Open Policy Agent,programming,DE,2022,3
 200,Elm,programming,DE,2022,3
 192,SystemVerilog,programming,DE,2022,3
@@ -61321,8 +61552,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,Nextflow,programming,DE,2022,3
 147,ASL,programming,DE,2022,3
 147,SAS,programming,DE,2022,3
-146,Logos,programming,DE,2022,3
 146,CAP CDS,programming,DE,2022,3
+146,Logos,programming,DE,2022,3
 146,Cap'n Proto,programming,DE,2022,3
 146,Ragel,programming,DE,2022,3
 140,XQuery,programming,DE,2022,3
@@ -61335,13 +61566,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 128,AGS Script,programming,DE,2022,3
 121,CUE,programming,DE,2022,3
 119,NewLisp,programming,DE,2022,3
-118,EmberScript,programming,DE,2022,3
 118,ImageJ Macro,programming,DE,2022,3
+118,EmberScript,programming,DE,2022,3
 115,Brainfuck,programming,DE,2022,3
 111,SuperCollider,programming,DE,2022,3
 109,Vala,programming,DE,2022,3
-109,Apex,programming,DE,2022,3
 109,Isabelle,programming,DE,2022,3
+109,Apex,programming,DE,2022,3
 108,Euphoria,programming,DE,2022,3
 104,Qt Script,programming,DE,2022,3
 142,Markdown,prose,DE,2022,3
@@ -61357,8 +61588,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 172,EJS,markup,DK,2022,3
 145,Handlebars,markup,DK,2022,3
 133,Mustache,markup,DK,2022,3
-132,Blade,markup,DK,2022,3
 132,Jinja,markup,DK,2022,3
+132,Blade,markup,DK,2022,3
 6872,JavaScript,programming,DK,2022,3
 4695,Python,programming,DK,2022,3
 4560,Shell,programming,DK,2022,3
@@ -61369,8 +61600,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1821,Makefile,programming,DK,2022,3
 1564,C,programming,DK,2022,3
 1552,C++,programming,DK,2022,3
-1035,Ruby,programming,DK,2022,3
 1035,Batchfile,programming,DK,2022,3
+1035,Ruby,programming,DK,2022,3
 921,PHP,programming,DK,2022,3
 863,CMake,programming,DK,2022,3
 770,PowerShell,programming,DK,2022,3
@@ -61392,8 +61623,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 220,XSLT,programming,DK,2022,3
 212,HCL,programming,DK,2022,3
 208,GLSL,programming,DK,2022,3
-184,Smarty,programming,DK,2022,3
 184,Objective-C++,programming,DK,2022,3
+184,Smarty,programming,DK,2022,3
 175,TSQL,programming,DK,2022,3
 171,Nix,programming,DK,2022,3
 169,Smalltalk,programming,DK,2022,3
@@ -61409,8 +61640,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Awk,programming,DK,2022,3
 119,PLpgSQL,programming,DK,2022,3
 113,Gherkin,programming,DK,2022,3
-108,Cython,programming,DK,2022,3
 108,Groovy,programming,DK,2022,3
+108,Cython,programming,DK,2022,3
 107,Yacc,programming,DK,2022,3
 2966,HTML,markup,DO,2022,3
 2478,CSS,markup,DO,2022,3
@@ -61560,8 +61791,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 206,MATLAB,programming,EG,2022,3
 205,Starlark,programming,EG,2022,3
 203,HCL,programming,EG,2022,3
-202,Objective-C++,programming,EG,2022,3
 202,Verilog,programming,EG,2022,3
+202,Objective-C++,programming,EG,2022,3
 200,Lua,programming,EG,2022,3
 184,Smarty,programming,EG,2022,3
 181,Perl,programming,EG,2022,3
@@ -61654,8 +61885,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 243,TSQL,programming,ES,2022,3
 241,sed,programming,ES,2022,3
 227,ASP.NET,programming,ES,2022,3
-226,Pascal,programming,ES,2022,3
 226,PLSQL,programming,ES,2022,3
+226,Pascal,programming,ES,2022,3
 224,Mathematica,programming,ES,2022,3
 223,CoffeeScript,programming,ES,2022,3
 219,GAP,programming,ES,2022,3
@@ -61681,8 +61912,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,QML,programming,ES,2022,3
 119,VBScript,programming,ES,2022,3
 117,GDScript,programming,ES,2022,3
-114,Inno Setup,programming,ES,2022,3
 114,Processing,programming,ES,2022,3
+114,Inno Setup,programming,ES,2022,3
 112,VHDL,programming,ES,2022,3
 110,PureBasic,programming,ES,2022,3
 104,Verilog,programming,ES,2022,3
@@ -61720,6 +61951,34 @@ num_pushers,language,language_type,iso2_code,year,quarter
 175,Forth,programming,ET,2022,3
 148,Makefile,programming,ET,2022,3
 145,Hack,programming,ET,2022,3
+349815,HTML,markup,EU,2022,3
+280573,CSS,markup,EU,2022,3
+91680,SCSS,markup,EU,2022,3
+45725,Jupyter Notebook,markup,EU,2022,3
+24872,Vue,markup,EU,2022,3
+18192,TeX,markup,EU,2022,3
+17011,Roff,markup,EU,2022,3
+11174,Less,markup,EU,2022,3
+8458,Jinja,markup,EU,2022,3
+8171,Handlebars,markup,EU,2022,3
+8109,Blade,markup,EU,2022,3
+7689,EJS,markup,EU,2022,3
+7510,Twig,markup,EU,2022,3
+6899,Mustache,markup,EU,2022,3
+4893,Svelte,markup,EU,2022,3
+3544,Pug,markup,EU,2022,3
+3536,Sass,markup,EU,2022,3
+3512,Rich Text Format,markup,EU,2022,3
+1174,Vim Snippet,markup,EU,2022,3
+1051,Nunjucks,markup,EU,2022,3
+1044,Stylus,markup,EU,2022,3
+1038,PostScript,markup,EU,2022,3
+652,Liquid,markup,EU,2022,3
+544,Astro,markup,EU,2022,3
+320,Haml,markup,EU,2022,3
+192,Latte,markup,EU,2022,3
+137,YASnippet,markup,EU,2022,3
+125,Slim,markup,EU,2022,3
 321296,JavaScript,programming,EU,2022,3
 219488,Shell,programming,EU,2022,3
 209736,Python,programming,EU,2022,3
@@ -61854,8 +62113,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 213,RPC,programming,EU,2022,3
 192,SystemVerilog,programming,EU,2022,3
 184,JetBrains MPS,programming,EU,2022,3
-174,RenderScript,programming,EU,2022,3
 174,Metal,programming,EU,2022,3
+174,RenderScript,programming,EU,2022,3
 172,Stata,programming,EU,2022,3
 171,Coq,programming,EU,2022,3
 171,Rebol,programming,EU,2022,3
@@ -61863,24 +62122,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 160,Zig,programming,EU,2022,3
 156,jq,programming,EU,2022,3
 155,Sage,programming,EU,2022,3
-153,Max,programming,EU,2022,3
 153,Nextflow,programming,EU,2022,3
+153,Max,programming,EU,2022,3
 147,ASL,programming,EU,2022,3
 147,SAS,programming,EU,2022,3
-146,Ragel,programming,EU,2022,3
-146,Logos,programming,EU,2022,3
 146,CAP CDS,programming,EU,2022,3
+146,Logos,programming,EU,2022,3
+146,Ragel,programming,EU,2022,3
 146,Cap'n Proto,programming,EU,2022,3
 140,XQuery,programming,EU,2022,3
 139,ABAP,programming,EU,2022,3
 139,Classic ASP,programming,EU,2022,3
 133,Crystal,programming,EU,2022,3
-128,SaltStack,programming,EU,2022,3
 128,AGS Script,programming,EU,2022,3
+128,SaltStack,programming,EU,2022,3
 121,CUE,programming,EU,2022,3
 119,NewLisp,programming,EU,2022,3
-118,EmberScript,programming,EU,2022,3
 118,ImageJ Macro,programming,EU,2022,3
+118,EmberScript,programming,EU,2022,3
 115,Brainfuck,programming,EU,2022,3
 111,SuperCollider,programming,EU,2022,3
 109,Vala,programming,EU,2022,3
@@ -61888,6 +62147,7 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,Isabelle,programming,EU,2022,3
 108,Euphoria,programming,EU,2022,3
 104,Qt Script,programming,EU,2022,3
+355,Markdown,prose,EU,2022,3
 8237,HTML,markup,FI,2022,3
 6710,CSS,markup,FI,2022,3
 1693,SCSS,markup,FI,2022,3
@@ -61900,8 +62160,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 173,EJS,markup,FI,2022,3
 138,Pug,markup,FI,2022,3
 130,Mustache,markup,FI,2022,3
-125,Svelte,markup,FI,2022,3
 125,Handlebars,markup,FI,2022,3
+125,Svelte,markup,FI,2022,3
 7716,JavaScript,programming,FI,2022,3
 5124,Python,programming,FI,2022,3
 4990,Shell,programming,FI,2022,3
@@ -61946,8 +62206,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,Yacc,programming,FI,2022,3
 142,RobotFramework,programming,FI,2022,3
 139,Hack,programming,FI,2022,3
-136,sed,programming,FI,2022,3
 136,Clojure,programming,FI,2022,3
+136,sed,programming,FI,2022,3
 127,Scala,programming,FI,2022,3
 124,Haskell,programming,FI,2022,3
 122,Dart,programming,FI,2022,3
@@ -62052,8 +62312,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 396,FreeMarker,programming,FR,2022,3
 384,CoffeeScript,programming,FR,2022,3
 381,Standard ML,programming,FR,2022,3
-379,PLSQL,programming,FR,2022,3
 379,Gnuplot,programming,FR,2022,3
+379,PLSQL,programming,FR,2022,3
 357,SWIG,programming,FR,2022,3
 352,Common Lisp,programming,FR,2022,3
 351,Mathematica,programming,FR,2022,3
@@ -62066,8 +62326,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 306,ASP.NET,programming,FR,2022,3
 295,ANTLR,programming,FR,2022,3
 292,D,programming,FR,2022,3
-271,Pawn,programming,FR,2022,3
 271,VHDL,programming,FR,2022,3
+271,Pawn,programming,FR,2022,3
 265,VBScript,programming,FR,2022,3
 262,SmPL,programming,FR,2022,3
 253,Erlang,programming,FR,2022,3
@@ -62081,8 +62341,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 180,PureBasic,programming,FR,2022,3
 177,AMPL,programming,FR,2022,3
 175,AutoHotkey,programming,FR,2022,3
-171,Coq,programming,FR,2022,3
 171,Visual Basic .NET,programming,FR,2022,3
+171,Coq,programming,FR,2022,3
 170,AppleScript,programming,FR,2022,3
 168,Nim,programming,FR,2022,3
 162,XS,programming,FR,2022,3
@@ -62264,8 +62524,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,AIDL,programming,GB,2022,3
 143,Apex,programming,GB,2022,3
 142,WebAssembly,programming,GB,2022,3
-141,UnrealScript,programming,GB,2022,3
 141,Module Management System,programming,GB,2022,3
+141,UnrealScript,programming,GB,2022,3
 137,Haxe,programming,GB,2022,3
 134,Reason,programming,GB,2022,3
 132,Fluent,programming,GB,2022,3
@@ -62274,10 +62534,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,SAS,programming,GB,2022,3
 123,Stan,programming,GB,2022,3
 122,Rebol,programming,GB,2022,3
-122,ASL,programming,GB,2022,3
 122,RenderScript,programming,GB,2022,3
-117,PureScript,programming,GB,2022,3
+122,ASL,programming,GB,2022,3
 117,Logos,programming,GB,2022,3
+117,PureScript,programming,GB,2022,3
 116,jq,programming,GB,2022,3
 114,BASIC,programming,GB,2022,3
 110,Zig,programming,GB,2022,3
@@ -62285,8 +62545,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 108,Nu,programming,GB,2022,3
 106,RobotFramework,programming,GB,2022,3
 102,Jasmin,programming,GB,2022,3
-102,Coq,programming,GB,2022,3
 102,Ragel,programming,GB,2022,3
+102,Coq,programming,GB,2022,3
 4386,HTML,markup,GE,2022,3
 3596,CSS,markup,GE,2022,3
 1122,SCSS,markup,GE,2022,3
@@ -62335,8 +62595,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 576,PHP,programming,GH,2022,3
 466,Dockerfile,programming,GH,2022,3
 456,Swift,programming,GH,2022,3
-454,Objective-C,programming,GH,2022,3
 454,Kotlin,programming,GH,2022,3
+454,Objective-C,programming,GH,2022,3
 438,Ruby,programming,GH,2022,3
 433,Dart,programming,GH,2022,3
 390,C#,programming,GH,2022,3
@@ -62525,17 +62785,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 287,ASP.NET,programming,HK,2022,3
 274,Haskell,programming,HK,2022,3
 262,Scheme,programming,HK,2022,3
-251,AppleScript,programming,HK,2022,3
 251,Mathematica,programming,HK,2022,3
+251,AppleScript,programming,HK,2022,3
 248,LLVM,programming,HK,2022,3
 240,PureBasic,programming,HK,2022,3
 239,Meson,programming,HK,2022,3
-238,Mako,programming,HK,2022,3
 238,Inno Setup,programming,HK,2022,3
+238,Mako,programming,HK,2022,3
 226,Julia,programming,HK,2022,3
 222,q,programming,HK,2022,3
-214,DTrace,programming,HK,2022,3
 214,HiveQL,programming,HK,2022,3
+214,DTrace,programming,HK,2022,3
 212,Metal,programming,HK,2022,3
 194,QML,programming,HK,2022,3
 193,Sage,programming,HK,2022,3
@@ -62543,10 +62803,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 186,AspectJ,programming,HK,2022,3
 185,Forth,programming,HK,2022,3
 183,M,programming,HK,2022,3
-183,RPC,programming,HK,2022,3
 183,ASL,programming,HK,2022,3
-183,SystemVerilog,programming,HK,2022,3
+183,RPC,programming,HK,2022,3
 183,Gnuplot,programming,HK,2022,3
+183,SystemVerilog,programming,HK,2022,3
 181,Common Lisp,programming,HK,2022,3
 180,Classic ASP,programming,HK,2022,3
 173,AutoHotkey,programming,HK,2022,3
@@ -62752,13 +63012,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 243,Clojure,programming,ID,2022,3
 237,Yacc,programming,ID,2022,3
 217,Lex,programming,ID,2022,3
-211,Raku,programming,ID,2022,3
 211,sed,programming,ID,2022,3
+211,Raku,programming,ID,2022,3
 197,Pascal,programming,ID,2022,3
 189,Visual Basic .NET,programming,ID,2022,3
 186,TSQL,programming,ID,2022,3
-183,XS,programming,ID,2022,3
 183,Forth,programming,ID,2022,3
+183,XS,programming,ID,2022,3
 182,SmPL,programming,ID,2022,3
 174,UnrealScript,programming,ID,2022,3
 166,Cython,programming,ID,2022,3
@@ -62780,8 +63040,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 230,TeX,markup,IE,2022,3
 199,Handlebars,markup,IE,2022,3
 185,EJS,markup,IE,2022,3
-152,Less,markup,IE,2022,3
 152,Jinja,markup,IE,2022,3
+152,Less,markup,IE,2022,3
 147,Mustache,markup,IE,2022,3
 105,Blade,markup,IE,2022,3
 5960,JavaScript,programming,IE,2022,3
@@ -62873,14 +63133,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 362,HLSL,programming,IL,2022,3
 355,Groovy,programming,IL,2022,3
 347,Dart,programming,IL,2022,3
-346,R,programming,IL,2022,3
 346,MATLAB,programming,IL,2022,3
+346,R,programming,IL,2022,3
 344,Vim Script,programming,IL,2022,3
 303,Objective-C++,programming,IL,2022,3
 303,M4,programming,IL,2022,3
 275,GLSL,programming,IL,2022,3
-273,XSLT,programming,IL,2022,3
 273,ASP.NET,programming,IL,2022,3
+273,XSLT,programming,IL,2022,3
 271,Mako,programming,IL,2022,3
 240,Scala,programming,IL,2022,3
 234,Solidity,programming,IL,2022,3
@@ -62888,8 +63148,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 209,Hack,programming,IL,2022,3
 190,Yacc,programming,IL,2022,3
 189,TSQL,programming,IL,2022,3
-183,Awk,programming,IL,2022,3
 183,Gherkin,programming,IL,2022,3
+183,Awk,programming,IL,2022,3
 177,Cython,programming,IL,2022,3
 171,Lex,programming,IL,2022,3
 169,Emacs Lisp,programming,IL,2022,3
@@ -62899,8 +63159,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Open Policy Agent,programming,IL,2022,3
 111,ANTLR,programming,IL,2022,3
 110,Smalltalk,programming,IL,2022,3
-105,YARA,programming,IL,2022,3
 105,Clojure,programming,IL,2022,3
+105,YARA,programming,IL,2022,3
 101,sed,programming,IL,2022,3
 351223,HTML,markup,IN,2022,3
 281295,CSS,markup,IN,2022,3
@@ -63011,9 +63271,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 481,QMake,programming,IN,2022,3
 465,NASL,programming,IN,2022,3
 460,Pascal,programming,IN,2022,3
-458,Elixir,programming,IN,2022,3
-458,GAP,programming,IN,2022,3
 458,Prolog,programming,IN,2022,3
+458,GAP,programming,IN,2022,3
+458,Elixir,programming,IN,2022,3
 424,RobotFramework,programming,IN,2022,3
 390,DIGITAL Command Language,programming,IN,2022,3
 377,Meson,programming,IN,2022,3
@@ -63021,8 +63281,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 360,Nu,programming,IN,2022,3
 355,F#,programming,IN,2022,3
 348,SWIG,programming,IN,2022,3
-347,NSIS,programming,IN,2022,3
 347,Common Lisp,programming,IN,2022,3
+347,NSIS,programming,IN,2022,3
 336,Mathematica,programming,IN,2022,3
 334,Bicep,programming,IN,2022,3
 316,Erlang,programming,IN,2022,3
@@ -63043,8 +63303,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 224,OpenEdge ABL,programming,IN,2022,3
 223,Gnuplot,programming,IN,2022,3
 218,QML,programming,IN,2022,3
-208,Standard ML,programming,IN,2022,3
 208,COBOL,programming,IN,2022,3
+208,Standard ML,programming,IN,2022,3
 207,Elm,programming,IN,2022,3
 205,Xonsh,programming,IN,2022,3
 203,Pawn,programming,IN,2022,3
@@ -63112,8 +63372,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 734,Vue,markup,IR,2022,3
 417,Less,markup,IR,2022,3
 198,TeX,markup,IR,2022,3
-175,EJS,markup,IR,2022,3
 175,Roff,markup,IR,2022,3
+175,EJS,markup,IR,2022,3
 103,Handlebars,markup,IR,2022,3
 8877,JavaScript,programming,IR,2022,3
 5555,Python,programming,IR,2022,3
@@ -63143,8 +63403,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 184,Lua,programming,IR,2022,3
 154,Solidity,programming,IR,2022,3
 151,Rust,programming,IR,2022,3
-129,QMake,programming,IR,2022,3
 129,TSQL,programming,IR,2022,3
+129,QMake,programming,IR,2022,3
 127,Smarty,programming,IR,2022,3
 126,ASP.NET,programming,IR,2022,3
 123,R,programming,IR,2022,3
@@ -63225,8 +63485,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 383,Fortran,programming,IT,2022,3
 371,Awk,programming,IT,2022,3
 348,Groovy,programming,IT,2022,3
-341,PLpgSQL,programming,IT,2022,3
 341,Gherkin,programming,IT,2022,3
+341,PLpgSQL,programming,IT,2022,3
 340,Yacc,programming,IT,2022,3
 335,QMake,programming,IT,2022,3
 326,Scala,programming,IT,2022,3
@@ -63247,8 +63507,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 198,Haskell,programming,IT,2022,3
 191,Gnuplot,programming,IT,2022,3
 191,Meson,programming,IT,2022,3
-188,SWIG,programming,IT,2022,3
 188,ASP.NET,programming,IT,2022,3
+188,SWIG,programming,IT,2022,3
 187,Julia,programming,IT,2022,3
 160,Scheme,programming,IT,2022,3
 159,PLSQL,programming,IT,2022,3
@@ -63269,8 +63529,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Processing,programming,IT,2022,3
 114,Verilog,programming,IT,2022,3
 111,Forth,programming,IT,2022,3
-110,AMPL,programming,IT,2022,3
 110,SourcePawn,programming,IT,2022,3
+110,AMPL,programming,IT,2022,3
 109,VBScript,programming,IT,2022,3
 108,Pawn,programming,IT,2022,3
 105,XS,programming,IT,2022,3
@@ -63363,8 +63623,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 2158,Dart,programming,JP,2022,3
 1791,HLSL,programming,JP,2022,3
 1548,ShaderLab,programming,JP,2022,3
-1445,M4,programming,JP,2022,3
 1445,Emacs Lisp,programming,JP,2022,3
+1445,M4,programming,JP,2022,3
 1374,GLSL,programming,JP,2022,3
 1360,Smarty,programming,JP,2022,3
 1345,Hack,programming,JP,2022,3
@@ -63410,12 +63670,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 323,TSQL,programming,JP,2022,3
 319,ASP.NET,programming,JP,2022,3
 309,ANTLR,programming,JP,2022,3
-299,Elixir,programming,JP,2022,3
 299,Mako,programming,JP,2022,3
+299,Elixir,programming,JP,2022,3
 287,GAP,programming,JP,2022,3
 276,Gnuplot,programming,JP,2022,3
-273,SWIG,programming,JP,2022,3
 273,Jsonnet,programming,JP,2022,3
+273,SWIG,programming,JP,2022,3
 272,Meson,programming,JP,2022,3
 271,Verilog,programming,JP,2022,3
 263,VBA,programming,JP,2022,3
@@ -63447,16 +63707,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,SystemVerilog,programming,JP,2022,3
 142,Reason,programming,JP,2022,3
 141,M,programming,JP,2022,3
-140,QML,programming,JP,2022,3
 140,Ragel,programming,JP,2022,3
+140,QML,programming,JP,2022,3
 139,Elm,programming,JP,2022,3
 135,VHDL,programming,JP,2022,3
 134,Scilab,programming,JP,2022,3
 126,POV-Ray SDL,programming,JP,2022,3
 112,Bicep,programming,JP,2022,3
 111,Ada,programming,JP,2022,3
-105,Logos,programming,JP,2022,3
 105,Sage,programming,JP,2022,3
+105,Logos,programming,JP,2022,3
 101,RPC,programming,JP,2022,3
 112,Markdown,prose,JP,2022,3
 11117,HTML,markup,KE,2022,3
@@ -63500,8 +63760,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 187,Mako,programming,KE,2022,3
 175,Rust,programming,KE,2022,3
 160,MATLAB,programming,KE,2022,3
-128,M,programming,KE,2022,3
 128,Forth,programming,KE,2022,3
+128,M,programming,KE,2022,3
 113,Smarty,programming,KE,2022,3
 110,Starlark,programming,KE,2022,3
 3098,HTML,markup,KG,2022,3
@@ -63619,8 +63879,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 398,Scala,programming,KR,2022,3
 378,Yacc,programming,KR,2022,3
 375,Fortran,programming,KR,2022,3
-352,Emacs Lisp,programming,KR,2022,3
 352,Lex,programming,KR,2022,3
+352,Emacs Lisp,programming,KR,2022,3
 330,Awk,programming,KR,2022,3
 329,Gherkin,programming,KR,2022,3
 320,Mathematica,programming,KR,2022,3
@@ -63667,8 +63927,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 492,CSS,markup,KW,2022,3
 492,JavaScript,programming,KW,2022,3
 201,Python,programming,KW,2022,3
-163,C#,programming,KW,2022,3
 163,Swift,programming,KW,2022,3
+163,C#,programming,KW,2022,3
 149,Shell,programming,KW,2022,3
 140,Java,programming,KW,2022,3
 4738,HTML,markup,KZ,2022,3
@@ -63747,8 +64007,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1852,PHP,programming,LK,2022,3
 1069,C++,programming,LK,2022,3
 895,C,programming,LK,2022,3
-776,C#,programming,LK,2022,3
 776,Objective-C,programming,LK,2022,3
+776,C#,programming,LK,2022,3
 731,Ruby,programming,LK,2022,3
 691,Makefile,programming,LK,2022,3
 690,Hack,programming,LK,2022,3
@@ -64218,8 +64478,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 353,Rich Text Format,markup,NL,2022,3
 267,Sass,markup,NL,2022,3
 266,Pug,markup,NL,2022,3
-146,PostScript,markup,NL,2022,3
 146,Vim Snippet,markup,NL,2022,3
+146,PostScript,markup,NL,2022,3
 139,Nunjucks,markup,NL,2022,3
 132,Stylus,markup,NL,2022,3
 108,Liquid,markup,NL,2022,3
@@ -64285,8 +64545,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 250,NSIS,programming,NL,2022,3
 249,PLSQL,programming,NL,2022,3
 244,ANTLR,programming,NL,2022,3
-240,Raku,programming,NL,2022,3
 240,Clojure,programming,NL,2022,3
+240,Raku,programming,NL,2022,3
 237,Meson,programming,NL,2022,3
 235,Smalltalk,programming,NL,2022,3
 228,Mathematica,programming,NL,2022,3
@@ -64301,8 +64561,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,QML,programming,NL,2022,3
 173,CoffeeScript,programming,NL,2022,3
 169,SourcePawn,programming,NL,2022,3
-167,FreeMarker,programming,NL,2022,3
 167,SWIG,programming,NL,2022,3
+167,FreeMarker,programming,NL,2022,3
 165,Common Lisp,programming,NL,2022,3
 163,Prolog,programming,NL,2022,3
 154,DIGITAL Command Language,programming,NL,2022,3
@@ -64311,9 +64571,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,D,programming,NL,2022,3
 131,SmPL,programming,NL,2022,3
 128,Erlang,programming,NL,2022,3
-123,Verilog,programming,NL,2022,3
-123,VBScript,programming,NL,2022,3
 123,Visual Basic .NET,programming,NL,2022,3
+123,VBScript,programming,NL,2022,3
+123,Verilog,programming,NL,2022,3
 122,F#,programming,NL,2022,3
 115,AutoHotkey,programming,NL,2022,3
 109,Standard ML,programming,NL,2022,3
@@ -64386,8 +64646,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,Yacc,programming,NO,2022,3
 114,PLSQL,programming,NO,2022,3
 112,GDB,programming,NO,2022,3
-108,Scala,programming,NO,2022,3
 108,Smalltalk,programming,NO,2022,3
+108,Scala,programming,NO,2022,3
 10175,HTML,markup,NP,2022,3
 8593,CSS,markup,NP,2022,3
 1923,SCSS,markup,NP,2022,3
@@ -64475,13 +64735,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,Objective-C++,programming,NZ,2022,3
 131,Emacs Lisp,programming,NZ,2022,3
 126,Scheme,programming,NZ,2022,3
-123,Dart,programming,NZ,2022,3
 123,MATLAB,programming,NZ,2022,3
+123,Dart,programming,NZ,2022,3
 107,GDScript,programming,NZ,2022,3
 105,Cython,programming,NZ,2022,3
 103,Fortran,programming,NZ,2022,3
-102,Starlark,programming,NZ,2022,3
 102,PLpgSQL,programming,NZ,2022,3
+102,Starlark,programming,NZ,2022,3
 332,HTML,markup,OM,2022,3
 262,CSS,markup,OM,2022,3
 281,JavaScript,programming,OM,2022,3
@@ -64591,8 +64851,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 236,Objective-C++,programming,PH,2022,3
 222,Solidity,programming,PH,2022,3
 219,Starlark,programming,PH,2022,3
-206,Rust,programming,PH,2022,3
 206,Assembly,programming,PH,2022,3
+206,Rust,programming,PH,2022,3
 202,Vim Script,programming,PH,2022,3
 195,ASP.NET,programming,PH,2022,3
 192,Perl,programming,PH,2022,3
@@ -64763,8 +65023,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,PureBasic,programming,PL,2022,3
 152,VBA,programming,PL,2022,3
 148,QML,programming,PL,2022,3
-147,Pawn,programming,PL,2022,3
 147,VBScript,programming,PL,2022,3
+147,Pawn,programming,PL,2022,3
 140,CoffeeScript,programming,PL,2022,3
 139,GDScript,programming,PL,2022,3
 138,Jsonnet,programming,PL,2022,3
@@ -64772,8 +65032,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,FreeMarker,programming,PL,2022,3
 126,Prolog,programming,PL,2022,3
 119,Gnuplot,programming,PL,2022,3
-116,DIGITAL Command Language,programming,PL,2022,3
 116,Julia,programming,PL,2022,3
+116,DIGITAL Command Language,programming,PL,2022,3
 109,Common Lisp,programming,PL,2022,3
 108,Erlang,programming,PL,2022,3
 108,F#,programming,PL,2022,3
@@ -64944,18 +65204,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 242,Hack,programming,RO,2022,3
 231,Vim Script,programming,RO,2022,3
 222,HCL,programming,RO,2022,3
-211,HLSL,programming,RO,2022,3
 211,ShaderLab,programming,RO,2022,3
+211,HLSL,programming,RO,2022,3
 201,M4,programming,RO,2022,3
-200,GLSL,programming,RO,2022,3
 200,Objective-C++,programming,RO,2022,3
+200,GLSL,programming,RO,2022,3
 190,XSLT,programming,RO,2022,3
 161,Starlark,programming,RO,2022,3
 159,Awk,programming,RO,2022,3
 158,Yacc,programming,RO,2022,3
+152,R,programming,RO,2022,3
 152,PLpgSQL,programming,RO,2022,3
 152,Groovy,programming,RO,2022,3
-152,R,programming,RO,2022,3
 149,MATLAB,programming,RO,2022,3
 139,Nix,programming,RO,2022,3
 138,Lex,programming,RO,2022,3
@@ -65116,8 +65376,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 243,DIGITAL Command Language,programming,RU,2022,3
 234,DM,programming,RU,2022,3
 233,Common Lisp,programming,RU,2022,3
-227,XS,programming,RU,2022,3
 227,F#,programming,RU,2022,3
+227,XS,programming,RU,2022,3
 220,Verilog,programming,RU,2022,3
 219,GDScript,programming,RU,2022,3
 217,AIDL,programming,RU,2022,3
@@ -65142,8 +65402,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,VBA,programming,RU,2022,3
 132,Metal,programming,RU,2022,3
 128,POV-Ray SDL,programming,RU,2022,3
-125,jq,programming,RU,2022,3
 125,Module Management System,programming,RU,2022,3
+125,jq,programming,RU,2022,3
 124,AppleScript,programming,RU,2022,3
 123,SystemVerilog,programming,RU,2022,3
 122,VHDL,programming,RU,2022,3
@@ -65153,9 +65413,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Processing,programming,RU,2022,3
 106,SAS,programming,RU,2022,3
 106,Ada,programming,RU,2022,3
-104,WebAssembly,programming,RU,2022,3
-104,Scilab,programming,RU,2022,3
 104,Thrift,programming,RU,2022,3
+104,Scilab,programming,RU,2022,3
+104,WebAssembly,programming,RU,2022,3
 1550,HTML,markup,RW,2022,3
 1427,CSS,markup,RW,2022,3
 367,SCSS,markup,RW,2022,3
@@ -65279,17 +65539,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 199,QMake,programming,SE,2022,3
 193,Gherkin,programming,SE,2022,3
 180,GDB,programming,SE,2022,3
-172,Lex,programming,SE,2022,3
 172,ASP.NET,programming,SE,2022,3
 172,Mathematica,programming,SE,2022,3
+172,Lex,programming,SE,2022,3
 170,TSQL,programming,SE,2022,3
 166,Scheme,programming,SE,2022,3
 165,Elixir,programming,SE,2022,3
 162,PLpgSQL,programming,SE,2022,3
 161,Tcl,programming,SE,2022,3
 159,Erlang,programming,SE,2022,3
-156,NSIS,programming,SE,2022,3
 156,Julia,programming,SE,2022,3
+156,NSIS,programming,SE,2022,3
 146,Meson,programming,SE,2022,3
 144,Fortran,programming,SE,2022,3
 143,AutoHotkey,programming,SE,2022,3
@@ -65355,8 +65615,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 643,HCL,programming,SG,2022,3
 544,M4,programming,SG,2022,3
 505,XSLT,programming,SG,2022,3
-496,HLSL,programming,SG,2022,3
 496,Starlark,programming,SG,2022,3
+496,HLSL,programming,SG,2022,3
 461,ShaderLab,programming,SG,2022,3
 453,Objective-C++,programming,SG,2022,3
 452,MATLAB,programming,SG,2022,3
@@ -65375,8 +65635,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 315,Gherkin,programming,SG,2022,3
 261,Tcl,programming,SG,2022,3
 258,sed,programming,SG,2022,3
-252,ANTLR,programming,SG,2022,3
 252,TSQL,programming,SG,2022,3
+252,ANTLR,programming,SG,2022,3
 227,FreeMarker,programming,SG,2022,3
 201,ASP.NET,programming,SG,2022,3
 190,QMake,programming,SG,2022,3
@@ -65458,8 +65718,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,PowerShell,programming,SK,2022,3
 142,Perl,programming,SK,2022,3
 138,Swift,programming,SK,2022,3
-131,Rust,programming,SK,2022,3
 131,Assembly,programming,SK,2022,3
+131,Rust,programming,SK,2022,3
 115,Procfile,programming,SK,2022,3
 110,Smarty,programming,SK,2022,3
 108,HTML,markup,SL,2022,3
@@ -65575,10 +65835,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 154,Nix,programming,TH,2022,3
 150,R,programming,TH,2022,3
 129,Gherkin,programming,TH,2022,3
-124,M4,programming,TH,2022,3
 124,XSLT,programming,TH,2022,3
-109,ASP.NET,programming,TH,2022,3
+124,M4,programming,TH,2022,3
 109,GLSL,programming,TH,2022,3
+109,ASP.NET,programming,TH,2022,3
 101,CoffeeScript,programming,TH,2022,3
 335,HTML,markup,TJ,2022,3
 263,CSS,markup,TJ,2022,3
@@ -65613,8 +65873,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 309,Makefile,programming,TN,2022,3
 305,Ruby,programming,TN,2022,3
 265,Procfile,programming,TN,2022,3
-236,Batchfile,programming,TN,2022,3
 236,CMake,programming,TN,2022,3
+236,Batchfile,programming,TN,2022,3
 160,Hack,programming,TN,2022,3
 120,Go,programming,TN,2022,3
 118,PowerShell,programming,TN,2022,3
@@ -65759,8 +66019,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 356,Objective-C++,programming,TW,2022,3
 354,Yacc,programming,TW,2022,3
 353,GLSL,programming,TW,2022,3
-345,XSLT,programming,TW,2022,3
 345,Cuda,programming,TW,2022,3
+345,XSLT,programming,TW,2022,3
 334,Lex,programming,TW,2022,3
 308,Tcl,programming,TW,2022,3
 305,Awk,programming,TW,2022,3
@@ -65787,8 +66047,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,Scala,programming,TW,2022,3
 138,SmPL,programming,TW,2022,3
 125,Haskell,programming,TW,2022,3
-123,Mathematica,programming,TW,2022,3
 123,Forth,programming,TW,2022,3
+123,Mathematica,programming,TW,2022,3
 122,FreeMarker,programming,TW,2022,3
 120,GAP,programming,TW,2022,3
 118,SystemVerilog,programming,TW,2022,3
@@ -65876,8 +66136,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 396,GLSL,programming,UA,2022,3
 377,Solidity,programming,UA,2022,3
 300,M4,programming,UA,2022,3
-293,TSQL,programming,UA,2022,3
 293,PLpgSQL,programming,UA,2022,3
+293,TSQL,programming,UA,2022,3
 290,XSLT,programming,UA,2022,3
 284,Groovy,programming,UA,2022,3
 275,Mako,programming,UA,2022,3
@@ -65894,8 +66154,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 129,Lex,programming,UA,2022,3
 127,CoffeeScript,programming,UA,2022,3
 122,Clojure,programming,UA,2022,3
-113,sed,programming,UA,2022,3
 113,FreeMarker,programming,UA,2022,3
+113,sed,programming,UA,2022,3
 105,Raku,programming,UA,2022,3
 104,GDB,programming,UA,2022,3
 102,NASL,programming,UA,2022,3
@@ -66056,8 +66316,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1729,Jsonnet,programming,US,2022,3
 1716,F#,programming,US,2022,3
 1687,Thrift,programming,US,2022,3
-1659,DTrace,programming,US,2022,3
 1659,OCaml,programming,US,2022,3
+1659,DTrace,programming,US,2022,3
 1639,AppleScript,programming,US,2022,3
 1618,Forth,programming,US,2022,3
 1608,Processing,programming,US,2022,3
@@ -66082,8 +66342,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 954,UnrealScript,programming,US,2022,3
 908,SAS,programming,US,2022,3
 898,AIDL,programming,US,2022,3
-867,Sage,programming,US,2022,3
 867,G-code,programming,US,2022,3
+867,Sage,programming,US,2022,3
 866,Nim,programming,US,2022,3
 850,DM,programming,US,2022,3
 817,Scilab,programming,US,2022,3
@@ -66119,8 +66379,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 488,Game Maker Language,programming,US,2022,3
 487,Stan,programming,US,2022,3
 473,Jasmin,programming,US,2022,3
-463,q,programming,US,2022,3
 463,SuperCollider,programming,US,2022,3
+463,q,programming,US,2022,3
 459,Max,programming,US,2022,3
 458,Ragel,programming,US,2022,3
 450,BASIC,programming,US,2022,3
@@ -66167,38 +66427,38 @@ num_pushers,language,language_type,iso2_code,year,quarter
 236,RouterOS Script,programming,US,2022,3
 232,VCL,programming,US,2022,3
 222,Clean,programming,US,2022,3
-221,Lean,programming,US,2022,3
 221,CWeb,programming,US,2022,3
+221,Lean,programming,US,2022,3
 219,Red,programming,US,2022,3
 216,Qt Script,programming,US,2022,3
 215,Objective-J,programming,US,2022,3
 210,PigLatin,programming,US,2022,3
 209,eC,programming,US,2022,3
-205,Kaitai Struct,programming,US,2022,3
 205,Move,programming,US,2022,3
+205,Kaitai Struct,programming,US,2022,3
 196,Eiffel,programming,US,2022,3
 183,Boogie,programming,US,2022,3
 178,ZenScript,programming,US,2022,3
 176,Vyper,programming,US,2022,3
-175,LabVIEW,programming,US,2022,3
 175,CLIPS,programming,US,2022,3
+175,LabVIEW,programming,US,2022,3
 174,LiveScript,programming,US,2022,3
 171,Witcher Script,programming,US,2022,3
 168,REXX,programming,US,2022,3
 168,Q#,programming,US,2022,3
-163,E,programming,US,2022,3
 163,P4,programming,US,2022,3
 163,Earthly,programming,US,2022,3
-162,AutoIt,programming,US,2022,3
+163,E,programming,US,2022,3
 162,Singularity,programming,US,2022,3
+162,AutoIt,programming,US,2022,3
 161,Cool,programming,US,2022,3
 160,LilyPond,programming,US,2022,3
 159,Clarion,programming,US,2022,3
 157,AngelScript,programming,US,2022,3
 156,BlitzBasic,programming,US,2022,3
+154,Harbour,programming,US,2022,3
 154,Modelica,programming,US,2022,3
 154,KRL,programming,US,2022,3
-154,Harbour,programming,US,2022,3
 151,SQF,programming,US,2022,3
 151,Monkey C,programming,US,2022,3
 150,Hy,programming,US,2022,3
@@ -66212,16 +66472,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Pike,programming,US,2022,3
 132,mIRC Script,programming,US,2022,3
 131,Nearley,programming,US,2022,3
-129,OpenQASM,programming,US,2022,3
 129,Fennel,programming,US,2022,3
+129,OpenQASM,programming,US,2022,3
 128,Promela,programming,US,2022,3
-125,LSL,programming,US,2022,3
-125,Squirrel,programming,US,2022,3
 125,Filebench WML,programming,US,2022,3
 125,Alloy,programming,US,2022,3
+125,LSL,programming,US,2022,3
+125,Squirrel,programming,US,2022,3
 124,Turing,programming,US,2022,3
-122,Isabelle,programming,US,2022,3
 122,Asymptote,programming,US,2022,3
+122,Isabelle,programming,US,2022,3
 120,Zeek,programming,US,2022,3
 118,F*,programming,US,2022,3
 115,Berry,programming,US,2022,3
@@ -66230,8 +66490,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,KakouneScript,programming,US,2022,3
 109,XC,programming,US,2022,3
 108,Odin,programming,US,2022,3
-107,Faust,programming,US,2022,3
 107,ZAP,programming,US,2022,3
+107,Faust,programming,US,2022,3
 106,MoonScript,programming,US,2022,3
 104,Sieve,programming,US,2022,3
 103,Lasso,programming,US,2022,3
@@ -66383,8 +66643,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 262,MATLAB,programming,VN,2022,3
 248,M4,programming,VN,2022,3
 228,CoffeeScript,programming,VN,2022,3
-202,Cython,programming,VN,2022,3
 202,R,programming,VN,2022,3
+202,Cython,programming,VN,2022,3
 201,Cuda,programming,VN,2022,3
 175,NSIS,programming,VN,2022,3
 161,QMake,programming,VN,2022,3
@@ -66637,8 +66897,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 265,Smalltalk,programming,AR,2022,4
 253,Nix,programming,AR,2022,4
 225,PLpgSQL,programming,AR,2022,4
-223,Haskell,programming,AR,2022,4
 223,Wollok,programming,AR,2022,4
+223,Haskell,programming,AR,2022,4
 208,XSLT,programming,AR,2022,4
 162,Visual Basic .NET,programming,AR,2022,4
 160,Julia,programming,AR,2022,4
@@ -66654,8 +66914,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,Mako,programming,AR,2022,4
 125,Cython,programming,AR,2022,4
 109,GAP,programming,AR,2022,4
-108,Scala,programming,AR,2022,4
 108,CoffeeScript,programming,AR,2022,4
+108,Scala,programming,AR,2022,4
 106,Prolog,programming,AR,2022,4
 105,Emacs Lisp,programming,AR,2022,4
 110,Markdown,prose,AR,2022,4
@@ -66724,8 +66984,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,Starlark,programming,AT,2022,4
 159,QMake,programming,AT,2022,4
 155,sed,programming,AT,2022,4
-147,Lex,programming,AT,2022,4
 147,Haskell,programming,AT,2022,4
+147,Lex,programming,AT,2022,4
 141,Scala,programming,AT,2022,4
 138,Tcl,programming,AT,2022,4
 124,Fortran,programming,AT,2022,4
@@ -66733,8 +66993,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Smalltalk,programming,AT,2022,4
 118,Julia,programming,AT,2022,4
 117,NSIS,programming,AT,2022,4
-115,Cython,programming,AT,2022,4
 115,GDB,programming,AT,2022,4
+115,Cython,programming,AT,2022,4
 114,NASL,programming,AT,2022,4
 113,Raku,programming,AT,2022,4
 112,TSQL,programming,AT,2022,4
@@ -66761,8 +67021,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 307,Blade,markup,AU,2022,4
 256,Sass,markup,AU,2022,4
 172,Astro,markup,AU,2022,4
-138,Twig,markup,AU,2022,4
 138,Nunjucks,markup,AU,2022,4
+138,Twig,markup,AU,2022,4
 115,PostScript,markup,AU,2022,4
 114,Stylus,markup,AU,2022,4
 111,Vim Snippet,markup,AU,2022,4
@@ -66826,8 +67086,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 247,Scheme,programming,AU,2022,4
 246,Smalltalk,programming,AU,2022,4
 246,Tcl,programming,AU,2022,4
-244,Mathematica,programming,AU,2022,4
 244,QMake,programming,AU,2022,4
+244,Mathematica,programming,AU,2022,4
 230,GDB,programming,AU,2022,4
 228,Julia,programming,AU,2022,4
 224,Raku,programming,AU,2022,4
@@ -66843,8 +67103,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 183,GAP,programming,AU,2022,4
 177,GDScript,programming,AU,2022,4
 175,Bicep,programming,AU,2022,4
-173,AutoHotkey,programming,AU,2022,4
 173,PLSQL,programming,AU,2022,4
+173,AutoHotkey,programming,AU,2022,4
 169,Elixir,programming,AU,2022,4
 168,VBScript,programming,AU,2022,4
 163,SWIG,programming,AU,2022,4
@@ -67079,8 +67339,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 587,Ruby,programming,BG,2022,4
 482,Go,programming,BG,2022,4
 430,CMake,programming,BG,2022,4
-290,PowerShell,programming,BG,2022,4
 290,Kotlin,programming,BG,2022,4
+290,PowerShell,programming,BG,2022,4
 264,Objective-C,programming,BG,2022,4
 263,Lua,programming,BG,2022,4
 243,TSQL,programming,BG,2022,4
@@ -67165,8 +67425,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 276,Twig,markup,BR,2022,4
 250,Stylus,markup,BR,2022,4
 237,Astro,markup,BR,2022,4
-180,PostScript,markup,BR,2022,4
 180,Closure Templates,markup,BR,2022,4
+180,PostScript,markup,BR,2022,4
 174,Vim Snippet,markup,BR,2022,4
 171,Nunjucks,markup,BR,2022,4
 122,Liquid,markup,BR,2022,4
@@ -67221,8 +67481,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 795,Groovy,programming,BR,2022,4
 710,Yacc,programming,BR,2022,4
 684,Portugol,programming,BR,2022,4
-663,Clojure,programming,BR,2022,4
 663,GAP,programming,BR,2022,4
+663,Clojure,programming,BR,2022,4
 653,M4,programming,BR,2022,4
 645,Scala,programming,BR,2022,4
 634,Emacs Lisp,programming,BR,2022,4
@@ -67279,8 +67539,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,SourcePawn,programming,BR,2022,4
 147,Nim,programming,BR,2022,4
 146,SWIG,programming,BR,2022,4
-143,Game Maker Language,programming,BR,2022,4
 143,Pawn,programming,BR,2022,4
+143,Game Maker Language,programming,BR,2022,4
 136,Classic ASP,programming,BR,2022,4
 130,M,programming,BR,2022,4
 125,AutoHotkey,programming,BR,2022,4
@@ -67429,8 +67689,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 697,TSQL,programming,CA,2022,4
 677,Fortran,programming,CA,2022,4
 666,Yacc,programming,CA,2022,4
-660,Haskell,programming,CA,2022,4
 660,ASP.NET,programming,CA,2022,4
+660,Haskell,programming,CA,2022,4
 604,sed,programming,CA,2022,4
 597,Tcl,programming,CA,2022,4
 549,Cuda,programming,CA,2022,4
@@ -67462,25 +67722,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 298,ANTLR,programming,CA,2022,4
 282,Verilog,programming,CA,2022,4
 280,PureBasic,programming,CA,2022,4
-278,VBScript,programming,CA,2022,4
 278,D,programming,CA,2022,4
+278,VBScript,programming,CA,2022,4
 276,Pawn,programming,CA,2022,4
 272,Forth,programming,CA,2022,4
 264,Inno Setup,programming,CA,2022,4
 256,Visual Basic .NET,programming,CA,2022,4
 243,SWIG,programming,CA,2022,4
-241,DIGITAL Command Language,programming,CA,2022,4
 241,VHDL,programming,CA,2022,4
+241,DIGITAL Command Language,programming,CA,2022,4
 234,Gnuplot,programming,CA,2022,4
 225,F#,programming,CA,2022,4
 224,Erlang,programming,CA,2022,4
 217,AppleScript,programming,CA,2022,4
-214,M,programming,CA,2022,4
 214,SmPL,programming,CA,2022,4
+214,M,programming,CA,2022,4
 209,Jsonnet,programming,CA,2022,4
 201,Nim,programming,CA,2022,4
-194,QML,programming,CA,2022,4
 194,DTrace,programming,CA,2022,4
+194,QML,programming,CA,2022,4
 189,Nu,programming,CA,2022,4
 178,OCaml,programming,CA,2022,4
 172,Standard ML,programming,CA,2022,4
@@ -67498,17 +67758,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,VBA,programming,CA,2022,4
 125,PureScript,programming,CA,2022,4
 123,Reason,programming,CA,2022,4
-120,Brainfuck,programming,CA,2022,4
 120,Zig,programming,CA,2022,4
+120,Brainfuck,programming,CA,2022,4
 120,AIDL,programming,CA,2022,4
 119,POV-Ray SDL,programming,CA,2022,4
 117,Metal,programming,CA,2022,4
 116,Scilab,programming,CA,2022,4
-113,Thrift,programming,CA,2022,4
 113,OpenSCAD,programming,CA,2022,4
-111,G-code,programming,CA,2022,4
+113,Thrift,programming,CA,2022,4
 111,Sage,programming,CA,2022,4
 111,Elm,programming,CA,2022,4
+111,G-code,programming,CA,2022,4
 110,RobotFramework,programming,CA,2022,4
 107,Ada,programming,CA,2022,4
 106,Logos,programming,CA,2022,4
@@ -67623,8 +67883,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,Mathematica,programming,CH,2022,4
 134,Prolog,programming,CH,2022,4
 133,ANTLR,programming,CH,2022,4
-132,POV-Ray SDL,programming,CH,2022,4
 132,Common Lisp,programming,CH,2022,4
+132,POV-Ray SDL,programming,CH,2022,4
 130,PureBasic,programming,CH,2022,4
 128,SmPL,programming,CH,2022,4
 127,SystemVerilog,programming,CH,2022,4
@@ -67682,8 +67942,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 409,Procfile,programming,CL,2022,4
 384,Objective-C,programming,CL,2022,4
 346,Go,programming,CL,2022,4
-344,PowerShell,programming,CL,2022,4
 344,Swift,programming,CL,2022,4
+344,PowerShell,programming,CL,2022,4
 329,R,programming,CL,2022,4
 255,Dart,programming,CL,2022,4
 243,Lua,programming,CL,2022,4
@@ -67695,8 +67955,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Smarty,programming,CL,2022,4
 128,Objective-C++,programming,CL,2022,4
 118,Perl,programming,CL,2022,4
-115,Starlark,programming,CL,2022,4
 115,Nix,programming,CL,2022,4
+115,Starlark,programming,CL,2022,4
 107,MATLAB,programming,CL,2022,4
 106,PLpgSQL,programming,CL,2022,4
 104,ASP.NET,programming,CL,2022,4
@@ -67797,8 +68057,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 851,Cython,programming,CN,2022,4
 797,sed,programming,CN,2022,4
 785,TSQL,programming,CN,2022,4
-772,ShaderLab,programming,CN,2022,4
 772,ANTLR,programming,CN,2022,4
+772,ShaderLab,programming,CN,2022,4
 771,Raku,programming,CN,2022,4
 740,GDB,programming,CN,2022,4
 730,Verilog,programming,CN,2022,4
@@ -67828,8 +68088,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 380,Smalltalk,programming,CN,2022,4
 367,HCL,programming,CN,2022,4
 346,CoffeeScript,programming,CN,2022,4
-344,Inno Setup,programming,CN,2022,4
 344,Meson,programming,CN,2022,4
+344,Inno Setup,programming,CN,2022,4
 343,Classic ASP,programming,CN,2022,4
 338,LLVM,programming,CN,2022,4
 329,M,programming,CN,2022,4
@@ -67853,8 +68113,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 208,Brainfuck,programming,CN,2022,4
 198,AppleScript,programming,CN,2022,4
 198,Logos,programming,CN,2022,4
-197,Module Management System,programming,CN,2022,4
 197,POV-Ray SDL,programming,CN,2022,4
+197,Module Management System,programming,CN,2022,4
 194,PureBasic,programming,CN,2022,4
 192,VHDL,programming,CN,2022,4
 192,Common Lisp,programming,CN,2022,4
@@ -67872,8 +68132,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 154,Stata,programming,CN,2022,4
 145,Ada,programming,CN,2022,4
 138,Processing,programming,CN,2022,4
-131,OCaml,programming,CN,2022,4
 131,ActionScript,programming,CN,2022,4
+131,OCaml,programming,CN,2022,4
 129,Arc,programming,CN,2022,4
 125,Ragel,programming,CN,2022,4
 124,VBA,programming,CN,2022,4
@@ -67949,8 +68209,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,PLpgSQL,programming,CO,2022,4
 148,Papyrus,programming,CO,2022,4
 140,Mathematica,programming,CO,2022,4
-130,Fortran,programming,CO,2022,4
 130,CoffeeScript,programming,CO,2022,4
+130,Fortran,programming,CO,2022,4
 116,Scala,programming,CO,2022,4
 3264,HTML,markup,CR,2022,4
 2895,CSS,markup,CR,2022,4
@@ -68067,8 +68327,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 429,M4,programming,CZ,2022,4
 398,Vim Script,programming,CZ,2022,4
 370,R,programming,CZ,2022,4
-358,Procfile,programming,CZ,2022,4
 358,Groovy,programming,CZ,2022,4
+358,Procfile,programming,CZ,2022,4
 338,Hack,programming,CZ,2022,4
 306,GLSL,programming,CZ,2022,4
 299,HCL,programming,CZ,2022,4
@@ -68077,8 +68337,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 273,Nix,programming,CZ,2022,4
 236,PLpgSQL,programming,CZ,2022,4
 234,Dart,programming,CZ,2022,4
-233,MATLAB,programming,CZ,2022,4
 233,Emacs Lisp,programming,CZ,2022,4
+233,MATLAB,programming,CZ,2022,4
 217,Gherkin,programming,CZ,2022,4
 216,sed,programming,CZ,2022,4
 204,Yacc,programming,CZ,2022,4
@@ -68095,8 +68355,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 134,Meson,programming,CZ,2022,4
 131,Tcl,programming,CZ,2022,4
 130,Solidity,programming,CZ,2022,4
-126,Smalltalk,programming,CZ,2022,4
 126,Mako,programming,CZ,2022,4
+126,Smalltalk,programming,CZ,2022,4
 125,NASL,programming,CZ,2022,4
 121,GDB,programming,CZ,2022,4
 117,Cython,programming,CZ,2022,4
@@ -68105,8 +68365,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,Clojure,programming,CZ,2022,4
 106,ASP.NET,programming,CZ,2022,4
 105,Pascal,programming,CZ,2022,4
-104,PLSQL,programming,CZ,2022,4
 104,OpenSCAD,programming,CZ,2022,4
+104,PLSQL,programming,CZ,2022,4
 103,Julia,programming,CZ,2022,4
 101,ANTLR,programming,CZ,2022,4
 257,YAML,data,DE,2022,4
@@ -68214,8 +68474,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 719,PLSQL,programming,DE,2022,4
 713,Elixir,programming,DE,2022,4
 685,Gnuplot,programming,DE,2022,4
-673,D,programming,DE,2022,4
 673,Mako,programming,DE,2022,4
+673,D,programming,DE,2022,4
 668,Inno Setup,programming,DE,2022,4
 656,SWIG,programming,DE,2022,4
 641,VHDL,programming,DE,2022,4
@@ -68253,8 +68513,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 313,DTrace,programming,DE,2022,4
 312,AMPL,programming,DE,2022,4
 280,AIDL,programming,DE,2022,4
-269,Scilab,programming,DE,2022,4
 269,BitBake,programming,DE,2022,4
+269,Scilab,programming,DE,2022,4
 247,Puppet,programming,DE,2022,4
 244,WebAssembly,programming,DE,2022,4
 238,SystemVerilog,programming,DE,2022,4
@@ -68262,8 +68522,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 222,Fluent,programming,DE,2022,4
 219,Xtend,programming,DE,2022,4
 219,Open Policy Agent,programming,DE,2022,4
-215,Thrift,programming,DE,2022,4
 215,VBA,programming,DE,2022,4
+215,Thrift,programming,DE,2022,4
 211,OpenEdge ABL,programming,DE,2022,4
 206,RPC,programming,DE,2022,4
 206,CUE,programming,DE,2022,4
@@ -68272,13 +68532,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 194,Bicep,programming,DE,2022,4
 192,CAP CDS,programming,DE,2022,4
 191,Module Management System,programming,DE,2022,4
-186,RenderScript,programming,DE,2022,4
 186,Crystal,programming,DE,2022,4
+186,RenderScript,programming,DE,2022,4
 182,Zig,programming,DE,2022,4
 180,JetBrains MPS,programming,DE,2022,4
+177,Logos,programming,DE,2022,4
 177,jq,programming,DE,2022,4
 177,ASL,programming,DE,2022,4
-177,Logos,programming,DE,2022,4
 174,Rebol,programming,DE,2022,4
 170,Sage,programming,DE,2022,4
 168,Stata,programming,DE,2022,4
@@ -68296,8 +68556,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Haxe,programming,DE,2022,4
 137,Apex,programming,DE,2022,4
 137,Ragel,programming,DE,2022,4
-133,Max,programming,DE,2022,4
 133,SuperCollider,programming,DE,2022,4
+133,Max,programming,DE,2022,4
 132,Vala,programming,DE,2022,4
 127,Classic ASP,programming,DE,2022,4
 126,ImageJ Macro,programming,DE,2022,4
@@ -68354,8 +68614,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 327,Vim Script,programming,DK,2022,4
 306,MATLAB,programming,DK,2022,4
 247,Procfile,programming,DK,2022,4
-240,HCL,programming,DK,2022,4
 240,Dart,programming,DK,2022,4
+240,HCL,programming,DK,2022,4
 237,Emacs Lisp,programming,DK,2022,4
 236,GLSL,programming,DK,2022,4
 235,XSLT,programming,DK,2022,4
@@ -68484,9 +68744,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 210,Kotlin,programming,EE,2022,4
 167,PowerShell,programming,EE,2022,4
 162,Objective-C,programming,EE,2022,4
+136,Rust,programming,EE,2022,4
 136,Lua,programming,EE,2022,4
 136,Swift,programming,EE,2022,4
-136,Rust,programming,EE,2022,4
 117,Perl,programming,EE,2022,4
 101,Procfile,programming,EE,2022,4
 20372,HTML,markup,EG,2022,4
@@ -68542,8 +68802,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,ShaderLab,programming,EG,2022,4
 134,HLSL,programming,EG,2022,4
 123,R,programming,EG,2022,4
-113,GLSL,programming,EG,2022,4
 113,Vim Script,programming,EG,2022,4
+113,GLSL,programming,EG,2022,4
 111,Tcl,programming,EG,2022,4
 105,YAML,data,ES,2022,4
 42378,HTML,markup,ES,2022,4
@@ -68561,8 +68821,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 689,Jinja,markup,ES,2022,4
 533,Twig,markup,ES,2022,4
 493,Pug,markup,ES,2022,4
-438,Sass,markup,ES,2022,4
 438,Svelte,markup,ES,2022,4
+438,Sass,markup,ES,2022,4
 428,Rich Text Format,markup,ES,2022,4
 269,Astro,markup,ES,2022,4
 201,Nunjucks,markup,ES,2022,4
@@ -68653,8 +68913,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,PureBasic,programming,ES,2022,4
 148,VBScript,programming,ES,2022,4
 147,SourcePawn,programming,ES,2022,4
-146,Prolog,programming,ES,2022,4
 146,Processing,programming,ES,2022,4
+146,Prolog,programming,ES,2022,4
 145,Inno Setup,programming,ES,2022,4
 141,Erlang,programming,ES,2022,4
 137,Verilog,programming,ES,2022,4
@@ -68703,6 +68963,37 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Hack,programming,ET,2022,4
 111,Forth,programming,ET,2022,4
 109,Batchfile,programming,ET,2022,4
+520,YAML,data,EU,2022,4
+348,JSON,data,EU,2022,4
+414044,HTML,markup,EU,2022,4
+339600,CSS,markup,EU,2022,4
+102715,SCSS,markup,EU,2022,4
+58123,Jupyter Notebook,markup,EU,2022,4
+27702,Vue,markup,EU,2022,4
+20856,TeX,markup,EU,2022,4
+18326,Roff,markup,EU,2022,4
+11853,Less,markup,EU,2022,4
+10030,EJS,markup,EU,2022,4
+9331,Blade,markup,EU,2022,4
+9057,Jinja,markup,EU,2022,4
+8945,Handlebars,markup,EU,2022,4
+8768,Twig,markup,EU,2022,4
+7369,Mustache,markup,EU,2022,4
+5617,Svelte,markup,EU,2022,4
+4481,Pug,markup,EU,2022,4
+3995,Rich Text Format,markup,EU,2022,4
+3827,Sass,markup,EU,2022,4
+1336,Astro,markup,EU,2022,4
+1259,Nunjucks,markup,EU,2022,4
+1133,PostScript,markup,EU,2022,4
+1098,Vim Snippet,markup,EU,2022,4
+1046,Stylus,markup,EU,2022,4
+621,Liquid,markup,EU,2022,4
+423,Haml,markup,EU,2022,4
+198,Latte,markup,EU,2022,4
+162,YASnippet,markup,EU,2022,4
+128,Slim,markup,EU,2022,4
+101,kvlang,markup,EU,2022,4
 373562,JavaScript,programming,EU,2022,4
 251804,Python,programming,EU,2022,4
 244663,Shell,programming,EU,2022,4
@@ -68867,8 +69158,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,SuperCollider,programming,EU,2022,4
 132,Vala,programming,EU,2022,4
 127,Classic ASP,programming,EU,2022,4
-126,ImageJ Macro,programming,EU,2022,4
 126,SaltStack,programming,EU,2022,4
+126,ImageJ Macro,programming,EU,2022,4
 125,Euphoria,programming,EU,2022,4
 124,Racket,programming,EU,2022,4
 118,BASIC,programming,EU,2022,4
@@ -68876,6 +69167,7 @@ num_pushers,language,language_type,iso2_code,year,quarter
 108,FreeBasic,programming,EU,2022,4
 108,Isabelle,programming,EU,2022,4
 102,Qt Script,programming,EU,2022,4
+870,Markdown,prose,EU,2022,4
 10716,HTML,markup,FI,2022,4
 8811,CSS,markup,FI,2022,4
 2043,SCSS,markup,FI,2022,4
@@ -68940,8 +69232,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,Yacc,programming,FI,2022,4
 139,sed,programming,FI,2022,4
 133,Groovy,programming,FI,2022,4
-119,Meson,programming,FI,2022,4
 119,Fortran,programming,FI,2022,4
+119,Meson,programming,FI,2022,4
 118,Gherkin,programming,FI,2022,4
 116,Tcl,programming,FI,2022,4
 103,Mathematica,programming,FI,2022,4
@@ -69057,8 +69349,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 362,SourcePawn,programming,FR,2022,4
 353,Forth,programming,FR,2022,4
 336,D,programming,FR,2022,4
-333,QML,programming,FR,2022,4
 333,ANTLR,programming,FR,2022,4
+333,QML,programming,FR,2022,4
 304,Pawn,programming,FR,2022,4
 302,GDScript,programming,FR,2022,4
 301,VHDL,programming,FR,2022,4
@@ -69085,23 +69377,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 164,XS,programming,FR,2022,4
 162,DTrace,programming,FR,2022,4
 156,OpenSCAD,programming,FR,2022,4
-150,Scilab,programming,FR,2022,4
 150,AIDL,programming,FR,2022,4
+150,Scilab,programming,FR,2022,4
 146,VBA,programming,FR,2022,4
 142,Reason,programming,FR,2022,4
 140,Puppet,programming,FR,2022,4
 136,Thrift,programming,FR,2022,4
-130,OpenEdge ABL,programming,FR,2022,4
 130,Zig,programming,FR,2022,4
-128,COBOL,programming,FR,2022,4
+130,OpenEdge ABL,programming,FR,2022,4
 128,Haxe,programming,FR,2022,4
+128,COBOL,programming,FR,2022,4
 125,Fluent,programming,FR,2022,4
 124,Open Policy Agent,programming,FR,2022,4
 121,G-code,programming,FR,2022,4
 118,UnrealScript,programming,FR,2022,4
 115,SystemVerilog,programming,FR,2022,4
-113,Logos,programming,FR,2022,4
 113,WebAssembly,programming,FR,2022,4
+113,Logos,programming,FR,2022,4
 111,PureScript,programming,FR,2022,4
 111,Apex,programming,FR,2022,4
 108,Stata,programming,FR,2022,4
@@ -69267,8 +69559,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 191,Metal,programming,GB,2022,4
 184,OpenSCAD,programming,GB,2022,4
 178,Scilab,programming,GB,2022,4
-159,Zig,programming,GB,2022,4
 159,G-code,programming,GB,2022,4
+159,Zig,programming,GB,2022,4
 157,AIDL,programming,GB,2022,4
 154,Racket,programming,GB,2022,4
 153,Rebol,programming,GB,2022,4
@@ -69279,25 +69571,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,VBA,programming,GB,2022,4
 145,RPC,programming,GB,2022,4
 145,PureScript,programming,GB,2022,4
-145,WebAssembly,programming,GB,2022,4
 145,DM,programming,GB,2022,4
+145,WebAssembly,programming,GB,2022,4
 144,Fluent,programming,GB,2022,4
 143,Apex,programming,GB,2022,4
-141,Brainfuck,programming,GB,2022,4
 141,Logos,programming,GB,2022,4
+141,Brainfuck,programming,GB,2022,4
 136,Module Management System,programming,GB,2022,4
 126,CUE,programming,GB,2022,4
 124,Haxe,programming,GB,2022,4
 122,RobotFramework,programming,GB,2022,4
 122,BASIC,programming,GB,2022,4
-118,COBOL,programming,GB,2022,4
-118,ASL,programming,GB,2022,4
 118,Sage,programming,GB,2022,4
+118,ASL,programming,GB,2022,4
+118,COBOL,programming,GB,2022,4
 117,jq,programming,GB,2022,4
-114,SuperCollider,programming,GB,2022,4
 114,Jasmin,programming,GB,2022,4
-113,Crystal,programming,GB,2022,4
+114,SuperCollider,programming,GB,2022,4
 113,Stan,programming,GB,2022,4
+113,Crystal,programming,GB,2022,4
 109,Io,programming,GB,2022,4
 108,SAS,programming,GB,2022,4
 104,q,programming,GB,2022,4
@@ -69359,8 +69651,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 401,Objective-C,programming,GH,2022,4
 387,Swift,programming,GH,2022,4
 379,Dart,programming,GH,2022,4
-325,Procfile,programming,GH,2022,4
 325,CMake,programming,GH,2022,4
+325,Procfile,programming,GH,2022,4
 245,Hack,programming,GH,2022,4
 215,Makefile,programming,GH,2022,4
 180,C#,programming,GH,2022,4
@@ -69444,9 +69736,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 194,Hack,programming,GT,2022,4
 176,Makefile,programming,GT,2022,4
 122,Ruby,programming,GT,2022,4
-118,Batchfile,programming,GT,2022,4
-118,ASP.NET,programming,GT,2022,4
 118,Objective-C,programming,GT,2022,4
+118,ASP.NET,programming,GT,2022,4
+118,Batchfile,programming,GT,2022,4
 113,CMake,programming,GT,2022,4
 109,Swift,programming,GT,2022,4
 105,Procfile,programming,GT,2022,4
@@ -69566,8 +69858,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 219,q,programming,HK,2022,4
 218,QML,programming,HK,2022,4
 214,DTrace,programming,HK,2022,4
-206,Gnuplot,programming,HK,2022,4
 206,M,programming,HK,2022,4
+206,Gnuplot,programming,HK,2022,4
 203,PureBasic,programming,HK,2022,4
 200,Metal,programming,HK,2022,4
 196,Sage,programming,HK,2022,4
@@ -69576,8 +69868,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 180,Forth,programming,HK,2022,4
 176,Elixir,programming,HK,2022,4
 173,RPC,programming,HK,2022,4
-172,AutoHotkey,programming,HK,2022,4
 172,ASL,programming,HK,2022,4
+172,AutoHotkey,programming,HK,2022,4
 170,SystemVerilog,programming,HK,2022,4
 167,Move,programming,HK,2022,4
 166,Classic ASP,programming,HK,2022,4
@@ -69590,11 +69882,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,ReScript,programming,HK,2022,4
 129,Brainfuck,programming,HK,2022,4
 129,D,programming,HK,2022,4
-127,F#,programming,HK,2022,4
-127,VHDL,programming,HK,2022,4
 127,Standard ML,programming,HK,2022,4
-127,WebAssembly,programming,HK,2022,4
+127,F#,programming,HK,2022,4
 127,Logos,programming,HK,2022,4
+127,VHDL,programming,HK,2022,4
+127,WebAssembly,programming,HK,2022,4
 124,Scilab,programming,HK,2022,4
 123,OCaml,programming,HK,2022,4
 123,Ragel,programming,HK,2022,4
@@ -69706,8 +69998,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 179,R,programming,HU,2022,4
 173,M4,programming,HU,2022,4
 165,HCL,programming,HU,2022,4
-156,ShaderLab,programming,HU,2022,4
 156,PLpgSQL,programming,HU,2022,4
+156,ShaderLab,programming,HU,2022,4
 146,Scala,programming,HU,2022,4
 144,Objective-C++,programming,HU,2022,4
 139,MATLAB,programming,HU,2022,4
@@ -69804,16 +70096,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,XS,programming,ID,2022,4
 163,SmPL,programming,ID,2022,4
 160,UnrealScript,programming,ID,2022,4
-152,GAP,programming,ID,2022,4
 152,Haxe,programming,ID,2022,4
+152,GAP,programming,ID,2022,4
 149,Mako,programming,ID,2022,4
 146,GDB,programming,ID,2022,4
 144,Prolog,programming,ID,2022,4
 142,D,programming,ID,2022,4
 141,Tcl,programming,ID,2022,4
 134,Emacs Lisp,programming,ID,2022,4
-131,Verilog,programming,ID,2022,4
 131,Processing,programming,ID,2022,4
+131,Verilog,programming,ID,2022,4
 130,Scheme,programming,ID,2022,4
 129,Cuda,programming,ID,2022,4
 119,VHDL,programming,ID,2022,4
@@ -69937,12 +70229,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 246,Scala,programming,IL,2022,4
 224,GLSL,programming,IL,2022,4
 223,PLpgSQL,programming,IL,2022,4
-211,TSQL,programming,IL,2022,4
 211,Hack,programming,IL,2022,4
+211,TSQL,programming,IL,2022,4
 210,Emacs Lisp,programming,IL,2022,4
 209,ASP.NET,programming,IL,2022,4
-206,Mako,programming,IL,2022,4
 206,Solidity,programming,IL,2022,4
+206,Mako,programming,IL,2022,4
 190,Yacc,programming,IL,2022,4
 189,Lex,programming,IL,2022,4
 178,Awk,programming,IL,2022,4
@@ -70102,8 +70394,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 497,OpenEdge ABL,programming,IN,2022,4
 494,DIGITAL Command Language,programming,IN,2022,4
 478,Mathematica,programming,IN,2022,4
-473,Jsonnet,programming,IN,2022,4
 473,NASL,programming,IN,2022,4
+473,Jsonnet,programming,IN,2022,4
 470,UnrealScript,programming,IN,2022,4
 457,q,programming,IN,2022,4
 445,Classic ASP,programming,IN,2022,4
@@ -70122,8 +70414,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 314,AppleScript,programming,IN,2022,4
 310,Thrift,programming,IN,2022,4
 307,Inno Setup,programming,IN,2022,4
-305,LLVM,programming,IN,2022,4
 305,Gnuplot,programming,IN,2022,4
+305,LLVM,programming,IN,2022,4
 302,Open Policy Agent,programming,IN,2022,4
 294,PigLatin,programming,IN,2022,4
 291,ActionScript,programming,IN,2022,4
@@ -70131,25 +70423,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 264,Objective-J,programming,IN,2022,4
 229,Ballerina,programming,IN,2022,4
 227,QML,programming,IN,2022,4
-217,Pawn,programming,IN,2022,4
 217,VBA,programming,IN,2022,4
+217,Pawn,programming,IN,2022,4
 214,Reason,programming,IN,2022,4
 209,Zig,programming,IN,2022,4
 199,Puppet,programming,IN,2022,4
 187,Xonsh,programming,IN,2022,4
 170,Io,programming,IN,2022,4
-167,AutoHotkey,programming,IN,2022,4
 167,Logos,programming,IN,2022,4
-158,Limbo,programming,IN,2022,4
+167,AutoHotkey,programming,IN,2022,4
 158,Motoko,programming,IN,2022,4
+158,Limbo,programming,IN,2022,4
 157,PEG.js,programming,IN,2022,4
 156,VCL,programming,IN,2022,4
 149,LiveScript,programming,IN,2022,4
 145,Sage,programming,IN,2022,4
 144,jq,programming,IN,2022,4
 140,AutoIt,programming,IN,2022,4
-132,WebAssembly,programming,IN,2022,4
 132,Euphoria,programming,IN,2022,4
+132,WebAssembly,programming,IN,2022,4
 129,Stata,programming,IN,2022,4
 128,ReScript,programming,IN,2022,4
 127,POV-Ray SDL,programming,IN,2022,4
@@ -70159,12 +70451,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Pony,programming,IN,2022,4
 119,RPC,programming,IN,2022,4
 119,Factor,programming,IN,2022,4
-115,SAS,programming,IN,2022,4
 115,Ring,programming,IN,2022,4
+115,SAS,programming,IN,2022,4
 114,Vala,programming,IN,2022,4
 112,AGS Script,programming,IN,2022,4
-111,RenderScript,programming,IN,2022,4
 111,Smali,programming,IN,2022,4
+111,RenderScript,programming,IN,2022,4
 109,ASL,programming,IN,2022,4
 105,Coq,programming,IN,2022,4
 101,APL,programming,IN,2022,4
@@ -70325,13 +70617,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 234,TSQL,programming,IT,2022,4
 232,Prolog,programming,IT,2022,4
 231,GDB,programming,IT,2022,4
-228,Pascal,programming,IT,2022,4
 228,ANTLR,programming,IT,2022,4
+228,Pascal,programming,IT,2022,4
 225,Haskell,programming,IT,2022,4
 217,FreeMarker,programming,IT,2022,4
 212,PLSQL,programming,IT,2022,4
-209,NSIS,programming,IT,2022,4
 209,Julia,programming,IT,2022,4
+209,NSIS,programming,IT,2022,4
 201,Gnuplot,programming,IT,2022,4
 197,SWIG,programming,IT,2022,4
 193,Scheme,programming,IT,2022,4
@@ -70340,8 +70632,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,Meson,programming,IT,2022,4
 181,QML,programming,IT,2022,4
 179,Inno Setup,programming,IT,2022,4
-169,Common Lisp,programming,IT,2022,4
 169,CoffeeScript,programming,IT,2022,4
+169,Common Lisp,programming,IT,2022,4
 168,Smalltalk,programming,IT,2022,4
 168,Visual Basic .NET,programming,IT,2022,4
 164,GAP,programming,IT,2022,4
@@ -70352,18 +70644,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,SmPL,programming,IT,2022,4
 143,Processing,programming,IT,2022,4
 134,PureBasic,programming,IT,2022,4
-132,Forth,programming,IT,2022,4
 132,M,programming,IT,2022,4
+132,Forth,programming,IT,2022,4
 129,Verilog,programming,IT,2022,4
 124,XS,programming,IT,2022,4
 121,Standard ML,programming,IT,2022,4
-117,SourcePawn,programming,IT,2022,4
 117,Mako,programming,IT,2022,4
+117,SourcePawn,programming,IT,2022,4
 113,VBScript,programming,IT,2022,4
 111,Pawn,programming,IT,2022,4
-110,D,programming,IT,2022,4
 110,GDScript,programming,IT,2022,4
 110,Erlang,programming,IT,2022,4
+110,D,programming,IT,2022,4
 106,Nu,programming,IT,2022,4
 618,HTML,markup,JM,2022,4
 545,CSS,markup,JM,2022,4
@@ -70421,8 +70713,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 347,Astro,markup,JP,2022,4
 340,Haml,markup,JP,2022,4
 295,Slim,markup,JP,2022,4
-205,Nunjucks,markup,JP,2022,4
 205,PostScript,markup,JP,2022,4
+205,Nunjucks,markup,JP,2022,4
 177,Liquid,markup,JP,2022,4
 153,Twig,markup,JP,2022,4
 145,YASnippet,markup,JP,2022,4
@@ -70487,8 +70779,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 418,Clojure,programming,JP,2022,4
 403,QMake,programming,JP,2022,4
 400,Pascal,programming,JP,2022,4
-393,SourcePawn,programming,JP,2022,4
 393,Gherkin,programming,JP,2022,4
+393,SourcePawn,programming,JP,2022,4
 392,Julia,programming,JP,2022,4
 386,NASL,programming,JP,2022,4
 379,NSIS,programming,JP,2022,4
@@ -70498,8 +70790,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 355,TSQL,programming,JP,2022,4
 334,Verilog,programming,JP,2022,4
 329,Smalltalk,programming,JP,2022,4
-323,PLSQL,programming,JP,2022,4
 323,FreeMarker,programming,JP,2022,4
+323,PLSQL,programming,JP,2022,4
 317,VBScript,programming,JP,2022,4
 313,Mako,programming,JP,2022,4
 302,ANTLR,programming,JP,2022,4
@@ -70718,8 +71010,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 433,Yacc,programming,KR,2022,4
 413,Fortran,programming,KR,2022,4
 409,Scala,programming,KR,2022,4
-390,Lex,programming,KR,2022,4
 390,Emacs Lisp,programming,KR,2022,4
+390,Lex,programming,KR,2022,4
 371,Awk,programming,KR,2022,4
 365,Raku,programming,KR,2022,4
 351,Mathematica,programming,KR,2022,4
@@ -70734,8 +71026,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 263,PureBasic,programming,KR,2022,4
 259,NSIS,programming,KR,2022,4
 224,FreeMarker,programming,KR,2022,4
-203,TSQL,programming,KR,2022,4
 203,GDB,programming,KR,2022,4
+203,TSQL,programming,KR,2022,4
 199,SWIG,programming,KR,2022,4
 192,XS,programming,KR,2022,4
 185,Forth,programming,KR,2022,4
@@ -70749,13 +71041,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,Processing,programming,KR,2022,4
 140,UnrealScript,programming,KR,2022,4
 139,Nu,programming,KR,2022,4
-138,Common Lisp,programming,KR,2022,4
 138,ANTLR,programming,KR,2022,4
+138,Common Lisp,programming,KR,2022,4
 137,Meson,programming,KR,2022,4
-128,SourcePawn,programming,KR,2022,4
 128,Sage,programming,KR,2022,4
-127,Jsonnet,programming,KR,2022,4
+128,SourcePawn,programming,KR,2022,4
 127,VBScript,programming,KR,2022,4
+127,Jsonnet,programming,KR,2022,4
 120,AutoHotkey,programming,KR,2022,4
 111,DTrace,programming,KR,2022,4
 109,Scheme,programming,KR,2022,4
@@ -70874,8 +71166,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,Rust,programming,LK,2022,4
 164,Lua,programming,LK,2022,4
 147,R,programming,LK,2022,4
-145,Solidity,programming,LK,2022,4
 145,PLSQL,programming,LK,2022,4
+145,Solidity,programming,LK,2022,4
 140,Perl,programming,LK,2022,4
 139,Scala,programming,LK,2022,4
 132,Groovy,programming,LK,2022,4
@@ -70905,8 +71197,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 651,Makefile,programming,LT,2022,4
 595,C++,programming,LT,2022,4
 549,C,programming,LT,2022,4
-339,Batchfile,programming,LT,2022,4
 339,Ruby,programming,LT,2022,4
+339,Batchfile,programming,LT,2022,4
 267,Go,programming,LT,2022,4
 232,CMake,programming,LT,2022,4
 209,Procfile,programming,LT,2022,4
@@ -70932,8 +71224,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 519,Shell,programming,LU,2022,4
 265,Dockerfile,programming,LU,2022,4
 218,TypeScript,programming,LU,2022,4
-185,Makefile,programming,LU,2022,4
 185,Java,programming,LU,2022,4
+185,Makefile,programming,LU,2022,4
 156,PHP,programming,LU,2022,4
 129,Ruby,programming,LU,2022,4
 122,C,programming,LU,2022,4
@@ -71007,8 +71299,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1816,JavaScript,programming,MD,2022,4
 724,Shell,programming,MD,2022,4
 632,Python,programming,MD,2022,4
-600,Java,programming,MD,2022,4
 600,TypeScript,programming,MD,2022,4
+600,Java,programming,MD,2022,4
 423,Dockerfile,programming,MD,2022,4
 400,C#,programming,MD,2022,4
 339,PHP,programming,MD,2022,4
@@ -71369,8 +71661,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 439,Rich Text Format,markup,NL,2022,4
 343,Pug,markup,NL,2022,4
 301,Sass,markup,NL,2022,4
-153,PostScript,markup,NL,2022,4
 153,Astro,markup,NL,2022,4
+153,PostScript,markup,NL,2022,4
 152,Vim Snippet,markup,NL,2022,4
 138,Nunjucks,markup,NL,2022,4
 133,Liquid,markup,NL,2022,4
@@ -71467,8 +71759,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,VHDL,programming,NL,2022,4
 146,Verilog,programming,NL,2022,4
 144,VBScript,programming,NL,2022,4
-139,GDScript,programming,NL,2022,4
 139,Forth,programming,NL,2022,4
+139,GDScript,programming,NL,2022,4
 129,AutoHotkey,programming,NL,2022,4
 127,Standard ML,programming,NL,2022,4
 124,OCaml,programming,NL,2022,4
@@ -71537,8 +71829,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 197,Dart,programming,NO,2022,4
 188,Gherkin,programming,NO,2022,4
 186,Objective-C++,programming,NO,2022,4
-176,Groovy,programming,NO,2022,4
 176,Fortran,programming,NO,2022,4
+176,Groovy,programming,NO,2022,4
 165,Scala,programming,NO,2022,4
 162,Tcl,programming,NO,2022,4
 159,Awk,programming,NO,2022,4
@@ -71669,8 +71961,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 289,Java,programming,PA,2022,4
 251,PHP,programming,PA,2022,4
 169,TypeScript,programming,PA,2022,4
-147,Dockerfile,programming,PA,2022,4
 147,Hack,programming,PA,2022,4
+147,Dockerfile,programming,PA,2022,4
 104,C++,programming,PA,2022,4
 13903,HTML,markup,PE,2022,4
 12141,CSS,markup,PE,2022,4
@@ -71716,8 +72008,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 178,R,programming,PE,2022,4
 141,Perl,programming,PE,2022,4
 120,Vim Script,programming,PE,2022,4
-102,Nix,programming,PE,2022,4
 102,Assembly,programming,PE,2022,4
+102,Nix,programming,PE,2022,4
 101,Smarty,programming,PE,2022,4
 24254,HTML,markup,PH,2022,4
 21181,CSS,markup,PH,2022,4
@@ -71917,16 +72209,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 380,Yacc,programming,PL,2022,4
 340,QMake,programming,PL,2022,4
 337,Lex,programming,PL,2022,4
-326,Tcl,programming,PL,2022,4
 326,Cython,programming,PL,2022,4
+326,Tcl,programming,PL,2022,4
 325,GDB,programming,PL,2022,4
 319,Mako,programming,PL,2022,4
 312,PLSQL,programming,PL,2022,4
-302,sed,programming,PL,2022,4
 302,Smalltalk,programming,PL,2022,4
+302,sed,programming,PL,2022,4
 281,ASP.NET,programming,PL,2022,4
-273,Pascal,programming,PL,2022,4
 273,Elixir,programming,PL,2022,4
+273,Pascal,programming,PL,2022,4
 260,Cuda,programming,PL,2022,4
 237,GAP,programming,PL,2022,4
 236,NASL,programming,PL,2022,4
@@ -71963,8 +72255,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,DIGITAL Command Language,programming,PL,2022,4
 115,OCaml,programming,PL,2022,4
 112,XS,programming,PL,2022,4
-112,LLVM,programming,PL,2022,4
 112,AMPL,programming,PL,2022,4
+112,LLVM,programming,PL,2022,4
 111,VHDL,programming,PL,2022,4
 110,Gnuplot,programming,PL,2022,4
 110,AutoHotkey,programming,PL,2022,4
@@ -72275,8 +72567,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 921,HCL,programming,RU,2022,4
 858,Smalltalk,programming,RU,2022,4
 776,TSQL,programming,RU,2022,4
-774,Cython,programming,RU,2022,4
 774,Scala,programming,RU,2022,4
+774,Cython,programming,RU,2022,4
 740,Yacc,programming,RU,2022,4
 729,Starlark,programming,RU,2022,4
 710,MATLAB,programming,RU,2022,4
@@ -72292,8 +72584,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 497,Fortran,programming,RU,2022,4
 472,Tcl,programming,RU,2022,4
 456,GDB,programming,RU,2022,4
-437,Mathematica,programming,RU,2022,4
 437,QML,programming,RU,2022,4
+437,Mathematica,programming,RU,2022,4
 423,Clojure,programming,RU,2022,4
 418,Raku,programming,RU,2022,4
 413,FreeMarker,programming,RU,2022,4
@@ -72348,13 +72640,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,G-code,programming,RU,2022,4
 109,VBA,programming,RU,2022,4
 109,Ren'Py,programming,RU,2022,4
-108,M,programming,RU,2022,4
 108,Nim,programming,RU,2022,4
-104,Ada,programming,RU,2022,4
+108,M,programming,RU,2022,4
 104,SAS,programming,RU,2022,4
+104,Ada,programming,RU,2022,4
+102,Haxe,programming,RU,2022,4
 102,Scilab,programming,RU,2022,4
 102,Processing,programming,RU,2022,4
-102,Haxe,programming,RU,2022,4
 1704,HTML,markup,RW,2022,4
 1556,CSS,markup,RW,2022,4
 325,SCSS,markup,RW,2022,4
@@ -72493,8 +72785,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 214,TSQL,programming,SE,2022,4
 213,Lex,programming,SE,2022,4
 211,Erlang,programming,SE,2022,4
-205,Smalltalk,programming,SE,2022,4
 205,Fortran,programming,SE,2022,4
+205,Smalltalk,programming,SE,2022,4
 204,SourcePawn,programming,SE,2022,4
 203,PLpgSQL,programming,SE,2022,4
 199,Scheme,programming,SE,2022,4
@@ -72506,14 +72798,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 161,PLSQL,programming,SE,2022,4
 157,NSIS,programming,SE,2022,4
 156,GAP,programming,SE,2022,4
-151,F#,programming,SE,2022,4
 151,AutoHotkey,programming,SE,2022,4
+151,F#,programming,SE,2022,4
 149,Raku,programming,SE,2022,4
 147,NASL,programming,SE,2022,4
 146,Pascal,programming,SE,2022,4
 143,Cython,programming,SE,2022,4
-139,Mako,programming,SE,2022,4
 139,Common Lisp,programming,SE,2022,4
+139,Mako,programming,SE,2022,4
 135,Bicep,programming,SE,2022,4
 133,SmPL,programming,SE,2022,4
 132,GDScript,programming,SE,2022,4
@@ -72679,8 +72971,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 249,Kotlin,programming,SK,2022,4
 182,Objective-C,programming,SK,2022,4
 176,Assembly,programming,SK,2022,4
-173,PowerShell,programming,SK,2022,4
 173,Hack,programming,SK,2022,4
+173,PowerShell,programming,SK,2022,4
 170,Perl,programming,SK,2022,4
 156,Lua,programming,SK,2022,4
 152,Swift,programming,SK,2022,4
@@ -72941,8 +73233,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 162,Scala,programming,TR,2022,4
 143,Awk,programming,TR,2022,4
 142,Tcl,programming,TR,2022,4
-141,Fortran,programming,TR,2022,4
 141,Cuda,programming,TR,2022,4
+141,Fortran,programming,TR,2022,4
 141,Lex,programming,TR,2022,4
 132,Cython,programming,TR,2022,4
 121,Pascal,programming,TR,2022,4
@@ -73049,16 +73341,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,Forth,programming,TW,2022,4
 126,Smalltalk,programming,TW,2022,4
 124,NSIS,programming,TW,2022,4
-120,ANTLR,programming,TW,2022,4
 120,FreeMarker,programming,TW,2022,4
+120,ANTLR,programming,TW,2022,4
 119,Haskell,programming,TW,2022,4
 117,Meson,programming,TW,2022,4
 115,SourcePawn,programming,TW,2022,4
 112,Pawn,programming,TW,2022,4
 111,XS,programming,TW,2022,4
-110,PLSQL,programming,TW,2022,4
 110,VHDL,programming,TW,2022,4
 110,SWIG,programming,TW,2022,4
+110,PLSQL,programming,TW,2022,4
 107,GAP,programming,TW,2022,4
 101,Scheme,programming,TW,2022,4
 946,HTML,markup,TZ,2022,4
@@ -73314,8 +73606,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1739,SmPL,programming,US,2022,4
 1693,AppleScript,programming,US,2022,4
 1673,DTrace,programming,US,2022,4
-1616,Erlang,programming,US,2022,4
 1616,Standard ML,programming,US,2022,4
+1616,Erlang,programming,US,2022,4
 1590,Thrift,programming,US,2022,4
 1578,SystemVerilog,programming,US,2022,4
 1577,D,programming,US,2022,4
@@ -73343,8 +73635,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 837,DM,programming,US,2022,4
 814,ActionScript,programming,US,2022,4
 814,Haxe,programming,US,2022,4
-808,Ada,programming,US,2022,4
 808,Sage,programming,US,2022,4
+808,Ada,programming,US,2022,4
 785,RenderScript,programming,US,2022,4
 777,Apex,programming,US,2022,4
 771,RPC,programming,US,2022,4
@@ -73408,8 +73700,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 276,1C Enterprise,programming,US,2022,4
 274,VCL,programming,US,2022,4
 270,LookML,programming,US,2022,4
-267,RouterOS Script,programming,US,2022,4
 267,Move,programming,US,2022,4
+267,RouterOS Script,programming,US,2022,4
 265,YARA,programming,US,2022,4
 251,Motoko,programming,US,2022,4
 250,Red,programming,US,2022,4
@@ -73431,19 +73723,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 206,ZenScript,programming,US,2022,4
 205,Cadence,programming,US,2022,4
 204,CWeb,programming,US,2022,4
-202,AngelScript,programming,US,2022,4
 202,Boogie,programming,US,2022,4
+202,AngelScript,programming,US,2022,4
 201,Eiffel,programming,US,2022,4
 196,Ren'Py,programming,US,2022,4
 194,Objective-J,programming,US,2022,4
-190,Witcher Script,programming,US,2022,4
 190,Pike,programming,US,2022,4
+190,Witcher Script,programming,US,2022,4
 185,P4,programming,US,2022,4
-178,KRL,programming,US,2022,4
 178,AutoIt,programming,US,2022,4
-176,CLIPS,programming,US,2022,4
-176,LilyPond,programming,US,2022,4
+178,KRL,programming,US,2022,4
 176,Common Workflow Language,programming,US,2022,4
+176,LilyPond,programming,US,2022,4
+176,CLIPS,programming,US,2022,4
 175,E,programming,US,2022,4
 173,LiveScript,programming,US,2022,4
 173,REXX,programming,US,2022,4
@@ -73451,8 +73743,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 167,Elvish,programming,US,2022,4
 163,Monkey C,programming,US,2022,4
 162,Alloy,programming,US,2022,4
-160,J,programming,US,2022,4
 160,Clarion,programming,US,2022,4
+160,J,programming,US,2022,4
 157,LabVIEW,programming,US,2022,4
 156,GSC,programming,US,2022,4
 155,Hy,programming,US,2022,4
@@ -73462,8 +73754,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 143,Berry,programming,US,2022,4
 142,OpenQASM,programming,US,2022,4
 141,Singularity,programming,US,2022,4
-140,Harbour,programming,US,2022,4
 140,BlitzBasic,programming,US,2022,4
+140,Harbour,programming,US,2022,4
 140,Agda,programming,US,2022,4
 137,Cool,programming,US,2022,4
 136,LSL,programming,US,2022,4
@@ -73472,26 +73764,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,Turing,programming,US,2022,4
 132,Nearley,programming,US,2022,4
 131,CartoCSS,programming,US,2022,4
+130,Modula-3,programming,US,2022,4
 130,LOLCODE,programming,US,2022,4
 130,Cypher,programming,US,2022,4
 130,Ink,programming,US,2022,4
-130,Modula-3,programming,US,2022,4
 126,SQF,programming,US,2022,4
 125,Sieve,programming,US,2022,4
-124,Filebench WML,programming,US,2022,4
 124,mIRC Script,programming,US,2022,4
 124,Zeek,programming,US,2022,4
-121,Squirrel,programming,US,2022,4
+124,Filebench WML,programming,US,2022,4
 121,Dafny,programming,US,2022,4
+121,Squirrel,programming,US,2022,4
 120,IGOR Pro,programming,US,2022,4
 119,Promela,programming,US,2022,4
 114,Asymptote,programming,US,2022,4
 113,Xtend,programming,US,2022,4
 111,F*,programming,US,2022,4
-110,Brightscript,programming,US,2022,4
 110,Idris,programming,US,2022,4
-110,KakouneScript,programming,US,2022,4
 110,Faust,programming,US,2022,4
+110,KakouneScript,programming,US,2022,4
+110,Brightscript,programming,US,2022,4
 108,Odin,programming,US,2022,4
 106,ChucK,programming,US,2022,4
 101,ZAP,programming,US,2022,4
@@ -73645,16 +73937,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 261,R,programming,VN,2022,4
 255,MATLAB,programming,VN,2022,4
 248,Smalltalk,programming,VN,2022,4
-226,CoffeeScript,programming,VN,2022,4
 226,M4,programming,VN,2022,4
+226,CoffeeScript,programming,VN,2022,4
 221,Cython,programming,VN,2022,4
 200,Cuda,programming,VN,2022,4
 162,Mako,programming,VN,2022,4
 157,Scala,programming,VN,2022,4
 156,NSIS,programming,VN,2022,4
 153,Pascal,programming,VN,2022,4
-152,PLSQL,programming,VN,2022,4
 152,QMake,programming,VN,2022,4
+152,PLSQL,programming,VN,2022,4
 141,Awk,programming,VN,2022,4
 129,GAP,programming,VN,2022,4
 123,Emacs Lisp,programming,VN,2022,4
@@ -73684,8 +73976,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,Dockerfile,programming,YE,2022,4
 122,Dart,programming,YE,2022,4
 107,Kotlin,programming,YE,2022,4
-106,Swift,programming,YE,2022,4
 106,Objective-C,programming,YE,2022,4
+106,Swift,programming,YE,2022,4
 103,Procfile,programming,YE,2022,4
 9345,HTML,markup,ZA,2022,4
 7968,CSS,markup,ZA,2022,4
@@ -73737,8 +74029,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,Smarty,programming,ZA,2022,4
 122,Vim Script,programming,ZA,2022,4
 120,Gherkin,programming,ZA,2022,4
-112,GLSL,programming,ZA,2022,4
 112,Brainfuck,programming,ZA,2022,4
+112,GLSL,programming,ZA,2022,4
 111,Nix,programming,ZA,2022,4
 104,XSLT,programming,ZA,2022,4
 103,Puppet,programming,ZA,2022,4
@@ -73841,8 +74133,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 227,Objective-C,programming,AM,2023,1
 152,PowerShell,programming,AM,2023,1
 133,Perl,programming,AM,2023,1
-104,HCL,programming,AM,2023,1
 104,Objective-C++,programming,AM,2023,1
+104,HCL,programming,AM,2023,1
 103,Lua,programming,AM,2023,1
 102,Rust,programming,AM,2023,1
 865,HTML,markup,AO,2023,1
@@ -73872,8 +74164,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 238,Astro,markup,AR,2023,1
 227,Svelte,markup,AR,2023,1
 211,Sass,markup,AR,2023,1
-149,Jinja,markup,AR,2023,1
 149,Rich Text Format,markup,AR,2023,1
+149,Jinja,markup,AR,2023,1
 119,Mustache,markup,AR,2023,1
 102,Twig,markup,AR,2023,1
 45622,JavaScript,programming,AR,2023,1
@@ -73928,23 +74220,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 160,Elixir,programming,AR,2023,1
 153,Mathematica,programming,AR,2023,1
 148,CoffeeScript,programming,AR,2023,1
-145,Prolog,programming,AR,2023,1
 145,Cython,programming,AR,2023,1
+145,Prolog,programming,AR,2023,1
 139,Awk,programming,AR,2023,1
 133,Papyrus,programming,AR,2023,1
 132,Visual Basic .NET,programming,AR,2023,1
 131,M4,programming,AR,2023,1
 130,GDScript,programming,AR,2023,1
-129,Mako,programming,AR,2023,1
 129,Tcl,programming,AR,2023,1
+129,Mako,programming,AR,2023,1
 127,Raku,programming,AR,2023,1
 118,Clojure,programming,AR,2023,1
 117,NSIS,programming,AR,2023,1
-111,Emacs Lisp,programming,AR,2023,1
 111,Forth,programming,AR,2023,1
-104,COBOL,programming,AR,2023,1
+111,Emacs Lisp,programming,AR,2023,1
 104,Julia,programming,AR,2023,1
 104,Yacc,programming,AR,2023,1
+104,COBOL,programming,AR,2023,1
 118,Markdown,prose,AR,2023,1
 9606,HTML,markup,AT,2023,1
 7661,CSS,markup,AT,2023,1
@@ -74018,18 +74310,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,NSIS,programming,AT,2023,1
 135,Cython,programming,AT,2023,1
 123,Scheme,programming,AT,2023,1
-120,Fortran,programming,AT,2023,1
 120,Solidity,programming,AT,2023,1
+120,Fortran,programming,AT,2023,1
 115,TSQL,programming,AT,2023,1
 114,Meson,programming,AT,2023,1
 113,Julia,programming,AT,2023,1
-112,Cuda,programming,AT,2023,1
 112,Pascal,programming,AT,2023,1
+112,Cuda,programming,AT,2023,1
 108,NASL,programming,AT,2023,1
 106,Raku,programming,AT,2023,1
 105,ANTLR,programming,AT,2023,1
-102,QML,programming,AT,2023,1
 102,GDB,programming,AT,2023,1
+102,QML,programming,AT,2023,1
 26562,HTML,markup,AU,2023,1
 21643,CSS,markup,AU,2023,1
 5942,SCSS,markup,AU,2023,1
@@ -74112,8 +74404,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 257,Scheme,programming,AU,2023,1
 248,Smalltalk,programming,AU,2023,1
 241,Tcl,programming,AU,2023,1
-241,QMake,programming,AU,2023,1
 241,Pascal,programming,AU,2023,1
+241,QMake,programming,AU,2023,1
 234,Bicep,programming,AU,2023,1
 229,Raku,programming,AU,2023,1
 223,SourcePawn,programming,AU,2023,1
@@ -74248,11 +74540,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,Gherkin,programming,BD,2023,1
 120,HCL,programming,BD,2023,1
 119,R,programming,BD,2023,1
+116,ShaderLab,programming,BD,2023,1
 116,HLSL,programming,BD,2023,1
 116,CoffeeScript,programming,BD,2023,1
-116,ShaderLab,programming,BD,2023,1
-113,Lex,programming,BD,2023,1
 113,Cython,programming,BD,2023,1
+113,Lex,programming,BD,2023,1
 110,Vim Script,programming,BD,2023,1
 108,Yacc,programming,BD,2023,1
 101,Fortran,programming,BD,2023,1
@@ -74265,8 +74557,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 510,Roff,markup,BE,2023,1
 416,Blade,markup,BE,2023,1
 333,Less,markup,BE,2023,1
-303,Twig,markup,BE,2023,1
 303,Jinja,markup,BE,2023,1
+303,Twig,markup,BE,2023,1
 278,Handlebars,markup,BE,2023,1
 247,Svelte,markup,BE,2023,1
 233,EJS,markup,BE,2023,1
@@ -74386,8 +74678,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,ShaderLab,programming,BG,2023,1
 117,XSLT,programming,BG,2023,1
 117,GLSL,programming,BG,2023,1
-112,Smalltalk,programming,BG,2023,1
 112,Dart,programming,BG,2023,1
+112,Smalltalk,programming,BG,2023,1
 111,PLpgSQL,programming,BG,2023,1
 109,Objective-C++,programming,BG,2023,1
 104,Nix,programming,BG,2023,1
@@ -74564,9 +74856,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 154,AIDL,programming,BR,2023,1
 149,Haxe,programming,BR,2023,1
 147,SourcePawn,programming,BR,2023,1
+143,Stata,programming,BR,2023,1
 143,Apex,programming,BR,2023,1
 143,SWIG,programming,BR,2023,1
-143,Stata,programming,BR,2023,1
 142,F#,programming,BR,2023,1
 139,Game Maker Language,programming,BR,2023,1
 138,Classic ASP,programming,BR,2023,1
@@ -74634,8 +74926,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,TSQL,programming,BY,2023,1
 134,PLpgSQL,programming,BY,2023,1
 130,Smarty,programming,BY,2023,1
-116,QMake,programming,BY,2023,1
 116,Groovy,programming,BY,2023,1
+116,QMake,programming,BY,2023,1
 110,Starlark,programming,BY,2023,1
 109,XSLT,programming,BY,2023,1
 104,HCL,programming,BY,2023,1
@@ -74773,8 +75065,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 179,OCaml,programming,CA,2023,1
 175,LLVM,programming,CA,2023,1
 171,Nim,programming,CA,2023,1
-167,AMPL,programming,CA,2023,1
 167,VBA,programming,CA,2023,1
+167,AMPL,programming,CA,2023,1
 162,XS,programming,CA,2023,1
 149,OpenSCAD,programming,CA,2023,1
 146,Jasmin,programming,CA,2023,1
@@ -74793,16 +75085,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,RobotFramework,programming,CA,2023,1
 111,Apex,programming,CA,2023,1
 111,Haxe,programming,CA,2023,1
-109,Classic ASP,programming,CA,2023,1
 109,Open Policy Agent,programming,CA,2023,1
+109,Classic ASP,programming,CA,2023,1
 108,PureScript,programming,CA,2023,1
 108,Fluent,programming,CA,2023,1
 106,Stan,programming,CA,2023,1
 105,Scilab,programming,CA,2023,1
 103,DM,programming,CA,2023,1
 102,AGS Script,programming,CA,2023,1
-102,Max,programming,CA,2023,1
 102,UnrealScript,programming,CA,2023,1
+102,Max,programming,CA,2023,1
 134,Markdown,prose,CA,2023,1
 618,HTML,markup,CD,2023,1
 580,CSS,markup,CD,2023,1
@@ -74973,8 +75265,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 316,CMake,programming,CL,2023,1
 287,Objective-C,programming,CL,2023,1
 283,Go,programming,CL,2023,1
-270,Lua,programming,CL,2023,1
 270,Swift,programming,CL,2023,1
+270,Lua,programming,CL,2023,1
 266,R,programming,CL,2023,1
 255,Procfile,programming,CL,2023,1
 234,Hack,programming,CL,2023,1
@@ -75097,8 +75389,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 577,Thrift,programming,CN,2023,1
 547,SWIG,programming,CN,2023,1
 546,XS,programming,CN,2023,1
-545,Solidity,programming,CN,2023,1
 545,Pascal,programming,CN,2023,1
+545,Solidity,programming,CN,2023,1
 542,SmPL,programming,CN,2023,1
 522,Clojure,programming,CN,2023,1
 517,Gherkin,programming,CN,2023,1
@@ -75108,8 +75400,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 473,Fortran,programming,CN,2023,1
 446,PLSQL,programming,CN,2023,1
 444,ASP.NET,programming,CN,2023,1
-439,Nix,programming,CN,2023,1
 439,HCL,programming,CN,2023,1
+439,Nix,programming,CN,2023,1
 426,GAP,programming,CN,2023,1
 423,VBScript,programming,CN,2023,1
 402,DIGITAL Command Language,programming,CN,2023,1
@@ -75134,8 +75426,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 246,DTrace,programming,CN,2023,1
 245,QML,programming,CN,2023,1
 244,Forth,programming,CN,2023,1
-242,D,programming,CN,2023,1
 242,Jsonnet,programming,CN,2023,1
+242,D,programming,CN,2023,1
 236,Julia,programming,CN,2023,1
 234,Gnuplot,programming,CN,2023,1
 224,PureBasic,programming,CN,2023,1
@@ -75171,8 +75463,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,Ragel,programming,CN,2023,1
 108,OpenEdge ABL,programming,CN,2023,1
 102,jq,programming,CN,2023,1
-101,Elixir,programming,CN,2023,1
 101,VBA,programming,CN,2023,1
+101,Elixir,programming,CN,2023,1
 193,Markdown,prose,CN,2023,1
 34931,HTML,markup,CO,2023,1
 28876,CSS,markup,CO,2023,1
@@ -75253,8 +75545,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,Tcl,programming,CO,2023,1
 123,F#,programming,CO,2023,1
 122,Haskell,programming,CO,2023,1
-119,Zig,programming,CO,2023,1
 119,Visual Basic .NET,programming,CO,2023,1
+119,Zig,programming,CO,2023,1
 110,Racket,programming,CO,2023,1
 109,Smalltalk,programming,CO,2023,1
 106,Julia,programming,CO,2023,1
@@ -75354,8 +75646,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1751,Batchfile,programming,CZ,2023,1
 1601,Ruby,programming,CZ,2023,1
 1502,CMake,programming,CZ,2023,1
-1023,PowerShell,programming,CZ,2023,1
 1023,Go,programming,CZ,2023,1
+1023,PowerShell,programming,CZ,2023,1
 821,Perl,programming,CZ,2023,1
 814,Kotlin,programming,CZ,2023,1
 740,Lua,programming,CZ,2023,1
@@ -75374,8 +75666,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 331,GLSL,programming,CZ,2023,1
 319,Awk,programming,CZ,2023,1
 307,HLSL,programming,CZ,2023,1
-303,Nix,programming,CZ,2023,1
 303,Objective-C++,programming,CZ,2023,1
+303,Nix,programming,CZ,2023,1
 287,PLpgSQL,programming,CZ,2023,1
 275,ShaderLab,programming,CZ,2023,1
 273,Procfile,programming,CZ,2023,1
@@ -75398,8 +75690,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,Meson,programming,CZ,2023,1
 146,FreeMarker,programming,CZ,2023,1
 145,Raku,programming,CZ,2023,1
-138,Mako,programming,CZ,2023,1
 138,Pascal,programming,CZ,2023,1
+138,Mako,programming,CZ,2023,1
 136,GDB,programming,CZ,2023,1
 132,ASP.NET,programming,CZ,2023,1
 129,PLSQL,programming,CZ,2023,1
@@ -75492,8 +75784,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1700,Gherkin,programming,DE,2023,1
 1666,Scala,programming,DE,2023,1
 1663,Yacc,programming,DE,2023,1
-1637,Starlark,programming,DE,2023,1
 1637,QMake,programming,DE,2023,1
+1637,Starlark,programming,DE,2023,1
 1480,sed,programming,DE,2023,1
 1439,Lex,programming,DE,2023,1
 1374,Haskell,programming,DE,2023,1
@@ -75555,9 +75847,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 380,F#,programming,DE,2023,1
 374,Jasmin,programming,DE,2023,1
 373,PureScript,programming,DE,2023,1
-367,UnrealScript,programming,DE,2023,1
 367,CUE,programming,DE,2023,1
 367,AMPL,programming,DE,2023,1
+367,UnrealScript,programming,DE,2023,1
 366,Standard ML,programming,DE,2023,1
 353,Processing,programming,DE,2023,1
 351,G-code,programming,DE,2023,1
@@ -75579,8 +75871,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 215,RPC,programming,DE,2023,1
 208,jq,programming,DE,2023,1
 203,Metal,programming,DE,2023,1
-202,Rebol,programming,DE,2023,1
 202,Module Management System,programming,DE,2023,1
+202,Rebol,programming,DE,2023,1
 199,Zig,programming,DE,2023,1
 194,ASL,programming,DE,2023,1
 187,AGS Script,programming,DE,2023,1
@@ -75595,8 +75887,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 173,Sage,programming,DE,2023,1
 170,Stata,programming,DE,2023,1
 157,Max,programming,DE,2023,1
-155,Cap'n Proto,programming,DE,2023,1
 155,SAS,programming,DE,2023,1
+155,Cap'n Proto,programming,DE,2023,1
 149,Logos,programming,DE,2023,1
 148,Brainfuck,programming,DE,2023,1
 141,Apex,programming,DE,2023,1
@@ -75604,10 +75896,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 139,EmberScript,programming,DE,2023,1
 139,Ragel,programming,DE,2023,1
 138,Visual Basic 6.0,programming,DE,2023,1
-137,XQuery,programming,DE,2023,1
 137,SuperCollider,programming,DE,2023,1
-132,Euphoria,programming,DE,2023,1
+137,XQuery,programming,DE,2023,1
 132,Crystal,programming,DE,2023,1
+132,Euphoria,programming,DE,2023,1
 130,NewLisp,programming,DE,2023,1
 128,Vala,programming,DE,2023,1
 125,Classic ASP,programming,DE,2023,1
@@ -75619,10 +75911,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,SaltStack,programming,DE,2023,1
 110,Isabelle,programming,DE,2023,1
 107,Berry,programming,DE,2023,1
-104,COBOL,programming,DE,2023,1
 104,ReScript,programming,DE,2023,1
-102,Cadence,programming,DE,2023,1
+104,COBOL,programming,DE,2023,1
 102,FreeBasic,programming,DE,2023,1
+102,Cadence,programming,DE,2023,1
 101,Limbo,programming,DE,2023,1
 367,Markdown,prose,DE,2023,1
 9747,HTML,markup,DK,2023,1
@@ -75680,8 +75972,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 240,TSQL,programming,DK,2023,1
 206,Gherkin,programming,DK,2023,1
 205,Procfile,programming,DK,2023,1
-176,PLpgSQL,programming,DK,2023,1
 176,M4,programming,DK,2023,1
+176,PLpgSQL,programming,DK,2023,1
 168,Hack,programming,DK,2023,1
 161,Smalltalk,programming,DK,2023,1
 160,Scala,programming,DK,2023,1
@@ -75763,8 +76055,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,Handlebars,markup,EC,2023,1
 5697,JavaScript,programming,EC,2023,1
 2055,TypeScript,programming,EC,2023,1
-2045,Java,programming,EC,2023,1
 2045,Python,programming,EC,2023,1
+2045,Java,programming,EC,2023,1
 1880,Shell,programming,EC,2023,1
 1308,PHP,programming,EC,2023,1
 814,C#,programming,EC,2023,1
@@ -75785,8 +76077,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,Go,programming,EC,2023,1
 123,R,programming,EC,2023,1
 107,CoffeeScript,programming,EC,2023,1
-102,TSQL,programming,EC,2023,1
 102,Perl,programming,EC,2023,1
+102,TSQL,programming,EC,2023,1
 3011,HTML,markup,EE,2023,1
 2436,CSS,markup,EE,2023,1
 652,SCSS,markup,EE,2023,1
@@ -75858,8 +76150,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 308,Gherkin,programming,EG,2023,1
 296,Verilog,programming,EG,2023,1
 268,ASP.NET,programming,EG,2023,1
-258,Lua,programming,EG,2023,1
 258,MATLAB,programming,EG,2023,1
+258,Lua,programming,EG,2023,1
 209,Perl,programming,EG,2023,1
 206,XSLT,programming,EG,2023,1
 203,Objective-C++,programming,EG,2023,1
@@ -75867,8 +76159,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 179,Rust,programming,EG,2023,1
 159,Starlark,programming,EG,2023,1
 150,HLSL,programming,EG,2023,1
-147,GLSL,programming,EG,2023,1
 147,ShaderLab,programming,EG,2023,1
+147,GLSL,programming,EG,2023,1
 132,Nix,programming,EG,2023,1
 132,R,programming,EG,2023,1
 123,Tcl,programming,EG,2023,1
@@ -75991,8 +76283,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 222,ActionScript,programming,ES,2023,1
 222,Crystal,programming,ES,2023,1
 219,Gnuplot,programming,ES,2023,1
-218,Elm,programming,ES,2023,1
 218,V,programming,ES,2023,1
+218,Elm,programming,ES,2023,1
 218,Haxe,programming,ES,2023,1
 217,NewLisp,programming,ES,2023,1
 215,Brainfuck,programming,ES,2023,1
@@ -76002,38 +76294,38 @@ num_pushers,language,language_type,iso2_code,year,quarter
 209,Limbo,programming,ES,2023,1
 208,Vala,programming,ES,2023,1
 203,Lasso,programming,ES,2023,1
-200,Racket,programming,ES,2023,1
 200,Arc,programming,ES,2023,1
-197,Jasmin,programming,ES,2023,1
+200,Racket,programming,ES,2023,1
 197,GDScript,programming,ES,2023,1
+197,Jasmin,programming,ES,2023,1
 191,Befunge,programming,ES,2023,1
 190,NASL,programming,ES,2023,1
 188,Modula-2,programming,ES,2023,1
 185,Alloy,programming,ES,2023,1
 184,LiveScript,programming,ES,2023,1
 184,Hy,programming,ES,2023,1
-183,Mercury,programming,ES,2023,1
-183,Boo,programming,ES,2023,1
 183,Red,programming,ES,2023,1
+183,Boo,programming,ES,2023,1
 183,CWeb,programming,ES,2023,1
+183,Mercury,programming,ES,2023,1
 182,Eiffel,programming,ES,2023,1
 182,Pony,programming,ES,2023,1
-181,VHDL,programming,ES,2023,1
 181,Cool,programming,ES,2023,1
+181,VHDL,programming,ES,2023,1
 180,Dylan,programming,ES,2023,1
+180,Agda,programming,ES,2023,1
+180,Turing,programming,ES,2023,1
 180,LOLCODE,programming,ES,2023,1
 180,Ballerina,programming,ES,2023,1
-180,Turing,programming,ES,2023,1
-180,Agda,programming,ES,2023,1
-179,HolyC,programming,ES,2023,1
+179,Fantom,programming,ES,2023,1
 179,Idris,programming,ES,2023,1
 179,Chapel,programming,ES,2023,1
-179,Fantom,programming,ES,2023,1
+179,HolyC,programming,ES,2023,1
 178,Nit,programming,ES,2023,1
 178,Genie,programming,ES,2023,1
-178,Ioke,programming,ES,2023,1
 178,Grace,programming,ES,2023,1
 178,Ceylon,programming,ES,2023,1
+178,Ioke,programming,ES,2023,1
 176,Self,programming,ES,2023,1
 175,SWIG,programming,ES,2023,1
 153,Verilog,programming,ES,2023,1
@@ -76082,6 +76374,38 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,Batchfile,programming,ET,2023,1
 112,Go,programming,ET,2023,1
 105,M,programming,ET,2023,1
+581,YAML,data,EU,2023,1
+401,JSON,data,EU,2023,1
+451962,HTML,markup,EU,2023,1
+373953,CSS,markup,EU,2023,1
+110376,SCSS,markup,EU,2023,1
+65728,Jupyter Notebook,markup,EU,2023,1
+30418,Vue,markup,EU,2023,1
+22782,TeX,markup,EU,2023,1
+20008,Roff,markup,EU,2023,1
+12143,Less,markup,EU,2023,1
+11387,Blade,markup,EU,2023,1
+9924,Jinja,markup,EU,2023,1
+9651,Twig,markup,EU,2023,1
+9547,Handlebars,markup,EU,2023,1
+9219,EJS,markup,EU,2023,1
+7548,Mustache,markup,EU,2023,1
+7316,Svelte,markup,EU,2023,1
+4653,Pug,markup,EU,2023,1
+4322,Sass,markup,EU,2023,1
+4026,Rich Text Format,markup,EU,2023,1
+2295,Astro,markup,EU,2023,1
+1163,PostScript,markup,EU,2023,1
+1054,Nunjucks,markup,EU,2023,1
+1045,Stylus,markup,EU,2023,1
+918,Vim Snippet,markup,EU,2023,1
+825,Liquid,markup,EU,2023,1
+389,Haml,markup,EU,2023,1
+231,Latte,markup,EU,2023,1
+210,kvlang,markup,EU,2023,1
+152,YASnippet,markup,EU,2023,1
+137,Slim,markup,EU,2023,1
+115,Mermaid,markup,EU,2023,1
 403509,JavaScript,programming,EU,2023,1
 273524,Python,programming,EU,2023,1
 255983,Shell,programming,EU,2023,1
@@ -76213,8 +76537,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 465,G-code,programming,EU,2023,1
 462,VBA,programming,EU,2023,1
 409,Apex,programming,EU,2023,1
-406,Fluent,programming,EU,2023,1
 406,Open Policy Agent,programming,EU,2023,1
+406,Fluent,programming,EU,2023,1
 402,Nu,programming,EU,2023,1
 389,BASIC,programming,EU,2023,1
 376,WebAssembly,programming,EU,2023,1
@@ -76242,8 +76566,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 208,jq,programming,EU,2023,1
 203,Lasso,programming,EU,2023,1
 202,Module Management System,programming,EU,2023,1
-200,Arc,programming,EU,2023,1
 200,Coq,programming,EU,2023,1
+200,Arc,programming,EU,2023,1
 191,Befunge,programming,EU,2023,1
 188,Modula-2,programming,EU,2023,1
 187,AGS Script,programming,EU,2023,1
@@ -76251,37 +76575,37 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,Alloy,programming,EU,2023,1
 184,LiveScript,programming,EU,2023,1
 184,Hy,programming,EU,2023,1
-183,Red,programming,EU,2023,1
 183,CWeb,programming,EU,2023,1
-183,Mercury,programming,EU,2023,1
 183,Boo,programming,EU,2023,1
+183,Mercury,programming,EU,2023,1
+183,Red,programming,EU,2023,1
 182,Eiffel,programming,EU,2023,1
 182,Pony,programming,EU,2023,1
 181,Cool,programming,EU,2023,1
 180,Turing,programming,EU,2023,1
-180,Dylan,programming,EU,2023,1
-180,Ballerina,programming,EU,2023,1
-180,Agda,programming,EU,2023,1
 180,LOLCODE,programming,EU,2023,1
-179,Chapel,programming,EU,2023,1
+180,Agda,programming,EU,2023,1
+180,Ballerina,programming,EU,2023,1
+180,Dylan,programming,EU,2023,1
 179,RenderScript,programming,EU,2023,1
+179,Chapel,programming,EU,2023,1
 179,Idris,programming,EU,2023,1
 179,Fantom,programming,EU,2023,1
 179,HolyC,programming,EU,2023,1
+178,Grace,programming,EU,2023,1
+178,Ioke,programming,EU,2023,1
 178,Nit,programming,EU,2023,1
 178,Ceylon,programming,EU,2023,1
-178,Grace,programming,EU,2023,1
 178,Genie,programming,EU,2023,1
-178,Ioke,programming,EU,2023,1
 176,Xtend,programming,EU,2023,1
 176,Self,programming,EU,2023,1
 175,Nextflow,programming,EU,2023,1
 157,Max,programming,EU,2023,1
-155,SAS,programming,EU,2023,1
 155,Cap'n Proto,programming,EU,2023,1
+155,SAS,programming,EU,2023,1
 139,Ragel,programming,EU,2023,1
-137,SuperCollider,programming,EU,2023,1
 137,XQuery,programming,EU,2023,1
+137,SuperCollider,programming,EU,2023,1
 132,Euphoria,programming,EU,2023,1
 125,Classic ASP,programming,EU,2023,1
 123,ImageJ Macro,programming,EU,2023,1
@@ -76291,8 +76615,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,Promela,programming,EU,2023,1
 107,Berry,programming,EU,2023,1
 104,ReScript,programming,EU,2023,1
-102,FreeBasic,programming,EU,2023,1
 102,Cadence,programming,EU,2023,1
+102,FreeBasic,programming,EU,2023,1
+919,Markdown,prose,EU,2023,1
 11197,HTML,markup,FI,2023,1
 9128,CSS,markup,FI,2023,1
 2189,SCSS,markup,FI,2023,1
@@ -76341,8 +76666,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 285,M4,programming,FI,2023,1
 281,Smarty,programming,FI,2023,1
 267,HCL,programming,FI,2023,1
-266,MATLAB,programming,FI,2023,1
 266,Objective-C++,programming,FI,2023,1
+266,MATLAB,programming,FI,2023,1
 256,Hack,programming,FI,2023,1
 253,Nix,programming,FI,2023,1
 252,QMake,programming,FI,2023,1
@@ -76460,8 +76785,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 562,GDB,programming,FR,2023,1
 553,Julia,programming,FR,2023,1
 552,Meson,programming,FR,2023,1
-532,TSQL,programming,FR,2023,1
 532,PLSQL,programming,FR,2023,1
+532,TSQL,programming,FR,2023,1
 527,GAP,programming,FR,2023,1
 526,Gnuplot,programming,FR,2023,1
 519,Scheme,programming,FR,2023,1
@@ -76515,13 +76840,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Puppet,programming,FR,2023,1
 139,Thrift,programming,FR,2023,1
 138,OpenSCAD,programming,FR,2023,1
-137,Open Policy Agent,programming,FR,2023,1
 137,Reason,programming,FR,2023,1
+137,Open Policy Agent,programming,FR,2023,1
 136,ActionScript,programming,FR,2023,1
 136,CUE,programming,FR,2023,1
 136,Bicep,programming,FR,2023,1
-134,COBOL,programming,FR,2023,1
 134,Visual Basic 6.0,programming,FR,2023,1
+134,COBOL,programming,FR,2023,1
 132,Sage,programming,FR,2023,1
 130,Haxe,programming,FR,2023,1
 129,WebAssembly,programming,FR,2023,1
@@ -76535,8 +76860,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,VBA,programming,FR,2023,1
 109,Promela,programming,FR,2023,1
 106,Logos,programming,FR,2023,1
-105,Jasmin,programming,FR,2023,1
 105,JetBrains MPS,programming,FR,2023,1
+105,Jasmin,programming,FR,2023,1
 104,ASL,programming,FR,2023,1
 103,Rebol,programming,FR,2023,1
 250,Markdown,prose,FR,2023,1
@@ -76641,8 +76966,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 634,NASL,programming,GB,2023,1
 577,Meson,programming,GB,2023,1
 575,GAP,programming,GB,2023,1
-561,PLSQL,programming,GB,2023,1
 561,SourcePawn,programming,GB,2023,1
+561,PLSQL,programming,GB,2023,1
 546,NSIS,programming,GB,2023,1
 533,Elixir,programming,GB,2023,1
 524,CoffeeScript,programming,GB,2023,1
@@ -76661,8 +76986,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 403,Visual Basic .NET,programming,GB,2023,1
 378,Gnuplot,programming,GB,2023,1
 377,AutoHotkey,programming,GB,2023,1
-376,Processing,programming,GB,2023,1
 376,VBScript,programming,GB,2023,1
+376,Processing,programming,GB,2023,1
 371,AppleScript,programming,GB,2023,1
 370,D,programming,GB,2023,1
 367,OCaml,programming,GB,2023,1
@@ -76672,8 +76997,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 346,SmPL,programming,GB,2023,1
 343,Open Policy Agent,programming,GB,2023,1
 326,GDScript,programming,GB,2023,1
-320,Jsonnet,programming,GB,2023,1
 320,Cycript,programming,GB,2023,1
+320,Jsonnet,programming,GB,2023,1
 316,PureBasic,programming,GB,2023,1
 308,DTrace,programming,GB,2023,1
 302,VHDL,programming,GB,2023,1
@@ -76692,16 +77017,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 211,POV-Ray SDL,programming,GB,2023,1
 210,Elm,programming,GB,2023,1
 192,Scilab,programming,GB,2023,1
-191,Metal,programming,GB,2023,1
 191,OpenSCAD,programming,GB,2023,1
+191,Metal,programming,GB,2023,1
 189,OpenEdge ABL,programming,GB,2023,1
 187,G-code,programming,GB,2023,1
 186,WebAssembly,programming,GB,2023,1
 181,AIDL,programming,GB,2023,1
 176,CUE,programming,GB,2023,1
 172,Zig,programming,GB,2023,1
-167,Reason,programming,GB,2023,1
 167,PureScript,programming,GB,2023,1
+167,Reason,programming,GB,2023,1
 164,ASL,programming,GB,2023,1
 161,RPC,programming,GB,2023,1
 157,UnrealScript,programming,GB,2023,1
@@ -76719,15 +77044,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 134,Jasmin,programming,GB,2023,1
 133,Racket,programming,GB,2023,1
 131,COBOL,programming,GB,2023,1
-129,SuperCollider,programming,GB,2023,1
 129,Rebol,programming,GB,2023,1
+129,SuperCollider,programming,GB,2023,1
 128,Haxe,programming,GB,2023,1
 123,Visual Basic 6.0,programming,GB,2023,1
 122,Max,programming,GB,2023,1
 119,RobotFramework,programming,GB,2023,1
 114,Brainfuck,programming,GB,2023,1
-114,Cap'n Proto,programming,GB,2023,1
 114,AGS Script,programming,GB,2023,1
+114,Cap'n Proto,programming,GB,2023,1
 113,Sage,programming,GB,2023,1
 112,SAS,programming,GB,2023,1
 111,JetBrains MPS,programming,GB,2023,1
@@ -76848,8 +77173,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 157,ShaderLab,programming,GR,2023,1
 156,GLSL,programming,GR,2023,1
 155,HCL,programming,GR,2023,1
-144,XSLT,programming,GR,2023,1
 144,Vim Script,programming,GR,2023,1
+144,XSLT,programming,GR,2023,1
 128,M4,programming,GR,2023,1
 119,PLpgSQL,programming,GR,2023,1
 109,Solidity,programming,GR,2023,1
@@ -76965,16 +77290,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 441,Fortran,programming,HK,2023,1
 435,SWIG,programming,HK,2023,1
 427,GAP,programming,HK,2023,1
-412,XS,programming,HK,2023,1
 412,TSQL,programming,HK,2023,1
+412,XS,programming,HK,2023,1
 407,SourcePawn,programming,HK,2023,1
 394,UnrealScript,programming,HK,2023,1
 390,Pascal,programming,HK,2023,1
 379,PLSQL,programming,HK,2023,1
 356,Mathematica,programming,HK,2023,1
 350,Jsonnet,programming,HK,2023,1
-350,CoffeeScript,programming,HK,2023,1
 350,Meson,programming,HK,2023,1
+350,CoffeeScript,programming,HK,2023,1
 332,Pawn,programming,HK,2023,1
 326,DIGITAL Command Language,programming,HK,2023,1
 305,VBScript,programming,HK,2023,1
@@ -76993,8 +77318,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 237,Metal,programming,HK,2023,1
 224,ASP.NET,programming,HK,2023,1
 214,DTrace,programming,HK,2023,1
-207,q,programming,HK,2023,1
 207,Common Lisp,programming,HK,2023,1
+207,q,programming,HK,2023,1
 205,Forth,programming,HK,2023,1
 200,M,programming,HK,2023,1
 195,Sage,programming,HK,2023,1
@@ -77002,14 +77327,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,QML,programming,HK,2023,1
 184,ASL,programming,HK,2023,1
 178,RPC,programming,HK,2023,1
-175,Erlang,programming,HK,2023,1
 175,SystemVerilog,programming,HK,2023,1
+175,Erlang,programming,HK,2023,1
 172,Classic ASP,programming,HK,2023,1
 166,D,programming,HK,2023,1
 164,Prolog,programming,HK,2023,1
 162,VHDL,programming,HK,2023,1
-157,POV-Ray SDL,programming,HK,2023,1
 157,Ragel,programming,HK,2023,1
+157,POV-Ray SDL,programming,HK,2023,1
 156,AspectJ,programming,HK,2023,1
 156,Visual Basic .NET,programming,HK,2023,1
 155,Standard ML,programming,HK,2023,1
@@ -77017,13 +77342,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,Elixir,programming,HK,2023,1
 144,RenderScript,programming,HK,2023,1
 139,WebAssembly,programming,HK,2023,1
-138,Brainfuck,programming,HK,2023,1
 138,Ada,programming,HK,2023,1
+138,Brainfuck,programming,HK,2023,1
 133,Terra,programming,HK,2023,1
-128,ReScript,programming,HK,2023,1
 128,Module Management System,programming,HK,2023,1
-123,F#,programming,HK,2023,1
+128,ReScript,programming,HK,2023,1
 123,Scilab,programming,HK,2023,1
+123,F#,programming,HK,2023,1
 122,OCaml,programming,HK,2023,1
 120,Open Policy Agent,programming,HK,2023,1
 115,Logos,programming,HK,2023,1
@@ -77081,8 +77406,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Hack,programming,HR,2023,1
 111,Perl,programming,HR,2023,1
 105,Procfile,programming,HR,2023,1
-104,Solidity,programming,HR,2023,1
 104,ASP.NET,programming,HR,2023,1
+104,Solidity,programming,HR,2023,1
 192,HTML,markup,HT,2023,1
 177,CSS,markup,HT,2023,1
 167,JavaScript,programming,HT,2023,1
@@ -77298,8 +77623,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Awk,programming,IE,2023,1
 109,Processing,programming,IE,2023,1
 108,Cython,programming,IE,2023,1
-104,MATLAB,programming,IE,2023,1
 104,PLpgSQL,programming,IE,2023,1
+104,MATLAB,programming,IE,2023,1
 16690,HTML,markup,IL,2023,1
 13224,CSS,markup,IL,2023,1
 3571,SCSS,markup,IL,2023,1
@@ -77357,8 +77682,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 254,PLpgSQL,programming,IL,2023,1
 254,Emacs Lisp,programming,IL,2023,1
 247,Gherkin,programming,IL,2023,1
-244,TSQL,programming,IL,2023,1
 244,GLSL,programming,IL,2023,1
+244,TSQL,programming,IL,2023,1
 243,Scala,programming,IL,2023,1
 223,Cython,programming,IL,2023,1
 218,Solidity,programming,IL,2023,1
@@ -77470,8 +77795,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 950,Raku,programming,IN,2023,1
 936,Clojure,programming,IN,2023,1
 927,Cuda,programming,IN,2023,1
-889,Apex,programming,IN,2023,1
 889,Verilog,programming,IN,2023,1
+889,Apex,programming,IN,2023,1
 863,ANTLR,programming,IN,2023,1
 735,PLSQL,programming,IN,2023,1
 724,GDB,programming,IN,2023,1
@@ -77509,8 +77834,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 341,Fluent,programming,IN,2023,1
 330,Open Policy Agent,programming,IN,2023,1
 327,Inno Setup,programming,IN,2023,1
-308,OpenEdge ABL,programming,IN,2023,1
 308,AppleScript,programming,IN,2023,1
+308,OpenEdge ABL,programming,IN,2023,1
 305,ActionScript,programming,IN,2023,1
 301,Gnuplot,programming,IN,2023,1
 295,Pawn,programming,IN,2023,1
@@ -77522,24 +77847,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 248,Puppet,programming,IN,2023,1
 243,D,programming,IN,2023,1
 238,Rebol,programming,IN,2023,1
-235,Standard ML,programming,IN,2023,1
 235,M,programming,IN,2023,1
+235,Standard ML,programming,IN,2023,1
 232,Processing,programming,IN,2023,1
 209,VHDL,programming,IN,2023,1
 200,PEG.js,programming,IN,2023,1
 189,PigLatin,programming,IN,2023,1
-185,GDScript,programming,IN,2023,1
 185,COBOL,programming,IN,2023,1
+185,GDScript,programming,IN,2023,1
 182,jq,programming,IN,2023,1
 176,GSC,programming,IN,2023,1
 175,OCaml,programming,IN,2023,1
 165,Xonsh,programming,IN,2023,1
-164,HiveQL,programming,IN,2023,1
 164,POV-Ray SDL,programming,IN,2023,1
+164,HiveQL,programming,IN,2023,1
 155,Metal,programming,IN,2023,1
 153,VCL,programming,IN,2023,1
-152,Cadence,programming,IN,2023,1
 152,WebAssembly,programming,IN,2023,1
+152,Cadence,programming,IN,2023,1
 151,AMPL,programming,IN,2023,1
 150,Ada,programming,IN,2023,1
 147,Sage,programming,IN,2023,1
@@ -77550,9 +77875,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,BitBake,programming,IN,2023,1
 130,Objective-J,programming,IN,2023,1
 129,ReScript,programming,IN,2023,1
-127,ABAP,programming,IN,2023,1
 127,Motoko,programming,IN,2023,1
 127,CUE,programming,IN,2023,1
+127,ABAP,programming,IN,2023,1
 126,Elm,programming,IN,2023,1
 125,RPC,programming,IN,2023,1
 124,ASL,programming,IN,2023,1
@@ -77714,8 +78039,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 389,Tcl,programming,IT,2023,1
 381,Yacc,programming,IT,2023,1
 377,Scala,programming,IT,2023,1
-371,Emacs Lisp,programming,IT,2023,1
 371,Starlark,programming,IT,2023,1
+371,Emacs Lisp,programming,IT,2023,1
 364,QMake,programming,IT,2023,1
 364,Gherkin,programming,IT,2023,1
 349,Cuda,programming,IT,2023,1
@@ -77726,8 +78051,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 257,Pascal,programming,IT,2023,1
 247,ANTLR,programming,IT,2023,1
 247,NASL,programming,IT,2023,1
-235,GDB,programming,IT,2023,1
 235,TSQL,programming,IT,2023,1
+235,GDB,programming,IT,2023,1
 227,Raku,programming,IT,2023,1
 224,VHDL,programming,IT,2023,1
 221,Haskell,programming,IT,2023,1
@@ -77737,8 +78062,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 198,Gnuplot,programming,IT,2023,1
 196,Meson,programming,IT,2023,1
 195,PLSQL,programming,IT,2023,1
-188,SWIG,programming,IT,2023,1
 188,Mathematica,programming,IT,2023,1
+188,SWIG,programming,IT,2023,1
 187,ASP.NET,programming,IT,2023,1
 184,Common Lisp,programming,IT,2023,1
 180,Scheme,programming,IT,2023,1
@@ -77750,8 +78075,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,M,programming,IT,2023,1
 154,Smalltalk,programming,IT,2023,1
 149,Forth,programming,IT,2023,1
-145,Verilog,programming,IT,2023,1
 145,Elixir,programming,IT,2023,1
+145,Verilog,programming,IT,2023,1
 136,PureBasic,programming,IT,2023,1
 134,Processing,programming,IT,2023,1
 131,Mako,programming,IT,2023,1
@@ -77906,15 +78231,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 299,Elixir,programming,JP,2023,1
 292,ASP.NET,programming,JP,2023,1
 286,SmPL,programming,JP,2023,1
-281,Meson,programming,JP,2023,1
 281,XS,programming,JP,2023,1
+281,Meson,programming,JP,2023,1
 279,SWIG,programming,JP,2023,1
 265,Gnuplot,programming,JP,2023,1
 260,GAP,programming,JP,2023,1
 254,Prolog,programming,JP,2023,1
 251,AIDL,programming,JP,2023,1
-244,Jsonnet,programming,JP,2023,1
 244,AppleScript,programming,JP,2023,1
+244,Jsonnet,programming,JP,2023,1
 239,OCaml,programming,JP,2023,1
 238,Pawn,programming,JP,2023,1
 232,Processing,programming,JP,2023,1
@@ -77925,8 +78250,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 216,LLVM,programming,JP,2023,1
 208,F#,programming,JP,2023,1
 202,Forth,programming,JP,2023,1
-201,Visual Basic .NET,programming,JP,2023,1
 201,Inno Setup,programming,JP,2023,1
+201,Visual Basic .NET,programming,JP,2023,1
 187,DTrace,programming,JP,2023,1
 185,POV-Ray SDL,programming,JP,2023,1
 181,Erlang,programming,JP,2023,1
@@ -77947,15 +78272,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,Ragel,programming,JP,2023,1
 118,Elm,programming,JP,2023,1
 116,RPC,programming,JP,2023,1
-115,RenderScript,programming,JP,2023,1
 115,Sage,programming,JP,2023,1
+115,RenderScript,programming,JP,2023,1
 113,Zig,programming,JP,2023,1
 112,WebAssembly,programming,JP,2023,1
 111,Module Management System,programming,JP,2023,1
 109,Logos,programming,JP,2023,1
 107,GDScript,programming,JP,2023,1
-102,ASL,programming,JP,2023,1
 102,Ada,programming,JP,2023,1
+102,ASL,programming,JP,2023,1
 101,Brainfuck,programming,JP,2023,1
 234,Markdown,prose,JP,2023,1
 14396,HTML,markup,KE,2023,1
@@ -78045,8 +78370,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1798,JavaScript,programming,KH,2023,1
 658,Shell,programming,KH,2023,1
 615,PHP,programming,KH,2023,1
-475,TypeScript,programming,KH,2023,1
 475,Java,programming,KH,2023,1
+475,TypeScript,programming,KH,2023,1
 377,Python,programming,KH,2023,1
 301,C++,programming,KH,2023,1
 273,Objective-C,programming,KH,2023,1
@@ -78129,11 +78454,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 534,Groovy,programming,KR,2023,1
 420,Scala,programming,KR,2023,1
 407,Gherkin,programming,KR,2023,1
-382,GAP,programming,KR,2023,1
 382,Mathematica,programming,KR,2023,1
+382,GAP,programming,KR,2023,1
 369,ASP.NET,programming,KR,2023,1
-354,Emacs Lisp,programming,KR,2023,1
 354,Fortran,programming,KR,2023,1
+354,Emacs Lisp,programming,KR,2023,1
 344,Mako,programming,KR,2023,1
 337,PLpgSQL,programming,KR,2023,1
 334,Yacc,programming,KR,2023,1
@@ -78162,9 +78487,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 136,QML,programming,KR,2023,1
 133,Nu,programming,KR,2023,1
 133,Pawn,programming,KR,2023,1
-129,ANTLR,programming,KR,2023,1
-129,AutoHotkey,programming,KR,2023,1
 129,Visual Basic .NET,programming,KR,2023,1
+129,AutoHotkey,programming,KR,2023,1
+129,ANTLR,programming,KR,2023,1
 127,Jsonnet,programming,KR,2023,1
 126,AIDL,programming,KR,2023,1
 124,Haskell,programming,KR,2023,1
@@ -78346,8 +78671,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 225,Java,programming,LU,2023,1
 197,Makefile,programming,LU,2023,1
 145,PHP,programming,LU,2023,1
-138,Ruby,programming,LU,2023,1
 138,C++,programming,LU,2023,1
+138,Ruby,programming,LU,2023,1
 136,C,programming,LU,2023,1
 113,Batchfile,programming,LU,2023,1
 2777,HTML,markup,LV,2023,1
@@ -78655,8 +78980,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 272,Less,markup,MY,2023,1
 222,Roff,markup,MY,2023,1
 194,EJS,markup,MY,2023,1
-133,Handlebars,markup,MY,2023,1
 133,Svelte,markup,MY,2023,1
+133,Handlebars,markup,MY,2023,1
 105,TeX,markup,MY,2023,1
 7616,JavaScript,programming,MY,2023,1
 3702,Python,programming,MY,2023,1
@@ -78689,8 +79014,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 157,HLSL,programming,MY,2023,1
 151,ShaderLab,programming,MY,2023,1
 141,Objective-C++,programming,MY,2023,1
-138,Nix,programming,MY,2023,1
 138,HCL,programming,MY,2023,1
+138,Nix,programming,MY,2023,1
 129,Smarty,programming,MY,2023,1
 121,Starlark,programming,MY,2023,1
 120,Vim Script,programming,MY,2023,1
@@ -78895,8 +79220,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 169,VHDL,programming,NL,2023,1
 165,SmPL,programming,NL,2023,1
 163,OCaml,programming,NL,2023,1
-161,AppleScript,programming,NL,2023,1
 161,DIGITAL Command Language,programming,NL,2023,1
+161,AppleScript,programming,NL,2023,1
 160,Erlang,programming,NL,2023,1
 157,VBScript,programming,NL,2023,1
 150,CoffeeScript,programming,NL,2023,1
@@ -78909,8 +79234,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,Pawn,programming,NL,2023,1
 128,Standard ML,programming,NL,2023,1
 127,Jsonnet,programming,NL,2023,1
-126,PureBasic,programming,NL,2023,1
 126,Nim,programming,NL,2023,1
+126,PureBasic,programming,NL,2023,1
 121,Visual Basic .NET,programming,NL,2023,1
 115,RobotFramework,programming,NL,2023,1
 113,Puppet,programming,NL,2023,1
@@ -78983,8 +79308,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 143,Yacc,programming,NO,2023,1
 137,Hack,programming,NO,2023,1
 130,VBScript,programming,NO,2023,1
-128,GDB,programming,NO,2023,1
 128,TSQL,programming,NO,2023,1
+128,GDB,programming,NO,2023,1
 126,Lex,programming,NO,2023,1
 124,sed,programming,NO,2023,1
 117,Scala,programming,NO,2023,1
@@ -78995,8 +79320,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Smalltalk,programming,NO,2023,1
 105,Clojure,programming,NO,2023,1
 104,Pascal,programming,NO,2023,1
-103,Verilog,programming,NO,2023,1
 103,SourcePawn,programming,NO,2023,1
+103,Verilog,programming,NO,2023,1
 102,Meson,programming,NO,2023,1
 12066,HTML,markup,NP,2023,1
 10224,CSS,markup,NP,2023,1
@@ -79134,8 +79459,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 826,C,programming,PE,2023,1
 749,Kotlin,programming,PE,2023,1
 553,Swift,programming,PE,2023,1
-540,Ruby,programming,PE,2023,1
 540,Objective-C,programming,PE,2023,1
+540,Ruby,programming,PE,2023,1
 530,Hack,programming,PE,2023,1
 524,CMake,programming,PE,2023,1
 501,Makefile,programming,PE,2023,1
@@ -79166,8 +79491,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 310,Roff,markup,PH,2023,1
 237,Svelte,markup,PH,2023,1
 232,Handlebars,markup,PH,2023,1
-142,Pug,markup,PH,2023,1
 142,TeX,markup,PH,2023,1
+142,Pug,markup,PH,2023,1
 136,Sass,markup,PH,2023,1
 110,Astro,markup,PH,2023,1
 21221,JavaScript,programming,PH,2023,1
@@ -79202,8 +79527,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 218,Assembly,programming,PH,2023,1
 204,ASP.NET,programming,PH,2023,1
 199,Perl,programming,PH,2023,1
-185,Vim Script,programming,PH,2023,1
 185,Starlark,programming,PH,2023,1
+185,Vim Script,programming,PH,2023,1
 176,Solidity,programming,PH,2023,1
 163,Gherkin,programming,PH,2023,1
 152,TSQL,programming,PH,2023,1
@@ -79229,8 +79554,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,Jinja,markup,PK,2023,1
 134,Sass,markup,PK,2023,1
 134,Mustache,markup,PK,2023,1
-101,Liquid,markup,PK,2023,1
 101,Svelte,markup,PK,2023,1
+101,Liquid,markup,PK,2023,1
 27627,JavaScript,programming,PK,2023,1
 8988,Python,programming,PK,2023,1
 8364,Shell,programming,PK,2023,1
@@ -79269,8 +79594,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,HCL,programming,PK,2023,1
 169,Gherkin,programming,PK,2023,1
 158,XSLT,programming,PK,2023,1
-151,R,programming,PK,2023,1
 151,CoffeeScript,programming,PK,2023,1
+151,R,programming,PK,2023,1
 137,MATLAB,programming,PK,2023,1
 127,GLSL,programming,PK,2023,1
 126,PLpgSQL,programming,PK,2023,1
@@ -79294,8 +79619,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 346,Pug,markup,PL,2023,1
 336,Rich Text Format,markup,PL,2023,1
 245,Astro,markup,PL,2023,1
-106,kvlang,markup,PL,2023,1
 106,Vim Snippet,markup,PL,2023,1
+106,kvlang,markup,PL,2023,1
 102,Stylus,markup,PL,2023,1
 38272,JavaScript,programming,PL,2023,1
 24179,Python,programming,PL,2023,1
@@ -79360,8 +79685,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 272,Pascal,programming,PL,2023,1
 271,sed,programming,PL,2023,1
 266,GAP,programming,PL,2023,1
-263,Fortran,programming,PL,2023,1
 263,NSIS,programming,PL,2023,1
+263,Fortran,programming,PL,2023,1
 259,NASL,programming,PL,2023,1
 254,Meson,programming,PL,2023,1
 250,SmPL,programming,PL,2023,1
@@ -79398,8 +79723,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,OCaml,programming,PL,2023,1
 111,DIGITAL Command Language,programming,PL,2023,1
 111,LLVM,programming,PL,2023,1
-107,AppleScript,programming,PL,2023,1
 107,AutoHotkey,programming,PL,2023,1
+107,AppleScript,programming,PL,2023,1
 107,UnrealScript,programming,PL,2023,1
 106,Nu,programming,PL,2023,1
 104,EmberScript,programming,PL,2023,1
@@ -79483,9 +79808,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 400,Dart,programming,PT,2023,1
 368,HCL,programming,PT,2023,1
 336,Vim Script,programming,PT,2023,1
-329,Solidity,programming,PT,2023,1
-329,Hack,programming,PT,2023,1
 329,Smarty,programming,PT,2023,1
+329,Hack,programming,PT,2023,1
+329,Solidity,programming,PT,2023,1
 327,R,programming,PT,2023,1
 301,MATLAB,programming,PT,2023,1
 271,Prolog,programming,PT,2023,1
@@ -79573,8 +79898,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 405,HLSL,programming,RO,2023,1
 393,ShaderLab,programming,RO,2023,1
 370,GLSL,programming,RO,2023,1
-331,Dart,programming,RO,2023,1
 331,Hack,programming,RO,2023,1
+331,Dart,programming,RO,2023,1
 324,Yacc,programming,RO,2023,1
 296,Smarty,programming,RO,2023,1
 293,TSQL,programming,RO,2023,1
@@ -79585,17 +79910,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 237,Objective-C++,programming,RO,2023,1
 235,Solidity,programming,RO,2023,1
 235,XSLT,programming,RO,2023,1
-219,Vim Script,programming,RO,2023,1
 219,Haskell,programming,RO,2023,1
+219,Vim Script,programming,RO,2023,1
 203,M4,programming,RO,2023,1
 195,Awk,programming,RO,2023,1
 189,Starlark,programming,RO,2023,1
 187,ASP.NET,programming,RO,2023,1
-167,R,programming,RO,2023,1
 167,Nix,programming,RO,2023,1
+167,R,programming,RO,2023,1
 166,Tcl,programming,RO,2023,1
-160,Verilog,programming,RO,2023,1
 160,Prolog,programming,RO,2023,1
+160,Verilog,programming,RO,2023,1
 155,PLpgSQL,programming,RO,2023,1
 151,Groovy,programming,RO,2023,1
 138,PLSQL,programming,RO,2023,1
@@ -79631,24 +79956,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 496,Batchfile,programming,RS,2023,1
 477,CMake,programming,RS,2023,1
 371,Kotlin,programming,RS,2023,1
-290,PowerShell,programming,RS,2023,1
 290,Hack,programming,RS,2023,1
+290,PowerShell,programming,RS,2023,1
 278,Objective-C,programming,RS,2023,1
 265,Rust,programming,RS,2023,1
 263,Swift,programming,RS,2023,1
 233,Assembly,programming,RS,2023,1
 208,Lua,programming,RS,2023,1
 161,Perl,programming,RS,2023,1
-159,Solidity,programming,RS,2023,1
 159,GLSL,programming,RS,2023,1
+159,Solidity,programming,RS,2023,1
 151,HCL,programming,RS,2023,1
 139,HLSL,programming,RS,2023,1
 131,Procfile,programming,RS,2023,1
 130,Vim Script,programming,RS,2023,1
 125,ASP.NET,programming,RS,2023,1
 122,Smarty,programming,RS,2023,1
-121,ShaderLab,programming,RS,2023,1
 121,Objective-C++,programming,RS,2023,1
+121,ShaderLab,programming,RS,2023,1
 119,Gherkin,programming,RS,2023,1
 114,XSLT,programming,RS,2023,1
 112,Dart,programming,RS,2023,1
@@ -79742,8 +80067,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 478,Haskell,programming,RU,2023,1
 445,GDB,programming,RU,2023,1
 440,Tcl,programming,RU,2023,1
-439,Clojure,programming,RU,2023,1
 439,Raku,programming,RU,2023,1
+439,Clojure,programming,RU,2023,1
 437,QML,programming,RU,2023,1
 413,sed,programming,RU,2023,1
 409,NASL,programming,RU,2023,1
@@ -79950,14 +80275,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 203,Fortran,programming,SE,2023,1
 200,Smalltalk,programming,SE,2023,1
 198,Cython,programming,SE,2023,1
-194,SourcePawn,programming,SE,2023,1
 194,Julia,programming,SE,2023,1
+194,SourcePawn,programming,SE,2023,1
 193,Clojure,programming,SE,2023,1
 192,Erlang,programming,SE,2023,1
 191,Cuda,programming,SE,2023,1
 173,Meson,programming,SE,2023,1
-170,GAP,programming,SE,2023,1
 170,Pascal,programming,SE,2023,1
+170,GAP,programming,SE,2023,1
 167,NSIS,programming,SE,2023,1
 158,PLSQL,programming,SE,2023,1
 158,Raku,programming,SE,2023,1
@@ -79966,14 +80291,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,AutoHotkey,programming,SE,2023,1
 138,GDScript,programming,SE,2023,1
 133,Solidity,programming,SE,2023,1
+131,ANTLR,programming,SE,2023,1
 131,SmPL,programming,SE,2023,1
 131,Inno Setup,programming,SE,2023,1
-131,ANTLR,programming,SE,2023,1
 130,Mako,programming,SE,2023,1
-125,Common Lisp,programming,SE,2023,1
 125,Verilog,programming,SE,2023,1
-124,SWIG,programming,SE,2023,1
+125,Common Lisp,programming,SE,2023,1
 124,VHDL,programming,SE,2023,1
+124,SWIG,programming,SE,2023,1
 119,D,programming,SE,2023,1
 116,AppleScript,programming,SE,2023,1
 113,DIGITAL Command Language,programming,SE,2023,1
@@ -80043,8 +80368,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 452,Hack,programming,SG,2023,1
 436,GLSL,programming,SG,2023,1
 425,PLpgSQL,programming,SG,2023,1
-413,Awk,programming,SG,2023,1
 413,Lex,programming,SG,2023,1
+413,Awk,programming,SG,2023,1
 387,Groovy,programming,SG,2023,1
 385,Scala,programming,SG,2023,1
 373,Cython,programming,SG,2023,1
@@ -80063,8 +80388,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 197,Bicep,programming,SG,2023,1
 189,NASL,programming,SG,2023,1
 180,Fortran,programming,SG,2023,1
-173,SWIG,programming,SG,2023,1
 173,Pascal,programming,SG,2023,1
+173,SWIG,programming,SG,2023,1
 171,ASP.NET,programming,SG,2023,1
 168,Thrift,programming,SG,2023,1
 164,SmPL,programming,SG,2023,1
@@ -80080,8 +80405,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,AIDL,programming,SG,2023,1
 125,Pawn,programming,SG,2023,1
 119,Meson,programming,SG,2023,1
-117,CoffeeScript,programming,SG,2023,1
 117,GAP,programming,SG,2023,1
+117,CoffeeScript,programming,SG,2023,1
 113,PLSQL,programming,SG,2023,1
 112,Smalltalk,programming,SG,2023,1
 108,VBScript,programming,SG,2023,1
@@ -80206,8 +80531,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 192,C++,programming,SV,2023,1
 174,Dockerfile,programming,SV,2023,1
 130,C,programming,SV,2023,1
-104,Swift,programming,SV,2023,1
 104,Objective-C,programming,SV,2023,1
+104,Swift,programming,SV,2023,1
 897,HTML,markup,SY,2023,1
 810,CSS,markup,SY,2023,1
 245,SCSS,markup,SY,2023,1
@@ -80263,8 +80588,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1742,Kotlin,programming,TH,2023,1
 1587,Objective-C,programming,TH,2023,1
 1569,Swift,programming,TH,2023,1
-1497,Go,programming,TH,2023,1
 1497,CMake,programming,TH,2023,1
+1497,Go,programming,TH,2023,1
 1375,Ruby,programming,TH,2023,1
 1306,Dart,programming,TH,2023,1
 1056,Hack,programming,TH,2023,1
@@ -80515,8 +80840,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 129,CoffeeScript,programming,TW,2023,1
 124,XS,programming,TW,2023,1
 119,UnrealScript,programming,TW,2023,1
-118,SourcePawn,programming,TW,2023,1
 118,Haskell,programming,TW,2023,1
+118,SourcePawn,programming,TW,2023,1
 116,ANTLR,programming,TW,2023,1
 112,VHDL,programming,TW,2023,1
 109,FreeMarker,programming,TW,2023,1
@@ -80583,8 +80908,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 961,PowerShell,programming,UA,2023,1
 795,Lua,programming,UA,2023,1
 786,Dart,programming,UA,2023,1
-743,ShaderLab,programming,UA,2023,1
 743,HLSL,programming,UA,2023,1
+743,ShaderLab,programming,UA,2023,1
 726,Hack,programming,UA,2023,1
 714,Rust,programming,UA,2023,1
 650,Assembly,programming,UA,2023,1
@@ -80609,18 +80934,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 218,Scala,programming,UA,2023,1
 188,R,programming,UA,2023,1
 164,Yacc,programming,UA,2023,1
-162,Smalltalk,programming,UA,2023,1
 162,Emacs Lisp,programming,UA,2023,1
+162,Smalltalk,programming,UA,2023,1
 150,ASP.NET,programming,UA,2023,1
 132,Lex,programming,UA,2023,1
 130,Pascal,programming,UA,2023,1
 130,Cython,programming,UA,2023,1
 127,FreeMarker,programming,UA,2023,1
 119,Clojure,programming,UA,2023,1
-114,Haskell,programming,UA,2023,1
 114,Mathematica,programming,UA,2023,1
-109,PLSQL,programming,UA,2023,1
+114,Haskell,programming,UA,2023,1
 109,NASL,programming,UA,2023,1
+109,PLSQL,programming,UA,2023,1
 109,GAP,programming,UA,2023,1
 108,MATLAB,programming,UA,2023,1
 106,Tcl,programming,UA,2023,1
@@ -80786,8 +81111,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1840,Processing,programming,US,2023,1
 1839,OCaml,programming,US,2023,1
 1821,SmPL,programming,US,2023,1
-1775,Thrift,programming,US,2023,1
 1775,F#,programming,US,2023,1
+1775,Thrift,programming,US,2023,1
 1771,Bicep,programming,US,2023,1
 1735,DTrace,programming,US,2023,1
 1703,Standard ML,programming,US,2023,1
@@ -80854,8 +81179,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 477,BitBake,programming,US,2023,1
 474,PEG.js,programming,US,2023,1
 470,q,programming,US,2023,1
-469,SuperCollider,programming,US,2023,1
 469,Stan,programming,US,2023,1
+469,SuperCollider,programming,US,2023,1
 463,Ragel,programming,US,2023,1
 461,Limbo,programming,US,2023,1
 450,Coq,programming,US,2023,1
@@ -80889,8 +81214,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 248,VCL,programming,US,2023,1
 245,xBase,programming,US,2023,1
 244,CodeQL,programming,US,2023,1
-239,Move,programming,US,2023,1
 239,Red,programming,US,2023,1
+239,Move,programming,US,2023,1
 235,Cadence,programming,US,2023,1
 234,nesC,programming,US,2023,1
 233,Clean,programming,US,2023,1
@@ -80911,16 +81236,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 196,LabVIEW,programming,US,2023,1
 195,LilyPond,programming,US,2023,1
 193,REXX,programming,US,2023,1
-191,CLIPS,programming,US,2023,1
 191,Cypher,programming,US,2023,1
+191,CLIPS,programming,US,2023,1
 189,Q#,programming,US,2023,1
 187,Objective-J,programming,US,2023,1
 186,CWeb,programming,US,2023,1
 185,GSC,programming,US,2023,1
 181,AutoIt,programming,US,2023,1
 180,OpenQASM,programming,US,2023,1
-178,Ink,programming,US,2023,1
 178,Elvish,programming,US,2023,1
+178,Ink,programming,US,2023,1
 177,Ren'Py,programming,US,2023,1
 175,AngelScript,programming,US,2023,1
 173,Hy,programming,US,2023,1
@@ -80928,24 +81253,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 169,KRL,programming,US,2023,1
 166,Fennel,programming,US,2023,1
 165,Clarion,programming,US,2023,1
-160,Slash,programming,US,2023,1
 160,Pike,programming,US,2023,1
+160,Slash,programming,US,2023,1
 158,E,programming,US,2023,1
 158,SQF,programming,US,2023,1
-155,P4,programming,US,2023,1
 155,CartoCSS,programming,US,2023,1
+155,P4,programming,US,2023,1
 154,Singularity,programming,US,2023,1
 154,J,programming,US,2023,1
-150,Monkey C,programming,US,2023,1
 150,LSL,programming,US,2023,1
+150,Monkey C,programming,US,2023,1
 148,Modula-3,programming,US,2023,1
 145,Alloy,programming,US,2023,1
 141,Cool,programming,US,2023,1
 139,Isabelle,programming,US,2023,1
 138,ABAP,programming,US,2023,1
-138,Harbour,programming,US,2023,1
 138,Modelica,programming,US,2023,1
 138,Agda,programming,US,2023,1
+138,Harbour,programming,US,2023,1
 136,Nearley,programming,US,2023,1
 134,mIRC Script,programming,US,2023,1
 131,Sieve,programming,US,2023,1
@@ -80955,8 +81280,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,Squirrel,programming,US,2023,1
 124,F*,programming,US,2023,1
 121,NetLogo,programming,US,2023,1
-120,Berry,programming,US,2023,1
 120,Odin,programming,US,2023,1
+120,Berry,programming,US,2023,1
 119,Filebench WML,programming,US,2023,1
 119,Asymptote,programming,US,2023,1
 117,Promela,programming,US,2023,1
@@ -80967,10 +81292,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Faust,programming,US,2023,1
 109,GAMS,programming,US,2023,1
 106,Lasso,programming,US,2023,1
-104,Augeas,programming,US,2023,1
 104,Yul,programming,US,2023,1
-104,XC,programming,US,2023,1
+104,Augeas,programming,US,2023,1
 104,Chapel,programming,US,2023,1
+104,XC,programming,US,2023,1
 101,MoonScript,programming,US,2023,1
 1005,Markdown,prose,US,2023,1
 3021,HTML,markup,UY,2023,1
@@ -81129,12 +81454,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 210,Cython,programming,VN,2023,1
 158,Mako,programming,VN,2023,1
 153,Awk,programming,VN,2023,1
-148,GAP,programming,VN,2023,1
 148,Emacs Lisp,programming,VN,2023,1
+148,GAP,programming,VN,2023,1
 140,QMake,programming,VN,2023,1
 139,NSIS,programming,VN,2023,1
-132,Pascal,programming,VN,2023,1
 132,Raku,programming,VN,2023,1
+132,Pascal,programming,VN,2023,1
 129,Yacc,programming,VN,2023,1
 124,Tcl,programming,VN,2023,1
 118,FreeMarker,programming,VN,2023,1
@@ -81177,8 +81502,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 932,Jupyter Notebook,markup,ZA,2023,1
 490,Vue,markup,ZA,2023,1
 251,Less,markup,ZA,2023,1
-193,Blade,markup,ZA,2023,1
 193,Roff,markup,ZA,2023,1
+193,Blade,markup,ZA,2023,1
 184,TeX,markup,ZA,2023,1
 180,Handlebars,markup,ZA,2023,1
 179,EJS,markup,ZA,2023,1
@@ -81242,7 +81567,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 170,TypeScript,programming,ZW,2023,1
 157,Java,programming,ZW,2023,1
 106,Assembly,programming,ZW,2023,1
+101,HTML,markup,AD,2023,2
 110,JavaScript,programming,AD,2023,2
+5518,HTML,markup,AE,2023,2
+4530,CSS,markup,AE,2023,2
+1127,SCSS,markup,AE,2023,2
+991,Jupyter Notebook,markup,AE,2023,2
+271,Vue,markup,AE,2023,2
+180,Blade,markup,AE,2023,2
+132,Roff,markup,AE,2023,2
+128,Less,markup,AE,2023,2
 4920,JavaScript,programming,AE,2023,2
 2831,Python,programming,AE,2023,2
 1963,Shell,programming,AE,2023,2
@@ -81276,6 +81610,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,HLSL,programming,AE,2023,2
 107,Objective-C++,programming,AE,2023,2
 106,Smarty,programming,AE,2023,2
+621,HTML,markup,AF,2023,2
+534,CSS,markup,AF,2023,2
 500,JavaScript,programming,AF,2023,2
 197,Python,programming,AF,2023,2
 108,PHP,programming,AF,2023,2
@@ -81283,6 +81619,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 105,Dart,programming,AF,2023,2
 104,Swift,programming,AF,2023,2
 102,Java,programming,AF,2023,2
+1339,HTML,markup,AL,2023,2
+1253,CSS,markup,AL,2023,2
+296,SCSS,markup,AL,2023,2
 1221,JavaScript,programming,AL,2023,2
 377,Python,programming,AL,2023,2
 362,TypeScript,programming,AL,2023,2
@@ -81294,6 +81633,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 173,C#,programming,AL,2023,2
 159,Hack,programming,AL,2023,2
 112,Makefile,programming,AL,2023,2
+4354,HTML,markup,AM,2023,2
+3585,CSS,markup,AM,2023,2
+1185,SCSS,markup,AM,2023,2
+423,Jupyter Notebook,markup,AM,2023,2
+288,Vue,markup,AM,2023,2
+211,Blade,markup,AM,2023,2
+123,Less,markup,AM,2023,2
+116,Roff,markup,AM,2023,2
 4282,JavaScript,programming,AM,2023,2
 1848,Python,programming,AM,2023,2
 1418,TypeScript,programming,AM,2023,2
@@ -81317,11 +81664,36 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Objective-C++,programming,AM,2023,2
 109,Perl,programming,AM,2023,2
 107,Lua,programming,AM,2023,2
+848,HTML,markup,AO,2023,2
+790,CSS,markup,AO,2023,2
+195,SCSS,markup,AO,2023,2
 794,JavaScript,programming,AO,2023,2
 310,TypeScript,programming,AO,2023,2
 238,PHP,programming,AO,2023,2
 156,Java,programming,AO,2023,2
 140,Python,programming,AO,2023,2
+104,JSON,data,AR,2023,2
+104,YAML,data,AR,2023,2
+57581,HTML,markup,AR,2023,2
+52246,CSS,markup,AR,2023,2
+10301,SCSS,markup,AR,2023,2
+3240,Jupyter Notebook,markup,AR,2023,2
+2167,Handlebars,markup,AR,2023,2
+1782,EJS,markup,AR,2023,2
+1174,Vue,markup,AR,2023,2
+784,Blade,markup,AR,2023,2
+653,Less,markup,AR,2023,2
+540,TeX,markup,AR,2023,2
+417,Roff,markup,AR,2023,2
+396,Pug,markup,AR,2023,2
+292,Astro,markup,AR,2023,2
+243,Nunjucks,markup,AR,2023,2
+224,Sass,markup,AR,2023,2
+224,Svelte,markup,AR,2023,2
+184,Rich Text Format,markup,AR,2023,2
+177,Mustache,markup,AR,2023,2
+173,Jinja,markup,AR,2023,2
+114,Twig,markup,AR,2023,2
 49636,JavaScript,programming,AR,2023,2
 13938,Python,programming,AR,2023,2
 11987,TypeScript,programming,AR,2023,2
@@ -81376,8 +81748,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 166,Processing,programming,AR,2023,2
 166,Fortran,programming,AR,2023,2
 160,Yacc,programming,AR,2023,2
-153,Tcl,programming,AR,2023,2
 153,Visual Basic .NET,programming,AR,2023,2
+153,Tcl,programming,AR,2023,2
 151,Lex,programming,AR,2023,2
 142,Cython,programming,AR,2023,2
 138,Awk,programming,AR,2023,2
@@ -81395,6 +81767,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,Scheme,programming,AR,2023,2
 103,Emacs Lisp,programming,AR,2023,2
 103,Forth,programming,AR,2023,2
+121,Markdown,prose,AR,2023,2
+9115,HTML,markup,AT,2023,2
+7376,CSS,markup,AT,2023,2
+2321,SCSS,markup,AT,2023,2
+1551,Jupyter Notebook,markup,AT,2023,2
+714,Vue,markup,AT,2023,2
+666,TeX,markup,AT,2023,2
+552,Roff,markup,AT,2023,2
+342,Less,markup,AT,2023,2
+294,Jinja,markup,AT,2023,2
+252,Handlebars,markup,AT,2023,2
+209,Svelte,markup,AT,2023,2
+202,EJS,markup,AT,2023,2
+191,Mustache,markup,AT,2023,2
+190,Twig,markup,AT,2023,2
+142,Blade,markup,AT,2023,2
+133,Rich Text Format,markup,AT,2023,2
+113,Sass,markup,AT,2023,2
 8235,JavaScript,programming,AT,2023,2
 6372,Python,programming,AT,2023,2
 5797,Shell,programming,AT,2023,2
@@ -81446,8 +81836,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Lex,programming,AT,2023,2
 133,Scala,programming,AT,2023,2
 131,Haskell,programming,AT,2023,2
-129,Meson,programming,AT,2023,2
 129,Cuda,programming,AT,2023,2
+129,Meson,programming,AT,2023,2
 121,Mathematica,programming,AT,2023,2
 118,Cython,programming,AT,2023,2
 116,Scheme,programming,AT,2023,2
@@ -81459,8 +81849,32 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Mako,programming,AT,2023,2
 105,Prolog,programming,AT,2023,2
 103,Pascal,programming,AT,2023,2
-101,Smalltalk,programming,AT,2023,2
 101,NASL,programming,AT,2023,2
+101,Smalltalk,programming,AT,2023,2
+29027,HTML,markup,AU,2023,2
+24021,CSS,markup,AU,2023,2
+6335,SCSS,markup,AU,2023,2
+4790,Jupyter Notebook,markup,AU,2023,2
+1527,TeX,markup,AU,2023,2
+1472,Vue,markup,AU,2023,2
+1252,Roff,markup,AU,2023,2
+752,Less,markup,AU,2023,2
+731,Handlebars,markup,AU,2023,2
+674,EJS,markup,AU,2023,2
+663,Jinja,markup,AU,2023,2
+500,Svelte,markup,AU,2023,2
+418,Mustache,markup,AU,2023,2
+409,Rich Text Format,markup,AU,2023,2
+353,Pug,markup,AU,2023,2
+342,Blade,markup,AU,2023,2
+290,Astro,markup,AU,2023,2
+199,Sass,markup,AU,2023,2
+146,Twig,markup,AU,2023,2
+146,Liquid,markup,AU,2023,2
+121,Nunjucks,markup,AU,2023,2
+115,Stylus,markup,AU,2023,2
+114,Vim Snippet,markup,AU,2023,2
+113,PostScript,markup,AU,2023,2
 26718,JavaScript,programming,AU,2023,2
 18919,Python,programming,AU,2023,2
 15551,Shell,programming,AU,2023,2
@@ -81501,8 +81915,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 532,Dart,programming,AU,2023,2
 493,Emacs Lisp,programming,AU,2023,2
 465,PLpgSQL,programming,AU,2023,2
-444,Starlark,programming,AU,2023,2
 444,Groovy,programming,AU,2023,2
+444,Starlark,programming,AU,2023,2
 432,TSQL,programming,AU,2023,2
 415,Solidity,programming,AU,2023,2
 400,Gherkin,programming,AU,2023,2
@@ -81513,8 +81927,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 323,Fortran,programming,AU,2023,2
 316,Scala,programming,AU,2023,2
 313,Bicep,programming,AU,2023,2
-296,ASP.NET,programming,AU,2023,2
 296,Tcl,programming,AU,2023,2
+296,ASP.NET,programming,AU,2023,2
 283,Lex,programming,AU,2023,2
 280,sed,programming,AU,2023,2
 271,Cuda,programming,AU,2023,2
@@ -81528,8 +81942,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 233,NSIS,programming,AU,2023,2
 228,Pascal,programming,AU,2023,2
 214,GAP,programming,AU,2023,2
-211,QMake,programming,AU,2023,2
 211,SourcePawn,programming,AU,2023,2
+211,QMake,programming,AU,2023,2
 201,Raku,programming,AU,2023,2
 198,Meson,programming,AU,2023,2
 194,NASL,programming,AU,2023,2
@@ -81557,12 +81971,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,Erlang,programming,AU,2023,2
 119,G-code,programming,AU,2023,2
 109,Verilog,programming,AU,2023,2
-107,QML,programming,AU,2023,2
 107,OCaml,programming,AU,2023,2
+107,QML,programming,AU,2023,2
 106,PureBasic,programming,AU,2023,2
 103,Standard ML,programming,AU,2023,2
 102,XS,programming,AU,2023,2
 102,M,programming,AU,2023,2
+4604,HTML,markup,AZ,2023,2
+4025,CSS,markup,AZ,2023,2
+1558,SCSS,markup,AZ,2023,2
+260,Jupyter Notebook,markup,AZ,2023,2
+145,Less,markup,AZ,2023,2
+120,Blade,markup,AZ,2023,2
 3817,JavaScript,programming,AZ,2023,2
 1161,C#,programming,AZ,2023,2
 984,Python,programming,AZ,2023,2
@@ -81577,12 +81997,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 228,Ruby,programming,AZ,2023,2
 204,Objective-C,programming,AZ,2023,2
 194,Swift,programming,AZ,2023,2
-152,CMake,programming,AZ,2023,2
 152,Makefile,programming,AZ,2023,2
+152,CMake,programming,AZ,2023,2
 150,Dart,programming,AZ,2023,2
 120,Batchfile,programming,AZ,2023,2
 111,Hack,programming,AZ,2023,2
 104,PowerShell,programming,AZ,2023,2
+2254,HTML,markup,BA,2023,2
+2040,CSS,markup,BA,2023,2
+411,SCSS,markup,BA,2023,2
+119,Blade,markup,BA,2023,2
 2078,JavaScript,programming,BA,2023,2
 622,TypeScript,programming,BA,2023,2
 566,C#,programming,BA,2023,2
@@ -81600,6 +82024,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 129,Dart,programming,BA,2023,2
 127,Makefile,programming,BA,2023,2
 115,Ruby,programming,BA,2023,2
+103,HTML,markup,BB,2023,2
+29511,HTML,markup,BD,2023,2
+26848,CSS,markup,BD,2023,2
+5243,SCSS,markup,BD,2023,2
+2864,Blade,markup,BD,2023,2
+2849,Jupyter Notebook,markup,BD,2023,2
+1301,Vue,markup,BD,2023,2
+885,Less,markup,BD,2023,2
+548,EJS,markup,BD,2023,2
+314,Handlebars,markup,BD,2023,2
+281,TeX,markup,BD,2023,2
+265,Roff,markup,BD,2023,2
+130,Pug,markup,BD,2023,2
+126,Svelte,markup,BD,2023,2
 25437,JavaScript,programming,BD,2023,2
 8027,Python,programming,BD,2023,2
 6802,PHP,programming,BD,2023,2
@@ -81639,6 +82077,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,Cython,programming,BD,2023,2
 108,Starlark,programming,BD,2023,2
 103,Vim Script,programming,BD,2023,2
+10941,HTML,markup,BE,2023,2
+9186,CSS,markup,BE,2023,2
+3057,SCSS,markup,BE,2023,2
+1823,Jupyter Notebook,markup,BE,2023,2
+803,Vue,markup,BE,2023,2
+767,TeX,markup,BE,2023,2
+470,Roff,markup,BE,2023,2
+395,Blade,markup,BE,2023,2
+312,Jinja,markup,BE,2023,2
+295,Less,markup,BE,2023,2
+294,Twig,markup,BE,2023,2
+289,Svelte,markup,BE,2023,2
+269,Handlebars,markup,BE,2023,2
+213,EJS,markup,BE,2023,2
+160,Rich Text Format,markup,BE,2023,2
+158,Mustache,markup,BE,2023,2
+138,Sass,markup,BE,2023,2
+125,Pug,markup,BE,2023,2
+124,Liquid,markup,BE,2023,2
 10099,JavaScript,programming,BE,2023,2
 7129,Python,programming,BE,2023,2
 5650,Shell,programming,BE,2023,2
@@ -81671,8 +82128,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 311,HCL,programming,BE,2023,2
 288,HLSL,programming,BE,2023,2
 274,GLSL,programming,BE,2023,2
-267,Dart,programming,BE,2023,2
 267,ShaderLab,programming,BE,2023,2
+267,Dart,programming,BE,2023,2
 264,Nix,programming,BE,2023,2
 242,Procfile,programming,BE,2023,2
 226,M4,programming,BE,2023,2
@@ -81682,8 +82139,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 181,Fortran,programming,BE,2023,2
 170,Emacs Lisp,programming,BE,2023,2
 163,TSQL,programming,BE,2023,2
-162,PLpgSQL,programming,BE,2023,2
 162,Scala,programming,BE,2023,2
+162,PLpgSQL,programming,BE,2023,2
 157,Julia,programming,BE,2023,2
 155,Solidity,programming,BE,2023,2
 144,Cython,programming,BE,2023,2
@@ -81695,8 +82152,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,PLSQL,programming,BE,2023,2
 119,Yacc,programming,BE,2023,2
 114,Common Lisp,programming,BE,2023,2
-113,Lex,programming,BE,2023,2
 113,Elixir,programming,BE,2023,2
+113,Lex,programming,BE,2023,2
 110,Pascal,programming,BE,2023,2
 109,Smalltalk,programming,BE,2023,2
 107,QMake,programming,BE,2023,2
@@ -81704,8 +82161,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 105,Meson,programming,BE,2023,2
 104,sed,programming,BE,2023,2
 101,Verilog,programming,BE,2023,2
+286,HTML,markup,BF,2023,2
+239,CSS,markup,BF,2023,2
 200,JavaScript,programming,BF,2023,2
 126,PHP,programming,BF,2023,2
+7881,HTML,markup,BG,2023,2
+6942,CSS,markup,BG,2023,2
+1626,SCSS,markup,BG,2023,2
+354,Jupyter Notebook,markup,BG,2023,2
+339,Handlebars,markup,BG,2023,2
+324,Vue,markup,BG,2023,2
+182,Less,markup,BG,2023,2
+179,Roff,markup,BG,2023,2
+146,EJS,markup,BG,2023,2
+142,Mustache,markup,BG,2023,2
+136,Blade,markup,BG,2023,2
+119,Pug,markup,BG,2023,2
+115,TeX,markup,BG,2023,2
 7362,JavaScript,programming,BG,2023,2
 2858,C#,programming,BG,2023,2
 2836,Python,programming,BG,2023,2
@@ -81743,12 +82215,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Gherkin,programming,BG,2023,2
 112,ASP.NET,programming,BG,2023,2
 109,Nix,programming,BG,2023,2
-106,HLSL,programming,BG,2023,2
 106,XSLT,programming,BG,2023,2
+106,HLSL,programming,BG,2023,2
+465,HTML,markup,BH,2023,2
+374,CSS,markup,BH,2023,2
 364,JavaScript,programming,BH,2023,2
 153,Python,programming,BH,2023,2
 101,PHP,programming,BH,2023,2
+155,HTML,markup,BI,2023,2
+132,CSS,markup,BI,2023,2
 125,JavaScript,programming,BI,2023,2
+1060,HTML,markup,BJ,2023,2
+867,CSS,markup,BJ,2023,2
+215,SCSS,markup,BJ,2023,2
+177,Blade,markup,BJ,2023,2
 810,JavaScript,programming,BJ,2023,2
 391,PHP,programming,BJ,2023,2
 338,Python,programming,BJ,2023,2
@@ -81756,7 +82236,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 199,C,programming,BJ,2023,2
 143,TypeScript,programming,BJ,2023,2
 107,C++,programming,BJ,2023,2
+154,HTML,markup,BN,2023,2
+136,CSS,markup,BN,2023,2
 137,JavaScript,programming,BN,2023,2
+3692,HTML,markup,BO,2023,2
+3138,CSS,markup,BO,2023,2
+756,SCSS,markup,BO,2023,2
+547,Blade,markup,BO,2023,2
+287,Jupyter Notebook,markup,BO,2023,2
+264,Vue,markup,BO,2023,2
+121,Less,markup,BO,2023,2
 3337,JavaScript,programming,BO,2023,2
 1065,Python,programming,BO,2023,2
 1052,TypeScript,programming,BO,2023,2
@@ -81776,6 +82265,32 @@ num_pushers,language,language_type,iso2_code,year,quarter
 177,Ruby,programming,BO,2023,2
 147,Batchfile,programming,BO,2023,2
 145,Makefile,programming,BO,2023,2
+193661,HTML,markup,BR,2023,2
+167440,CSS,markup,BR,2023,2
+23454,SCSS,markup,BR,2023,2
+15553,Jupyter Notebook,markup,BR,2023,2
+6923,Vue,markup,BR,2023,2
+5554,Blade,markup,BR,2023,2
+3622,EJS,markup,BR,2023,2
+2678,Handlebars,markup,BR,2023,2
+2493,Less,markup,BR,2023,2
+2218,Roff,markup,BR,2023,2
+2187,TeX,markup,BR,2023,2
+1259,Sass,markup,BR,2023,2
+836,Pug,markup,BR,2023,2
+822,Jinja,markup,BR,2023,2
+751,Svelte,markup,BR,2023,2
+686,Mustache,markup,BR,2023,2
+508,Rich Text Format,markup,BR,2023,2
+412,Astro,markup,BR,2023,2
+305,Twig,markup,BR,2023,2
+212,kvlang,markup,BR,2023,2
+204,Stylus,markup,BR,2023,2
+178,PostScript,markup,BR,2023,2
+178,Closure Templates,markup,BR,2023,2
+173,Vim Snippet,markup,BR,2023,2
+159,Liquid,markup,BR,2023,2
+141,Nunjucks,markup,BR,2023,2
 155692,JavaScript,programming,BR,2023,2
 59431,Python,programming,BR,2023,2
 54234,TypeScript,programming,BR,2023,2
@@ -81852,8 +82367,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 358,sed,programming,BR,2023,2
 338,Julia,programming,BR,2023,2
 319,VBScript,programming,BR,2023,2
-300,DIGITAL Command Language,programming,BR,2023,2
 300,Nu,programming,BR,2023,2
+300,DIGITAL Command Language,programming,BR,2023,2
 288,Meson,programming,BR,2023,2
 285,Cuda,programming,BR,2023,2
 262,PureBasic,programming,BR,2023,2
@@ -81870,8 +82385,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 212,QML,programming,BR,2023,2
 207,AIDL,programming,BR,2023,2
 203,xBase,programming,BR,2023,2
-198,Erlang,programming,BR,2023,2
 198,Stata,programming,BR,2023,2
+198,Erlang,programming,BR,2023,2
 197,SmPL,programming,BR,2023,2
 197,Inno Setup,programming,BR,2023,2
 191,Gnuplot,programming,BR,2023,2
@@ -81887,8 +82402,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,XS,programming,BR,2023,2
 132,Haxe,programming,BR,2023,2
 128,SWIG,programming,BR,2023,2
-122,AutoHotkey,programming,BR,2023,2
 122,UnrealScript,programming,BR,2023,2
+122,AutoHotkey,programming,BR,2023,2
 122,M,programming,BR,2023,2
 120,Zig,programming,BR,2023,2
 118,Pawn,programming,BR,2023,2
@@ -81898,8 +82413,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,OCaml,programming,BR,2023,2
 106,AMPL,programming,BR,2023,2
 102,Bicep,programming,BR,2023,2
+113,Markdown,prose,BR,2023,2
+247,HTML,markup,BT,2023,2
+244,CSS,markup,BT,2023,2
 234,JavaScript,programming,BT,2023,2
+377,HTML,markup,BW,2023,2
+344,CSS,markup,BW,2023,2
 214,JavaScript,programming,BW,2023,2
+11228,HTML,markup,BY,2023,2
+8964,CSS,markup,BY,2023,2
+3170,SCSS,markup,BY,2023,2
+446,Jupyter Notebook,markup,BY,2023,2
+378,Vue,markup,BY,2023,2
+247,Less,markup,BY,2023,2
+210,Blade,markup,BY,2023,2
+156,Sass,markup,BY,2023,2
+151,Roff,markup,BY,2023,2
+115,Handlebars,markup,BY,2023,2
+114,TeX,markup,BY,2023,2
+105,EJS,markup,BY,2023,2
 9553,JavaScript,programming,BY,2023,2
 4288,Python,programming,BY,2023,2
 3820,Java,programming,BY,2023,2
@@ -81937,6 +82469,31 @@ num_pushers,language,language_type,iso2_code,year,quarter
 128,Smarty,programming,BY,2023,2
 113,PLpgSQL,programming,BY,2023,2
 111,XSLT,programming,BY,2023,2
+107,YAML,data,CA,2023,2
+69388,HTML,markup,CA,2023,2
+59163,CSS,markup,CA,2023,2
+14972,SCSS,markup,CA,2023,2
+14442,Jupyter Notebook,markup,CA,2023,2
+3426,TeX,markup,CA,2023,2
+3091,Vue,markup,CA,2023,2
+2749,EJS,markup,CA,2023,2
+2468,Roff,markup,CA,2023,2
+1954,Handlebars,markup,CA,2023,2
+1430,Less,markup,CA,2023,2
+1312,Jinja,markup,CA,2023,2
+1068,Svelte,markup,CA,2023,2
+937,Pug,markup,CA,2023,2
+928,Mustache,markup,CA,2023,2
+887,Rich Text Format,markup,CA,2023,2
+795,Blade,markup,CA,2023,2
+475,Astro,markup,CA,2023,2
+426,Sass,markup,CA,2023,2
+315,Liquid,markup,CA,2023,2
+291,Twig,markup,CA,2023,2
+253,PostScript,markup,CA,2023,2
+217,Stylus,markup,CA,2023,2
+213,Nunjucks,markup,CA,2023,2
+193,Vim Snippet,markup,CA,2023,2
 63902,JavaScript,programming,CA,2023,2
 43012,Python,programming,CA,2023,2
 29573,Shell,programming,CA,2023,2
@@ -82051,8 +82608,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 159,Nim,programming,CA,2023,2
 156,Nu,programming,CA,2023,2
 155,Thrift,programming,CA,2023,2
-148,Jasmin,programming,CA,2023,2
 148,OpenSCAD,programming,CA,2023,2
+148,Jasmin,programming,CA,2023,2
 143,CUE,programming,CA,2023,2
 141,Metal,programming,CA,2023,2
 141,POV-Ray SDL,programming,CA,2023,2
@@ -82068,17 +82625,41 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Reason,programming,CA,2023,2
 111,Scilab,programming,CA,2023,2
 107,Open Policy Agent,programming,CA,2023,2
-104,Cap'n Proto,programming,CA,2023,2
 104,OpenEdge ABL,programming,CA,2023,2
+104,Cap'n Proto,programming,CA,2023,2
 103,RobotFramework,programming,CA,2023,2
 102,UnrealScript,programming,CA,2023,2
 101,Puppet,programming,CA,2023,2
+167,Markdown,prose,CA,2023,2
+683,HTML,markup,CD,2023,2
+638,CSS,markup,CD,2023,2
+170,SCSS,markup,CD,2023,2
 595,JavaScript,programming,CD,2023,2
 236,PHP,programming,CD,2023,2
 195,Python,programming,CD,2023,2
 138,TypeScript,programming,CD,2023,2
 127,Java,programming,CD,2023,2
 107,Shell,programming,CD,2023,2
+15375,HTML,markup,CH,2023,2
+12175,CSS,markup,CH,2023,2
+4219,Jupyter Notebook,markup,CH,2023,2
+4127,SCSS,markup,CH,2023,2
+1788,TeX,markup,CH,2023,2
+1167,Vue,markup,CH,2023,2
+1049,Roff,markup,CH,2023,2
+540,Jinja,markup,CH,2023,2
+471,Less,markup,CH,2023,2
+435,Handlebars,markup,CH,2023,2
+352,Mustache,markup,CH,2023,2
+340,Svelte,markup,CH,2023,2
+293,Blade,markup,CH,2023,2
+264,EJS,markup,CH,2023,2
+251,Rich Text Format,markup,CH,2023,2
+236,Twig,markup,CH,2023,2
+202,Sass,markup,CH,2023,2
+176,Pug,markup,CH,2023,2
+126,PostScript,markup,CH,2023,2
+122,Astro,markup,CH,2023,2
 13488,JavaScript,programming,CH,2023,2
 13063,Python,programming,CH,2023,2
 11000,Shell,programming,CH,2023,2
@@ -82123,8 +82704,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 385,Hack,programming,CH,2023,2
 362,PLpgSQL,programming,CH,2023,2
 333,Objective-C++,programming,CH,2023,2
-330,sed,programming,CH,2023,2
 330,Dart,programming,CH,2023,2
+330,sed,programming,CH,2023,2
 319,Solidity,programming,CH,2023,2
 314,HLSL,programming,CH,2023,2
 302,Cython,programming,CH,2023,2
@@ -82139,8 +82720,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 224,Mako,programming,CH,2023,2
 209,Gnuplot,programming,CH,2023,2
 208,SWIG,programming,CH,2023,2
-203,Julia,programming,CH,2023,2
 203,Pascal,programming,CH,2023,2
+203,Julia,programming,CH,2023,2
 202,Scheme,programming,CH,2023,2
 197,GDB,programming,CH,2023,2
 193,VHDL,programming,CH,2023,2
@@ -82150,27 +82731,31 @@ num_pushers,language,language_type,iso2_code,year,quarter
 173,TSQL,programming,CH,2023,2
 159,Prolog,programming,CH,2023,2
 152,NSIS,programming,CH,2023,2
-150,Mathematica,programming,CH,2023,2
 150,Forth,programming,CH,2023,2
+150,Mathematica,programming,CH,2023,2
 144,Verilog,programming,CH,2023,2
 144,PureBasic,programming,CH,2023,2
 142,Raku,programming,CH,2023,2
-139,Smalltalk,programming,CH,2023,2
 139,ANTLR,programming,CH,2023,2
+139,Smalltalk,programming,CH,2023,2
 136,SmPL,programming,CH,2023,2
 133,Pawn,programming,CH,2023,2
-130,Common Lisp,programming,CH,2023,2
 130,Jsonnet,programming,CH,2023,2
+130,Common Lisp,programming,CH,2023,2
 128,POV-Ray SDL,programming,CH,2023,2
 126,CoffeeScript,programming,CH,2023,2
 121,Standard ML,programming,CH,2023,2
 118,Erlang,programming,CH,2023,2
-113,FreeMarker,programming,CH,2023,2
 113,QML,programming,CH,2023,2
+113,FreeMarker,programming,CH,2023,2
 112,Elixir,programming,CH,2023,2
 110,SystemVerilog,programming,CH,2023,2
 104,M,programming,CH,2023,2
 101,Inno Setup,programming,CH,2023,2
+1120,HTML,markup,CI,2023,2
+981,CSS,markup,CI,2023,2
+288,SCSS,markup,CI,2023,2
+173,Blade,markup,CI,2023,2
 921,JavaScript,programming,CI,2023,2
 414,PHP,programming,CI,2023,2
 346,Python,programming,CI,2023,2
@@ -82187,6 +82772,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Hack,programming,CI,2023,2
 109,CMake,programming,CI,2023,2
 106,Ruby,programming,CI,2023,2
+14342,HTML,markup,CL,2023,2
+12656,CSS,markup,CL,2023,2
+2406,SCSS,markup,CL,2023,2
+1673,Jupyter Notebook,markup,CL,2023,2
+633,Vue,markup,CL,2023,2
+471,Blade,markup,CL,2023,2
+276,TeX,markup,CL,2023,2
+275,Handlebars,markup,CL,2023,2
+218,Less,markup,CL,2023,2
+167,EJS,markup,CL,2023,2
+151,Roff,markup,CL,2023,2
 12474,JavaScript,programming,CL,2023,2
 7151,Python,programming,CL,2023,2
 2686,TypeScript,programming,CL,2023,2
@@ -82223,6 +82819,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 124,Assembly,programming,CL,2023,2
 117,GLSL,programming,CL,2023,2
 103,Smarty,programming,CL,2023,2
+2637,HTML,markup,CM,2023,2
+2351,CSS,markup,CM,2023,2
+652,SCSS,markup,CM,2023,2
+314,Blade,markup,CM,2023,2
+159,Vue,markup,CM,2023,2
+154,Jupyter Notebook,markup,CM,2023,2
 2310,JavaScript,programming,CM,2023,2
 743,Python,programming,CM,2023,2
 730,PHP,programming,CM,2023,2
@@ -82230,8 +82832,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 587,Shell,programming,CM,2023,2
 580,Java,programming,CM,2023,2
 441,C,programming,CM,2023,2
-333,Dockerfile,programming,CM,2023,2
 333,Kotlin,programming,CM,2023,2
+333,Dockerfile,programming,CM,2023,2
 316,Objective-C,programming,CM,2023,2
 314,C++,programming,CM,2023,2
 307,Dart,programming,CM,2023,2
@@ -82241,6 +82843,28 @@ num_pushers,language,language_type,iso2_code,year,quarter
 184,Hack,programming,CM,2023,2
 119,Makefile,programming,CM,2023,2
 106,Batchfile,programming,CM,2023,2
+66639,HTML,markup,CN,2023,2
+47070,CSS,markup,CN,2023,2
+18953,Vue,markup,CN,2023,2
+15937,SCSS,markup,CN,2023,2
+8030,Less,markup,CN,2023,2
+5526,Jupyter Notebook,markup,CN,2023,2
+3119,Roff,markup,CN,2023,2
+1993,TeX,markup,CN,2023,2
+1861,EJS,markup,CN,2023,2
+1326,Stylus,markup,CN,2023,2
+889,Mustache,markup,CN,2023,2
+880,Handlebars,markup,CN,2023,2
+699,Jinja,markup,CN,2023,2
+697,Pug,markup,CN,2023,2
+597,Astro,markup,CN,2023,2
+482,Rich Text Format,markup,CN,2023,2
+320,Blade,markup,CN,2023,2
+309,Sass,markup,CN,2023,2
+306,Vim Snippet,markup,CN,2023,2
+268,Svelte,markup,CN,2023,2
+239,PostScript,markup,CN,2023,2
+135,Nunjucks,markup,CN,2023,2
 60175,JavaScript,programming,CN,2023,2
 38676,Python,programming,CN,2023,2
 35600,Shell,programming,CN,2023,2
@@ -82303,8 +82927,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 529,Gherkin,programming,CN,2023,2
 517,Pascal,programming,CN,2023,2
 506,SWIG,programming,CN,2023,2
-505,Clojure,programming,CN,2023,2
 505,Fortran,programming,CN,2023,2
+505,Clojure,programming,CN,2023,2
 498,UnrealScript,programming,CN,2023,2
 492,Thrift,programming,CN,2023,2
 489,Nix,programming,CN,2023,2
@@ -82325,14 +82949,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 335,Inno Setup,programming,CN,2023,2
 316,QML,programming,CN,2023,2
 309,Classic ASP,programming,CN,2023,2
-294,CoffeeScript,programming,CN,2023,2
 294,Mako,programming,CN,2023,2
+294,CoffeeScript,programming,CN,2023,2
 266,Mathematica,programming,CN,2023,2
 262,SystemVerilog,programming,CN,2023,2
 252,Jsonnet,programming,CN,2023,2
 246,ASL,programming,CN,2023,2
-237,AMPL,programming,CN,2023,2
 237,Visual Basic .NET,programming,CN,2023,2
+237,AMPL,programming,CN,2023,2
 234,AppleScript,programming,CN,2023,2
 231,Forth,programming,CN,2023,2
 229,M,programming,CN,2023,2
@@ -82357,8 +82981,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 157,Module Management System,programming,CN,2023,2
 156,Prolog,programming,CN,2023,2
 152,Brainfuck,programming,CN,2023,2
-144,Terra,programming,CN,2023,2
 144,Scilab,programming,CN,2023,2
+144,Terra,programming,CN,2023,2
 136,Visual Basic 6.0,programming,CN,2023,2
 134,V,programming,CN,2023,2
 129,Ada,programming,CN,2023,2
@@ -82368,6 +82992,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,Nim,programming,CN,2023,2
 103,Arc,programming,CN,2023,2
 102,ActionScript,programming,CN,2023,2
+171,Markdown,prose,CN,2023,2
+40943,HTML,markup,CO,2023,2
+35550,CSS,markup,CO,2023,2
+7276,SCSS,markup,CO,2023,2
+4425,Jupyter Notebook,markup,CO,2023,2
+1809,Blade,markup,CO,2023,2
+1634,Vue,markup,CO,2023,2
+787,Less,markup,CO,2023,2
+678,EJS,markup,CO,2023,2
+625,Handlebars,markup,CO,2023,2
+412,TeX,markup,CO,2023,2
+324,Pug,markup,CO,2023,2
+322,Roff,markup,CO,2023,2
+282,Sass,markup,CO,2023,2
+266,Astro,markup,CO,2023,2
+186,Svelte,markup,CO,2023,2
+137,Rich Text Format,markup,CO,2023,2
+133,Stylus,markup,CO,2023,2
+125,Nunjucks,markup,CO,2023,2
+113,Jinja,markup,CO,2023,2
+107,Twig,markup,CO,2023,2
 34825,JavaScript,programming,CO,2023,2
 13499,Python,programming,CO,2023,2
 10665,Java,programming,CO,2023,2
@@ -82424,6 +83069,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Julia,programming,CO,2023,2
 112,Elixir,programming,CO,2023,2
 102,Visual Basic .NET,programming,CO,2023,2
+4454,HTML,markup,CR,2023,2
+4070,CSS,markup,CR,2023,2
+899,SCSS,markup,CR,2023,2
+327,Jupyter Notebook,markup,CR,2023,2
+122,Vue,markup,CR,2023,2
+120,Blade,markup,CR,2023,2
+111,Less,markup,CR,2023,2
 4060,JavaScript,programming,CR,2023,2
 1614,Java,programming,CR,2023,2
 1598,Python,programming,CR,2023,2
@@ -82447,6 +83099,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,Dart,programming,CR,2023,2
 121,PowerShell,programming,CR,2023,2
 113,Go,programming,CR,2023,2
+951,HTML,markup,CU,2023,2
+805,CSS,markup,CU,2023,2
+168,SCSS,markup,CU,2023,2
 773,JavaScript,programming,CU,2023,2
 508,Python,programming,CU,2023,2
 281,TypeScript,programming,CU,2023,2
@@ -82457,7 +83112,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 150,Dockerfile,programming,CU,2023,2
 142,C,programming,CU,2023,2
 137,PHP,programming,CU,2023,2
+118,HTML,markup,CV,2023,2
+108,CSS,markup,CV,2023,2
 112,JavaScript,programming,CV,2023,2
+1515,HTML,markup,CY,2023,2
+1212,CSS,markup,CY,2023,2
+345,SCSS,markup,CY,2023,2
+209,Jupyter Notebook,markup,CY,2023,2
 1360,JavaScript,programming,CY,2023,2
 917,Python,programming,CY,2023,2
 794,Shell,programming,CY,2023,2
@@ -82477,6 +83138,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,Swift,programming,CY,2023,2
 139,Objective-C,programming,CY,2023,2
 110,Rust,programming,CY,2023,2
+11236,HTML,markup,CZ,2023,2
+9471,CSS,markup,CZ,2023,2
+2588,SCSS,markup,CZ,2023,2
+1226,Jupyter Notebook,markup,CZ,2023,2
+710,Roff,markup,CZ,2023,2
+678,Vue,markup,CZ,2023,2
+644,TeX,markup,CZ,2023,2
+438,Less,markup,CZ,2023,2
+402,Jinja,markup,CZ,2023,2
+298,Mustache,markup,CZ,2023,2
+289,Svelte,markup,CZ,2023,2
+251,Handlebars,markup,CZ,2023,2
+245,Blade,markup,CZ,2023,2
+224,Latte,markup,CZ,2023,2
+198,Pug,markup,CZ,2023,2
+182,EJS,markup,CZ,2023,2
+167,Rich Text Format,markup,CZ,2023,2
+161,Twig,markup,CZ,2023,2
+159,Sass,markup,CZ,2023,2
 10177,JavaScript,programming,CZ,2023,2
 7727,Python,programming,CZ,2023,2
 6355,Shell,programming,CZ,2023,2
@@ -82536,17 +83216,47 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,Solidity,programming,CZ,2023,2
 140,FreeMarker,programming,CZ,2023,2
 133,Smalltalk,programming,CZ,2023,2
-132,Raku,programming,CZ,2023,2
 132,NASL,programming,CZ,2023,2
+132,Raku,programming,CZ,2023,2
 130,Cython,programming,CZ,2023,2
 130,ASP.NET,programming,CZ,2023,2
-128,GDB,programming,CZ,2023,2
 128,Mako,programming,CZ,2023,2
+128,GDB,programming,CZ,2023,2
 122,Jsonnet,programming,CZ,2023,2
 118,Scheme,programming,CZ,2023,2
 103,Pawn,programming,CZ,2023,2
 102,ANTLR,programming,CZ,2023,2
 101,NSIS,programming,CZ,2023,2
+319,YAML,data,DE,2023,2
+256,JSON,data,DE,2023,2
+72591,HTML,markup,DE,2023,2
+58157,CSS,markup,DE,2023,2
+18772,SCSS,markup,DE,2023,2
+14771,Jupyter Notebook,markup,DE,2023,2
+6174,TeX,markup,DE,2023,2
+6077,Vue,markup,DE,2023,2
+5032,Roff,markup,DE,2023,2
+2740,Jinja,markup,DE,2023,2
+2517,Less,markup,DE,2023,2
+2154,Handlebars,markup,DE,2023,2
+1905,Mustache,markup,DE,2023,2
+1892,Svelte,markup,DE,2023,2
+1536,EJS,markup,DE,2023,2
+1172,Twig,markup,DE,2023,2
+1153,Rich Text Format,markup,DE,2023,2
+1147,Blade,markup,DE,2023,2
+1013,Sass,markup,DE,2023,2
+821,Pug,markup,DE,2023,2
+656,Astro,markup,DE,2023,2
+462,Vim Snippet,markup,DE,2023,2
+440,PostScript,markup,DE,2023,2
+385,Nunjucks,markup,DE,2023,2
+324,Stylus,markup,DE,2023,2
+310,Liquid,markup,DE,2023,2
+213,Haml,markup,DE,2023,2
+147,Mermaid,markup,DE,2023,2
+126,YASnippet,markup,DE,2023,2
+115,Slim,markup,DE,2023,2
 67316,JavaScript,programming,DE,2023,2
 59404,Python,programming,DE,2023,2
 53620,Shell,programming,DE,2023,2
@@ -82643,8 +83353,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 466,DIGITAL Command Language,programming,DE,2023,2
 443,Forth,programming,DE,2023,2
 439,PureBasic,programming,DE,2023,2
-409,Reason,programming,DE,2023,2
 409,PureScript,programming,DE,2023,2
+409,Reason,programming,DE,2023,2
 408,CUE,programming,DE,2023,2
 406,XS,programming,DE,2023,2
 404,POV-Ray SDL,programming,DE,2023,2
@@ -82678,12 +83388,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 218,RobotFramework,programming,DE,2023,2
 214,OpenEdge ABL,programming,DE,2023,2
 211,Ada,programming,DE,2023,2
-206,Bicep,programming,DE,2023,2
 206,Stata,programming,DE,2023,2
+206,Bicep,programming,DE,2023,2
 203,jq,programming,DE,2023,2
 193,CAP CDS,programming,DE,2023,2
-192,RenderScript,programming,DE,2023,2
 192,ASL,programming,DE,2023,2
+192,RenderScript,programming,DE,2023,2
 191,Visual Basic 6.0,programming,DE,2023,2
 190,Nextflow,programming,DE,2023,2
 185,Rebol,programming,DE,2023,2
@@ -82697,28 +83407,45 @@ num_pushers,language,language_type,iso2_code,year,quarter
 157,EmberScript,programming,DE,2023,2
 152,SAS,programming,DE,2023,2
 152,ABAP,programming,DE,2023,2
-150,Xtend,programming,DE,2023,2
 150,Crystal,programming,DE,2023,2
+150,Xtend,programming,DE,2023,2
 149,Nu,programming,DE,2023,2
 144,NewLisp,programming,DE,2023,2
 141,Cap'n Proto,programming,DE,2023,2
 140,SuperCollider,programming,DE,2023,2
 140,Brainfuck,programming,DE,2023,2
-134,Ragel,programming,DE,2023,2
 134,Logos,programming,DE,2023,2
+134,Ragel,programming,DE,2023,2
 132,Apex,programming,DE,2023,2
 128,XQuery,programming,DE,2023,2
 126,ImageJ Macro,programming,DE,2023,2
 125,Haxe,programming,DE,2023,2
 122,Vala,programming,DE,2023,2
-118,Classic ASP,programming,DE,2023,2
 118,Euphoria,programming,DE,2023,2
+118,Classic ASP,programming,DE,2023,2
 117,BASIC,programming,DE,2023,2
 115,COBOL,programming,DE,2023,2
 113,FreeBasic,programming,DE,2023,2
 111,Qt Script,programming,DE,2023,2
 106,SaltStack,programming,DE,2023,2
 103,Limbo,programming,DE,2023,2
+392,Markdown,prose,DE,2023,2
+9733,HTML,markup,DK,2023,2
+8350,CSS,markup,DK,2023,2
+2182,Jupyter Notebook,markup,DK,2023,2
+1878,SCSS,markup,DK,2023,2
+805,TeX,markup,DK,2023,2
+603,Vue,markup,DK,2023,2
+404,Roff,markup,DK,2023,2
+286,Svelte,markup,DK,2023,2
+212,Less,markup,DK,2023,2
+210,Astro,markup,DK,2023,2
+194,Jinja,markup,DK,2023,2
+183,Handlebars,markup,DK,2023,2
+180,EJS,markup,DK,2023,2
+136,Mustache,markup,DK,2023,2
+129,Blade,markup,DK,2023,2
+105,Pug,markup,DK,2023,2
 8706,JavaScript,programming,DK,2023,2
 6888,Python,programming,DK,2023,2
 4965,Shell,programming,DK,2023,2
@@ -82764,20 +83491,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 169,Hack,programming,DK,2023,2
 161,ASP.NET,programming,DK,2023,2
 152,Scala,programming,DK,2023,2
-148,Tcl,programming,DK,2023,2
 148,Haskell,programming,DK,2023,2
+148,Tcl,programming,DK,2023,2
 140,Awk,programming,DK,2023,2
 136,Julia,programming,DK,2023,2
 134,Groovy,programming,DK,2023,2
 130,Yacc,programming,DK,2023,2
 125,Fortran,programming,DK,2023,2
-122,Mathematica,programming,DK,2023,2
 122,ANTLR,programming,DK,2023,2
+122,Mathematica,programming,DK,2023,2
 120,Smalltalk,programming,DK,2023,2
 117,Cuda,programming,DK,2023,2
 108,Lex,programming,DK,2023,2
 102,Cython,programming,DK,2023,2
 101,Starlark,programming,DK,2023,2
+3355,HTML,markup,DO,2023,2
+2892,CSS,markup,DO,2023,2
+519,SCSS,markup,DO,2023,2
+156,Vue,markup,DO,2023,2
+109,Jupyter Notebook,markup,DO,2023,2
+103,Blade,markup,DO,2023,2
 2936,JavaScript,programming,DO,2023,2
 968,C#,programming,DO,2023,2
 847,TypeScript,programming,DO,2023,2
@@ -82797,6 +83530,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,Makefile,programming,DO,2023,2
 142,Batchfile,programming,DO,2023,2
 107,TSQL,programming,DO,2023,2
+3943,HTML,markup,DZ,2023,2
+3553,CSS,markup,DZ,2023,2
+610,SCSS,markup,DZ,2023,2
+401,Jupyter Notebook,markup,DZ,2023,2
+241,Blade,markup,DZ,2023,2
+164,Vue,markup,DZ,2023,2
 3365,JavaScript,programming,DZ,2023,2
 1430,Python,programming,DZ,2023,2
 728,Java,programming,DZ,2023,2
@@ -82818,6 +83557,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,C#,programming,DZ,2023,2
 106,PowerShell,programming,DZ,2023,2
 104,Procfile,programming,DZ,2023,2
+6500,HTML,markup,EC,2023,2
+5432,CSS,markup,EC,2023,2
+1405,SCSS,markup,EC,2023,2
+756,Jupyter Notebook,markup,EC,2023,2
+312,Blade,markup,EC,2023,2
+246,Vue,markup,EC,2023,2
+238,Less,markup,EC,2023,2
+138,TeX,markup,EC,2023,2
+109,Handlebars,markup,EC,2023,2
 5405,JavaScript,programming,EC,2023,2
 2261,Java,programming,EC,2023,2
 2148,TypeScript,programming,EC,2023,2
@@ -82843,6 +83591,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 128,Papyrus,programming,EC,2023,2
 113,Go,programming,EC,2023,2
 101,CoffeeScript,programming,EC,2023,2
+2922,HTML,markup,EE,2023,2
+2438,CSS,markup,EE,2023,2
+608,SCSS,markup,EE,2023,2
+333,Jupyter Notebook,markup,EE,2023,2
+270,Vue,markup,EE,2023,2
+118,Roff,markup,EE,2023,2
+103,EJS,markup,EE,2023,2
 2706,JavaScript,programming,EE,2023,2
 1608,Python,programming,EE,2023,2
 1223,Shell,programming,EE,2023,2
@@ -82865,6 +83620,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 150,Lua,programming,EE,2023,2
 125,Rust,programming,EE,2023,2
 101,Perl,programming,EE,2023,2
+24124,HTML,markup,EG,2023,2
+20535,CSS,markup,EG,2023,2
+4942,SCSS,markup,EG,2023,2
+4112,Jupyter Notebook,markup,EG,2023,2
+1875,Blade,markup,EG,2023,2
+976,Vue,markup,EG,2023,2
+807,Less,markup,EG,2023,2
+796,EJS,markup,EG,2023,2
+497,Handlebars,markup,EG,2023,2
+371,Roff,markup,EG,2023,2
+282,TeX,markup,EG,2023,2
+244,Pug,markup,EG,2023,2
+143,Rich Text Format,markup,EG,2023,2
+134,Jinja,markup,EG,2023,2
+119,Sass,markup,EG,2023,2
+102,Svelte,markup,EG,2023,2
 20245,JavaScript,programming,EG,2023,2
 9847,Python,programming,EG,2023,2
 8353,C,programming,EG,2023,2
@@ -82921,6 +83692,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,PureBasic,programming,EG,2023,2
 104,Solidity,programming,EG,2023,2
 101,Scala,programming,EG,2023,2
+106,YAML,data,ES,2023,2
+44386,HTML,markup,ES,2023,2
+37185,CSS,markup,ES,2023,2
+10143,SCSS,markup,ES,2023,2
+6933,Jupyter Notebook,markup,ES,2023,2
+2456,Vue,markup,ES,2023,2
+1634,Blade,markup,ES,2023,2
+1463,TeX,markup,ES,2023,2
+1370,Roff,markup,ES,2023,2
+1056,Less,markup,ES,2023,2
+937,Handlebars,markup,ES,2023,2
+876,EJS,markup,ES,2023,2
+744,Jinja,markup,ES,2023,2
+614,Mustache,markup,ES,2023,2
+607,Svelte,markup,ES,2023,2
+601,Twig,markup,ES,2023,2
+518,Pug,markup,ES,2023,2
+448,Sass,markup,ES,2023,2
+445,Rich Text Format,markup,ES,2023,2
+396,Astro,markup,ES,2023,2
+139,Nunjucks,markup,ES,2023,2
+115,Stylus,markup,ES,2023,2
+110,PostScript,markup,ES,2023,2
+102,Liquid,markup,ES,2023,2
 39336,JavaScript,programming,ES,2023,2
 23348,Python,programming,ES,2023,2
 17548,Shell,programming,ES,2023,2
@@ -83003,8 +83798,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 257,Ada,programming,ES,2023,2
 257,AppleScript,programming,ES,2023,2
 256,Meson,programming,ES,2023,2
-252,FreeMarker,programming,ES,2023,2
 252,sed,programming,ES,2023,2
+252,FreeMarker,programming,ES,2023,2
 246,OCaml,programming,ES,2023,2
 239,BASIC,programming,ES,2023,2
 232,Standard ML,programming,ES,2023,2
@@ -83028,40 +83823,40 @@ num_pushers,language,language_type,iso2_code,year,quarter
 191,Haxe,programming,ES,2023,2
 187,AL,programming,ES,2023,2
 186,GDScript,programming,ES,2023,2
-185,xBase,programming,ES,2023,2
 185,Vala,programming,ES,2023,2
 185,V,programming,ES,2023,2
-183,Lasso,programming,ES,2023,2
+185,xBase,programming,ES,2023,2
 183,Arc,programming,ES,2023,2
+183,Lasso,programming,ES,2023,2
 182,Racket,programming,ES,2023,2
 180,Brainfuck,programming,ES,2023,2
 172,Hy,programming,ES,2023,2
 171,Alloy,programming,ES,2023,2
-170,Red,programming,ES,2023,2
-170,CWeb,programming,ES,2023,2
 170,LiveScript,programming,ES,2023,2
+170,CWeb,programming,ES,2023,2
+170,Red,programming,ES,2023,2
 169,Jsonnet,programming,ES,2023,2
-168,Eiffel,programming,ES,2023,2
 168,Mercury,programming,ES,2023,2
+168,Eiffel,programming,ES,2023,2
 167,Agda,programming,ES,2023,2
 167,Cool,programming,ES,2023,2
 166,Boo,programming,ES,2023,2
-165,Modula-2,programming,ES,2023,2
-165,Genie,programming,ES,2023,2
 165,LOLCODE,programming,ES,2023,2
-164,HolyC,programming,ES,2023,2
+165,Genie,programming,ES,2023,2
+165,Modula-2,programming,ES,2023,2
 164,Turing,programming,ES,2023,2
 164,Ballerina,programming,ES,2023,2
+164,HolyC,programming,ES,2023,2
 164,Idris,programming,ES,2023,2
-163,Fantom,programming,ES,2023,2
 163,Chapel,programming,ES,2023,2
 163,SourcePawn,programming,ES,2023,2
 163,Pony,programming,ES,2023,2
-162,Self,programming,ES,2023,2
+163,Fantom,programming,ES,2023,2
 162,Ceylon,programming,ES,2023,2
-162,Dylan,programming,ES,2023,2
-162,Ioke,programming,ES,2023,2
+162,Self,programming,ES,2023,2
 162,Nit,programming,ES,2023,2
+162,Ioke,programming,ES,2023,2
+162,Dylan,programming,ES,2023,2
 161,Witcher Script,programming,ES,2023,2
 161,Grace,programming,ES,2023,2
 160,Befunge,programming,ES,2023,2
@@ -83074,11 +83869,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,Papyrus,programming,ES,2023,2
 118,Visual Basic 6.0,programming,ES,2023,2
 113,M,programming,ES,2023,2
-111,Bicep,programming,ES,2023,2
 111,RobotFramework,programming,ES,2023,2
+111,Bicep,programming,ES,2023,2
 108,SmPL,programming,ES,2023,2
 104,AutoHotkey,programming,ES,2023,2
 102,Thrift,programming,ES,2023,2
+123,Markdown,prose,ES,2023,2
+2691,HTML,markup,ET,2023,2
+2369,CSS,markup,ET,2023,2
+442,SCSS,markup,ET,2023,2
+189,Jupyter Notebook,markup,ET,2023,2
 2417,JavaScript,programming,ET,2023,2
 1528,Shell,programming,ET,2023,2
 1420,Python,programming,ET,2023,2
@@ -83089,17 +83889,48 @@ num_pushers,language,language_type,iso2_code,year,quarter
 462,Ruby,programming,ET,2023,2
 397,Java,programming,ET,2023,2
 380,PHP,programming,ET,2023,2
-341,Kotlin,programming,ET,2023,2
 341,Objective-C,programming,ET,2023,2
+341,Kotlin,programming,ET,2023,2
 336,Dart,programming,ET,2023,2
 327,Swift,programming,ET,2023,2
 300,CMake,programming,ET,2023,2
 294,Puppet,programming,ET,2023,2
 228,Dockerfile,programming,ET,2023,2
-132,Makefile,programming,ET,2023,2
 132,C#,programming,ET,2023,2
+132,Makefile,programming,ET,2023,2
 125,Hack,programming,ET,2023,2
 116,Batchfile,programming,ET,2023,2
+597,YAML,data,EU,2023,2
+410,JSON,data,EU,2023,2
+438010,HTML,markup,EU,2023,2
+369130,CSS,markup,EU,2023,2
+105938,SCSS,markup,EU,2023,2
+68337,Jupyter Notebook,markup,EU,2023,2
+29916,Vue,markup,EU,2023,2
+22618,TeX,markup,EU,2023,2
+19221,Roff,markup,EU,2023,2
+11286,Blade,markup,EU,2023,2
+11215,Less,markup,EU,2023,2
+10179,Jinja,markup,EU,2023,2
+9686,Handlebars,markup,EU,2023,2
+9314,Twig,markup,EU,2023,2
+8625,EJS,markup,EU,2023,2
+7629,Svelte,markup,EU,2023,2
+7261,Mustache,markup,EU,2023,2
+4411,Rich Text Format,markup,EU,2023,2
+4268,Pug,markup,EU,2023,2
+3855,Sass,markup,EU,2023,2
+2657,Astro,markup,EU,2023,2
+1158,PostScript,markup,EU,2023,2
+936,Nunjucks,markup,EU,2023,2
+929,Stylus,markup,EU,2023,2
+886,Liquid,markup,EU,2023,2
+886,Vim Snippet,markup,EU,2023,2
+328,Haml,markup,EU,2023,2
+224,Latte,markup,EU,2023,2
+147,Mermaid,markup,EU,2023,2
+126,YASnippet,markup,EU,2023,2
+115,Slim,markup,EU,2023,2
 399841,JavaScript,programming,EU,2023,2
 277214,Python,programming,EU,2023,2
 221872,Shell,programming,EU,2023,2
@@ -83257,42 +84088,42 @@ num_pushers,language,language_type,iso2_code,year,quarter
 192,RenderScript,programming,EU,2023,2
 190,Nextflow,programming,EU,2023,2
 187,AL,programming,EU,2023,2
+185,V,programming,EU,2023,2
 185,xBase,programming,EU,2023,2
 185,Coq,programming,EU,2023,2
-185,V,programming,EU,2023,2
 184,Module Management System,programming,EU,2023,2
-183,Arc,programming,EU,2023,2
 183,Lasso,programming,EU,2023,2
+183,Arc,programming,EU,2023,2
 182,Racket,programming,EU,2023,2
 174,Max,programming,EU,2023,2
 172,Hy,programming,EU,2023,2
 171,Alloy,programming,EU,2023,2
-170,CWeb,programming,EU,2023,2
 170,Red,programming,EU,2023,2
+170,CWeb,programming,EU,2023,2
 170,LiveScript,programming,EU,2023,2
 169,AGS Script,programming,EU,2023,2
-168,Eiffel,programming,EU,2023,2
 168,Mercury,programming,EU,2023,2
-167,Agda,programming,EU,2023,2
+168,Eiffel,programming,EU,2023,2
 167,Cool,programming,EU,2023,2
+167,Agda,programming,EU,2023,2
 166,Boo,programming,EU,2023,2
-165,Modula-2,programming,EU,2023,2
 165,Genie,programming,EU,2023,2
 165,LOLCODE,programming,EU,2023,2
-164,Ballerina,programming,EU,2023,2
+165,Modula-2,programming,EU,2023,2
 164,Idris,programming,EU,2023,2
+164,Ballerina,programming,EU,2023,2
 164,HolyC,programming,EU,2023,2
 164,Turing,programming,EU,2023,2
-163,Chapel,programming,EU,2023,2
-163,Fantom,programming,EU,2023,2
 163,Pony,programming,EU,2023,2
-162,Ioke,programming,EU,2023,2
-162,Self,programming,EU,2023,2
-162,Dylan,programming,EU,2023,2
+163,Fantom,programming,EU,2023,2
+163,Chapel,programming,EU,2023,2
 162,Ceylon,programming,EU,2023,2
+162,Ioke,programming,EU,2023,2
+162,Dylan,programming,EU,2023,2
 162,Nit,programming,EU,2023,2
-161,Grace,programming,EU,2023,2
+162,Self,programming,EU,2023,2
 161,Witcher Script,programming,EU,2023,2
+161,Grace,programming,EU,2023,2
 160,Befunge,programming,EU,2023,2
 152,SAS,programming,EU,2023,2
 150,Xtend,programming,EU,2023,2
@@ -83303,11 +84134,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,Papyrus,programming,EU,2023,2
 128,XQuery,programming,EU,2023,2
 126,ImageJ Macro,programming,EU,2023,2
-118,Classic ASP,programming,EU,2023,2
 118,Euphoria,programming,EU,2023,2
+118,Classic ASP,programming,EU,2023,2
 113,FreeBasic,programming,EU,2023,2
 111,Qt Script,programming,EU,2023,2
 106,SaltStack,programming,EU,2023,2
+954,Markdown,prose,EU,2023,2
+10107,HTML,markup,FI,2023,2
+8554,CSS,markup,FI,2023,2
+1962,SCSS,markup,FI,2023,2
+1132,Jupyter Notebook,markup,FI,2023,2
+467,Roff,markup,FI,2023,2
+437,TeX,markup,FI,2023,2
+412,Vue,markup,FI,2023,2
+269,Jinja,markup,FI,2023,2
+269,Less,markup,FI,2023,2
+204,Pug,markup,FI,2023,2
+200,Svelte,markup,FI,2023,2
+200,EJS,markup,FI,2023,2
+197,Handlebars,markup,FI,2023,2
+138,Mustache,markup,FI,2023,2
 9550,JavaScript,programming,FI,2023,2
 6477,Python,programming,FI,2023,2
 5208,Shell,programming,FI,2023,2
@@ -83355,17 +84201,44 @@ num_pushers,language,language_type,iso2_code,year,quarter
 146,Awk,programming,FI,2023,2
 138,Yacc,programming,FI,2023,2
 136,Fortran,programming,FI,2023,2
-127,Cuda,programming,FI,2023,2
 127,Starlark,programming,FI,2023,2
+127,Cuda,programming,FI,2023,2
 125,Groovy,programming,FI,2023,2
 122,sed,programming,FI,2023,2
-119,Haskell,programming,FI,2023,2
 119,Meson,programming,FI,2023,2
+119,Haskell,programming,FI,2023,2
 107,Mathematica,programming,FI,2023,2
 107,Gherkin,programming,FI,2023,2
 103,Scheme,programming,FI,2023,2
 102,GDB,programming,FI,2023,2
 101,Tcl,programming,FI,2023,2
+172,YAML,data,FR,2023,2
+154,JSON,data,FR,2023,2
+71585,HTML,markup,FR,2023,2
+63597,CSS,markup,FR,2023,2
+19496,SCSS,markup,FR,2023,2
+10315,Jupyter Notebook,markup,FR,2023,2
+5825,Vue,markup,FR,2023,2
+5137,Twig,markup,FR,2023,2
+3480,TeX,markup,FR,2023,2
+3032,Roff,markup,FR,2023,2
+2027,Less,markup,FR,2023,2
+1763,Jinja,markup,FR,2023,2
+1581,Handlebars,markup,FR,2023,2
+1550,Blade,markup,FR,2023,2
+1504,EJS,markup,FR,2023,2
+1193,Mustache,markup,FR,2023,2
+1177,Svelte,markup,FR,2023,2
+778,Rich Text Format,markup,FR,2023,2
+749,Pug,markup,FR,2023,2
+747,Sass,markup,FR,2023,2
+558,Astro,markup,FR,2023,2
+301,PostScript,markup,FR,2023,2
+262,Nunjucks,markup,FR,2023,2
+254,Stylus,markup,FR,2023,2
+190,Liquid,markup,FR,2023,2
+189,Vim Snippet,markup,FR,2023,2
+115,Haml,markup,FR,2023,2
 67074,JavaScript,programming,FR,2023,2
 41458,Python,programming,FR,2023,2
 34973,Shell,programming,FR,2023,2
@@ -83429,8 +84302,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 543,Haskell,programming,FR,2023,2
 537,GDB,programming,FR,2023,2
 534,NASL,programming,FR,2023,2
-525,Scheme,programming,FR,2023,2
 525,Meson,programming,FR,2023,2
+525,Scheme,programming,FR,2023,2
 510,Julia,programming,FR,2023,2
 502,Raku,programming,FR,2023,2
 490,PLSQL,programming,FR,2023,2
@@ -83463,21 +84336,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 244,DIGITAL Command Language,programming,FR,2023,2
 238,Processing,programming,FR,2023,2
 238,Jsonnet,programming,FR,2023,2
-227,M,programming,FR,2023,2
 227,AppleScript,programming,FR,2023,2
+227,M,programming,FR,2023,2
 207,Visual Basic .NET,programming,FR,2023,2
 200,F#,programming,FR,2023,2
 194,AMPL,programming,FR,2023,2
 193,POV-Ray SDL,programming,FR,2023,2
-185,Coq,programming,FR,2023,2
 185,XS,programming,FR,2023,2
+185,Coq,programming,FR,2023,2
 183,AutoHotkey,programming,FR,2023,2
 174,Nim,programming,FR,2023,2
 170,AIDL,programming,FR,2023,2
 164,LLVM,programming,FR,2023,2
 164,Ada,programming,FR,2023,2
-162,Stata,programming,FR,2023,2
 162,RobotFramework,programming,FR,2023,2
+162,Stata,programming,FR,2023,2
 159,Zig,programming,FR,2023,2
 156,SystemVerilog,programming,FR,2023,2
 149,CUE,programming,FR,2023,2
@@ -83487,8 +84360,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 146,OpenSCAD,programming,FR,2023,2
 144,COBOL,programming,FR,2023,2
 143,Scilab,programming,FR,2023,2
-141,DTrace,programming,FR,2023,2
 141,Sage,programming,FR,2023,2
+141,DTrace,programming,FR,2023,2
 137,Elm,programming,FR,2023,2
 130,UnrealScript,programming,FR,2023,2
 129,Thrift,programming,FR,2023,2
@@ -83496,8 +84369,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 123,OpenEdge ABL,programming,FR,2023,2
 122,WebAssembly,programming,FR,2023,2
 121,Visual Basic 6.0,programming,FR,2023,2
-119,ASL,programming,FR,2023,2
 119,PureScript,programming,FR,2023,2
+119,ASL,programming,FR,2023,2
 118,Fluent,programming,FR,2023,2
 118,Haxe,programming,FR,2023,2
 115,ActionScript,programming,FR,2023,2
@@ -83505,6 +84378,40 @@ num_pushers,language,language_type,iso2_code,year,quarter
 108,JetBrains MPS,programming,FR,2023,2
 105,Logos,programming,FR,2023,2
 102,Apex,programming,FR,2023,2
+232,Markdown,prose,FR,2023,2
+144,HTML,markup,GA,2023,2
+116,CSS,markup,GA,2023,2
+197,YAML,data,GB,2023,2
+180,JSON,data,GB,2023,2
+77260,HTML,markup,GB,2023,2
+63188,CSS,markup,GB,2023,2
+19278,SCSS,markup,GB,2023,2
+15571,Jupyter Notebook,markup,GB,2023,2
+4381,TeX,markup,GB,2023,2
+3465,Vue,markup,GB,2023,2
+3416,Roff,markup,GB,2023,2
+1983,Jinja,markup,GB,2023,2
+1876,Handlebars,markup,GB,2023,2
+1803,Less,markup,GB,2023,2
+1787,EJS,markup,GB,2023,2
+1460,Mustache,markup,GB,2023,2
+1394,Nunjucks,markup,GB,2023,2
+1372,Blade,markup,GB,2023,2
+1216,Svelte,markup,GB,2023,2
+1055,Rich Text Format,markup,GB,2023,2
+937,Pug,markup,GB,2023,2
+680,Sass,markup,GB,2023,2
+672,Astro,markup,GB,2023,2
+522,Twig,markup,GB,2023,2
+367,PostScript,markup,GB,2023,2
+359,Liquid,markup,GB,2023,2
+302,Vim Snippet,markup,GB,2023,2
+231,Stylus,markup,GB,2023,2
+164,Haml,markup,GB,2023,2
+146,RAML,markup,GB,2023,2
+139,Mermaid,markup,GB,2023,2
+121,Slim,markup,GB,2023,2
+112,YASnippet,markup,GB,2023,2
 70752,JavaScript,programming,GB,2023,2
 54411,Python,programming,GB,2023,2
 43046,Shell,programming,GB,2023,2
@@ -83554,8 +84461,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1083,TSQL,programming,GB,2023,2
 1072,Cython,programming,GB,2023,2
 1054,Solidity,programming,GB,2023,2
-952,Haskell,programming,GB,2023,2
 952,Yacc,programming,GB,2023,2
+952,Haskell,programming,GB,2023,2
 935,Cuda,programming,GB,2023,2
 882,ASP.NET,programming,GB,2023,2
 838,Tcl,programming,GB,2023,2
@@ -83620,8 +84527,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 229,POV-Ray SDL,programming,GB,2023,2
 227,Thrift,programming,GB,2023,2
 226,SystemVerilog,programming,GB,2023,2
-212,Zig,programming,GB,2023,2
 212,Nim,programming,GB,2023,2
+212,Zig,programming,GB,2023,2
 193,WebAssembly,programming,GB,2023,2
 192,CUE,programming,GB,2023,2
 189,Ada,programming,GB,2023,2
@@ -83642,8 +84549,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 148,Visual Basic 6.0,programming,GB,2023,2
 146,Fluent,programming,GB,2023,2
 145,Logos,programming,GB,2023,2
-143,SAS,programming,GB,2023,2
 143,PureScript,programming,GB,2023,2
+143,SAS,programming,GB,2023,2
 139,jq,programming,GB,2023,2
 136,VBA,programming,GB,2023,2
 136,Stan,programming,GB,2023,2
@@ -83655,16 +84562,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Brainfuck,programming,GB,2023,2
 119,Rebol,programming,GB,2023,2
 118,Apex,programming,GB,2023,2
-116,SuperCollider,programming,GB,2023,2
 116,BASIC,programming,GB,2023,2
+116,SuperCollider,programming,GB,2023,2
 114,COBOL,programming,GB,2023,2
 111,Cap'n Proto,programming,GB,2023,2
-109,Max,programming,GB,2023,2
 109,Racket,programming,GB,2023,2
+109,Max,programming,GB,2023,2
 107,ActionScript,programming,GB,2023,2
 104,JetBrains MPS,programming,GB,2023,2
 103,q,programming,GB,2023,2
 102,NewLisp,programming,GB,2023,2
+273,Markdown,prose,GB,2023,2
+6960,HTML,markup,GE,2023,2
+5939,CSS,markup,GE,2023,2
+1602,SCSS,markup,GE,2023,2
+366,Jupyter Notebook,markup,GE,2023,2
+351,Vue,markup,GE,2023,2
+170,Blade,markup,GE,2023,2
+139,Less,markup,GE,2023,2
 5961,JavaScript,programming,GE,2023,2
 2377,Python,programming,GE,2023,2
 2337,TypeScript,programming,GE,2023,2
@@ -83690,9 +84605,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,Dart,programming,GE,2023,2
 116,HLSL,programming,GE,2023,2
 113,ShaderLab,programming,GE,2023,2
-110,Objective-C++,programming,GE,2023,2
 110,HCL,programming,GE,2023,2
+110,Objective-C++,programming,GE,2023,2
 106,Assembly,programming,GE,2023,2
+5865,HTML,markup,GH,2023,2
+4840,CSS,markup,GH,2023,2
+866,SCSS,markup,GH,2023,2
+731,Jupyter Notebook,markup,GH,2023,2
+248,Blade,markup,GH,2023,2
+222,Vue,markup,GH,2023,2
+135,Less,markup,GH,2023,2
+120,EJS,markup,GH,2023,2
 4638,JavaScript,programming,GH,2023,2
 3623,Shell,programming,GH,2023,2
 2810,C,programming,GH,2023,2
@@ -83719,6 +84642,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Go,programming,GH,2023,2
 114,MATLAB,programming,GH,2023,2
 109,Brainfuck,programming,GH,2023,2
+101,HTML,markup,GN,2023,2
+5413,HTML,markup,GR,2023,2
+4533,CSS,markup,GR,2023,2
+1117,Jupyter Notebook,markup,GR,2023,2
+1103,SCSS,markup,GR,2023,2
+302,TeX,markup,GR,2023,2
+240,Vue,markup,GR,2023,2
+232,Roff,markup,GR,2023,2
+161,Handlebars,markup,GR,2023,2
+157,EJS,markup,GR,2023,2
+136,Less,markup,GR,2023,2
+130,Jinja,markup,GR,2023,2
+127,Blade,markup,GR,2023,2
+104,Mustache,markup,GR,2023,2
 4733,JavaScript,programming,GR,2023,2
 3933,Python,programming,GR,2023,2
 2568,Shell,programming,GR,2023,2
@@ -83756,10 +84693,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 124,Dart,programming,GR,2023,2
 121,PLpgSQL,programming,GR,2023,2
 118,M4,programming,GR,2023,2
-108,Objective-C++,programming,GR,2023,2
 108,Lex,programming,GR,2023,2
-104,Yacc,programming,GR,2023,2
+108,Objective-C++,programming,GR,2023,2
 104,Groovy,programming,GR,2023,2
+104,Yacc,programming,GR,2023,2
+3772,HTML,markup,GT,2023,2
+3033,CSS,markup,GT,2023,2
+606,SCSS,markup,GT,2023,2
+339,Jupyter Notebook,markup,GT,2023,2
+160,Blade,markup,GT,2023,2
+134,Vue,markup,GT,2023,2
 2854,JavaScript,programming,GT,2023,2
 1155,Java,programming,GT,2023,2
 1103,Python,programming,GT,2023,2
@@ -83780,6 +84723,28 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,Kotlin,programming,GT,2023,2
 115,Swift,programming,GT,2023,2
 110,Objective-C,programming,GT,2023,2
+43890,HTML,markup,HK,2023,2
+33320,CSS,markup,HK,2023,2
+12913,SCSS,markup,HK,2023,2
+10299,Vue,markup,HK,2023,2
+6573,Jupyter Notebook,markup,HK,2023,2
+5427,Less,markup,HK,2023,2
+2816,Roff,markup,HK,2023,2
+2225,TeX,markup,HK,2023,2
+1498,EJS,markup,HK,2023,2
+1183,Mustache,markup,HK,2023,2
+1040,Stylus,markup,HK,2023,2
+960,Handlebars,markup,HK,2023,2
+913,Jinja,markup,HK,2023,2
+576,Pug,markup,HK,2023,2
+554,Astro,markup,HK,2023,2
+453,Svelte,markup,HK,2023,2
+452,Rich Text Format,markup,HK,2023,2
+399,Blade,markup,HK,2023,2
+393,Vim Snippet,markup,HK,2023,2
+350,Sass,markup,HK,2023,2
+193,PostScript,markup,HK,2023,2
+148,Nunjucks,markup,HK,2023,2
 43797,JavaScript,programming,HK,2023,2
 34009,Shell,programming,HK,2023,2
 33271,Python,programming,HK,2023,2
@@ -83885,8 +84850,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 182,q,programming,HK,2023,2
 177,Elixir,programming,HK,2023,2
 174,Common Lisp,programming,HK,2023,2
-173,Erlang,programming,HK,2023,2
 173,POV-Ray SDL,programming,HK,2023,2
+173,Erlang,programming,HK,2023,2
 171,Visual Basic .NET,programming,HK,2023,2
 169,Classic ASP,programming,HK,2023,2
 158,VHDL,programming,HK,2023,2
@@ -83913,10 +84878,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,MLIR,programming,HK,2023,2
 105,CUE,programming,HK,2023,2
 104,Move,programming,HK,2023,2
-103,Zig,programming,HK,2023,2
 103,ReScript,programming,HK,2023,2
 103,Visual Basic 6.0,programming,HK,2023,2
+103,Zig,programming,HK,2023,2
 102,Stata,programming,HK,2023,2
+214,Markdown,prose,HK,2023,2
+1556,HTML,markup,HN,2023,2
+1416,CSS,markup,HN,2023,2
+280,SCSS,markup,HN,2023,2
+109,Blade,markup,HN,2023,2
 1322,JavaScript,programming,HN,2023,2
 429,TypeScript,programming,HN,2023,2
 371,C#,programming,HN,2023,2
@@ -83926,6 +84896,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 182,Dockerfile,programming,HN,2023,2
 133,Shell,programming,HN,2023,2
 126,C++,programming,HN,2023,2
+4344,HTML,markup,HR,2023,2
+3821,CSS,markup,HR,2023,2
+950,SCSS,markup,HR,2023,2
+353,Jupyter Notebook,markup,HR,2023,2
+316,Vue,markup,HR,2023,2
+126,TeX,markup,HR,2023,2
+115,Blade,markup,HR,2023,2
+108,Roff,markup,HR,2023,2
 4001,JavaScript,programming,HR,2023,2
 1783,Python,programming,HR,2023,2
 1278,Shell,programming,HR,2023,2
@@ -83954,7 +84932,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,ShaderLab,programming,HR,2023,2
 105,HLSL,programming,HR,2023,2
 103,Perl,programming,HR,2023,2
+201,HTML,markup,HT,2023,2
+172,CSS,markup,HT,2023,2
 159,JavaScript,programming,HT,2023,2
+9205,HTML,markup,HU,2023,2
+7795,CSS,markup,HU,2023,2
+1942,SCSS,markup,HU,2023,2
+847,Jupyter Notebook,markup,HU,2023,2
+559,Vue,markup,HU,2023,2
+459,Blade,markup,HU,2023,2
+332,Roff,markup,HU,2023,2
+271,TeX,markup,HU,2023,2
+245,EJS,markup,HU,2023,2
+170,Less,markup,HU,2023,2
+158,Handlebars,markup,HU,2023,2
+156,Mustache,markup,HU,2023,2
+154,Jinja,markup,HU,2023,2
+150,Svelte,markup,HU,2023,2
+122,Rich Text Format,markup,HU,2023,2
+118,Twig,markup,HU,2023,2
 7894,JavaScript,programming,HU,2023,2
 4364,Python,programming,HU,2023,2
 3223,Shell,programming,HU,2023,2
@@ -84001,6 +84997,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Yacc,programming,HU,2023,2
 108,Awk,programming,HU,2023,2
 101,Lex,programming,HU,2023,2
+67589,HTML,markup,ID,2023,2
+62655,CSS,markup,ID,2023,2
+16056,Blade,markup,ID,2023,2
+16045,SCSS,markup,ID,2023,2
+10258,Jupyter Notebook,markup,ID,2023,2
+4516,Vue,markup,ID,2023,2
+3535,Less,markup,ID,2023,2
+1623,EJS,markup,ID,2023,2
+813,Roff,markup,ID,2023,2
+760,Handlebars,markup,ID,2023,2
+596,Pug,markup,ID,2023,2
+513,Svelte,markup,ID,2023,2
+483,TeX,markup,ID,2023,2
+345,Sass,markup,ID,2023,2
+306,Astro,markup,ID,2023,2
+232,Rich Text Format,markup,ID,2023,2
+181,Stylus,markup,ID,2023,2
+179,Jinja,markup,ID,2023,2
+136,Mustache,markup,ID,2023,2
+105,Twig,markup,ID,2023,2
 65962,JavaScript,programming,ID,2023,2
 32080,PHP,programming,ID,2023,2
 20870,Python,programming,ID,2023,2
@@ -84056,8 +85072,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 237,Clojure,programming,ID,2023,2
 221,TSQL,programming,ID,2023,2
 220,Forth,programming,ID,2023,2
-213,sed,programming,ID,2023,2
 213,Raku,programming,ID,2023,2
+213,sed,programming,ID,2023,2
 199,SmPL,programming,ID,2023,2
 194,XS,programming,ID,2023,2
 190,UnrealScript,programming,ID,2023,2
@@ -84065,16 +85081,31 @@ num_pushers,language,language_type,iso2_code,year,quarter
 183,AIDL,programming,ID,2023,2
 169,GDB,programming,ID,2023,2
 160,Fortran,programming,ID,2023,2
-133,Scala,programming,ID,2023,2
 133,GAP,programming,ID,2023,2
+133,Scala,programming,ID,2023,2
 124,Mathematica,programming,ID,2023,2
 122,GDScript,programming,ID,2023,2
 118,Emacs Lisp,programming,ID,2023,2
 108,Cuda,programming,ID,2023,2
 105,Smalltalk,programming,ID,2023,2
 102,QMake,programming,ID,2023,2
-101,Inno Setup,programming,ID,2023,2
 101,Prolog,programming,ID,2023,2
+101,Inno Setup,programming,ID,2023,2
+115,Markdown,prose,ID,2023,2
+8351,HTML,markup,IE,2023,2
+6897,CSS,markup,IE,2023,2
+1676,SCSS,markup,IE,2023,2
+1596,Jupyter Notebook,markup,IE,2023,2
+299,Vue,markup,IE,2023,2
+298,Roff,markup,IE,2023,2
+280,TeX,markup,IE,2023,2
+216,Handlebars,markup,IE,2023,2
+193,Jinja,markup,IE,2023,2
+183,Less,markup,IE,2023,2
+168,EJS,markup,IE,2023,2
+146,Mustache,markup,IE,2023,2
+138,Svelte,markup,IE,2023,2
+138,Blade,markup,IE,2023,2
 7285,JavaScript,programming,IE,2023,2
 5416,Python,programming,IE,2023,2
 4005,Shell,programming,IE,2023,2
@@ -84097,8 +85128,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 355,Rust,programming,IE,2023,2
 337,HLSL,programming,IE,2023,2
 336,Objective-C,programming,IE,2023,2
-323,Lua,programming,IE,2023,2
 323,Perl,programming,IE,2023,2
+323,Lua,programming,IE,2023,2
 320,ShaderLab,programming,IE,2023,2
 307,Assembly,programming,IE,2023,2
 306,Swift,programming,IE,2023,2
@@ -84106,15 +85137,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 262,Smarty,programming,IE,2023,2
 224,Vim Script,programming,IE,2023,2
 195,GLSL,programming,IE,2023,2
-161,XSLT,programming,IE,2023,2
 161,Objective-C++,programming,IE,2023,2
+161,XSLT,programming,IE,2023,2
 151,M4,programming,IE,2023,2
-150,Hack,programming,IE,2023,2
 150,Nix,programming,IE,2023,2
+150,Hack,programming,IE,2023,2
 148,Groovy,programming,IE,2023,2
 128,Starlark,programming,IE,2023,2
-126,Scala,programming,IE,2023,2
 126,Emacs Lisp,programming,IE,2023,2
+126,Scala,programming,IE,2023,2
 124,Gherkin,programming,IE,2023,2
 118,Solidity,programming,IE,2023,2
 116,Cython,programming,IE,2023,2
@@ -84123,6 +85154,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,Awk,programming,IE,2023,2
 106,MATLAB,programming,IE,2023,2
 102,GAP,programming,IE,2023,2
+16893,HTML,markup,IL,2023,2
+13767,CSS,markup,IL,2023,2
+3418,SCSS,markup,IL,2023,2
+3201,Jupyter Notebook,markup,IL,2023,2
+688,Vue,markup,IL,2023,2
+643,EJS,markup,IL,2023,2
+596,Roff,markup,IL,2023,2
+416,Mustache,markup,IL,2023,2
+409,Jinja,markup,IL,2023,2
+392,Handlebars,markup,IL,2023,2
+392,TeX,markup,IL,2023,2
+334,Less,markup,IL,2023,2
+273,Pug,markup,IL,2023,2
+215,Rich Text Format,markup,IL,2023,2
+146,Svelte,markup,IL,2023,2
+132,Sass,markup,IL,2023,2
+111,Blade,markup,IL,2023,2
 16169,JavaScript,programming,IL,2023,2
 13543,Python,programming,IL,2023,2
 8140,Shell,programming,IL,2023,2
@@ -84181,6 +85229,36 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,ANTLR,programming,IL,2023,2
 102,Jsonnet,programming,IL,2023,2
 101,Meson,programming,IL,2023,2
+151,YAML,data,IN,2023,2
+144,JSON,data,IN,2023,2
+442841,HTML,markup,IN,2023,2
+365945,CSS,markup,IN,2023,2
+90110,Jupyter Notebook,markup,IN,2023,2
+55307,SCSS,markup,IN,2023,2
+17830,EJS,markup,IN,2023,2
+7475,Less,markup,IN,2023,2
+6099,Vue,markup,IN,2023,2
+6016,Roff,markup,IN,2023,2
+5869,Handlebars,markup,IN,2023,2
+4923,Blade,markup,IN,2023,2
+3484,Pug,markup,IN,2023,2
+3417,TeX,markup,IN,2023,2
+3290,Jinja,markup,IN,2023,2
+2654,Mustache,markup,IN,2023,2
+1791,Rich Text Format,markup,IN,2023,2
+1634,Svelte,markup,IN,2023,2
+1302,Sass,markup,IN,2023,2
+967,Astro,markup,IN,2023,2
+584,Twig,markup,IN,2023,2
+562,Liquid,markup,IN,2023,2
+469,Stylus,markup,IN,2023,2
+345,PostScript,markup,IN,2023,2
+308,Nunjucks,markup,IN,2023,2
+278,kvlang,markup,IN,2023,2
+253,Vim Snippet,markup,IN,2023,2
+207,RAML,markup,IN,2023,2
+153,Haml,markup,IN,2023,2
+135,Slim,markup,IN,2023,2
 358971,JavaScript,programming,IN,2023,2
 179609,Python,programming,IN,2023,2
 124797,Java,programming,IN,2023,2
@@ -84312,26 +85390,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 159,Ada,programming,IN,2023,2
 159,Zig,programming,IN,2023,2
 157,WebAssembly,programming,IN,2023,2
-154,PureScript,programming,IN,2023,2
-154,ReScript,programming,IN,2023,2
-154,Sage,programming,IN,2023,2
 154,PigLatin,programming,IN,2023,2
+154,Sage,programming,IN,2023,2
 154,LookML,programming,IN,2023,2
+154,ReScript,programming,IN,2023,2
+154,PureScript,programming,IN,2023,2
 153,ABAP,programming,IN,2023,2
 152,CAP CDS,programming,IN,2023,2
-151,Rebol,programming,IN,2023,2
 151,CUE,programming,IN,2023,2
+151,Rebol,programming,IN,2023,2
 146,PEG.js,programming,IN,2023,2
 144,Xonsh,programming,IN,2023,2
 144,Brainfuck,programming,IN,2023,2
 143,Motoko,programming,IN,2023,2
-141,Metal,programming,IN,2023,2
-141,POV-Ray SDL,programming,IN,2023,2
 141,Cadence,programming,IN,2023,2
+141,POV-Ray SDL,programming,IN,2023,2
+141,Metal,programming,IN,2023,2
+139,Elm,programming,IN,2023,2
+139,ASL,programming,IN,2023,2
 139,VCL,programming,IN,2023,2
 139,Stata,programming,IN,2023,2
-139,ASL,programming,IN,2023,2
-139,Elm,programming,IN,2023,2
 133,Io,programming,IN,2023,2
 122,AutoHotkey,programming,IN,2023,2
 121,Dhall,programming,IN,2023,2
@@ -84345,6 +85423,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 105,q,programming,IN,2023,2
 103,Lasso,programming,IN,2023,2
 102,AGS Script,programming,IN,2023,2
+311,Markdown,prose,IN,2023,2
+1739,HTML,markup,IQ,2023,2
+1352,CSS,markup,IQ,2023,2
+201,SCSS,markup,IQ,2023,2
+132,Vue,markup,IQ,2023,2
+128,Blade,markup,IQ,2023,2
+110,Jupyter Notebook,markup,IQ,2023,2
 1366,JavaScript,programming,IQ,2023,2
 820,Python,programming,IQ,2023,2
 391,Shell,programming,IQ,2023,2
@@ -84362,6 +85447,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 182,Java,programming,IQ,2023,2
 158,C#,programming,IQ,2023,2
 134,Ruby,programming,IQ,2023,2
+11042,HTML,markup,IR,2023,2
+9622,CSS,markup,IR,2023,2
+2545,SCSS,markup,IR,2023,2
+1950,Jupyter Notebook,markup,IR,2023,2
+789,Blade,markup,IR,2023,2
+777,Vue,markup,IR,2023,2
+485,Less,markup,IR,2023,2
+226,TeX,markup,IR,2023,2
+184,EJS,markup,IR,2023,2
+181,Roff,markup,IR,2023,2
+125,Handlebars,markup,IR,2023,2
 9959,JavaScript,programming,IR,2023,2
 6688,Python,programming,IR,2023,2
 3057,Shell,programming,IR,2023,2
@@ -84395,6 +85491,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,ASP.NET,programming,IR,2023,2
 106,Verilog,programming,IR,2023,2
 101,XSLT,programming,IR,2023,2
+714,HTML,markup,IS,2023,2
+679,CSS,markup,IS,2023,2
+168,SCSS,markup,IS,2023,2
 685,JavaScript,programming,IS,2023,2
 480,Python,programming,IS,2023,2
 369,Shell,programming,IS,2023,2
@@ -84406,6 +85505,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 166,C++,programming,IS,2023,2
 121,Ruby,programming,IS,2023,2
 106,C#,programming,IS,2023,2
+26831,HTML,markup,IT,2023,2
+22323,CSS,markup,IT,2023,2
+6600,SCSS,markup,IT,2023,2
+5568,Jupyter Notebook,markup,IT,2023,2
+2182,Vue,markup,IT,2023,2
+2018,TeX,markup,IT,2023,2
+1311,Blade,markup,IT,2023,2
+1245,Roff,markup,IT,2023,2
+615,Less,markup,IT,2023,2
+524,Jinja,markup,IT,2023,2
+505,Handlebars,markup,IT,2023,2
+459,EJS,markup,IT,2023,2
+390,Svelte,markup,IT,2023,2
+372,Mustache,markup,IT,2023,2
+310,Rich Text Format,markup,IT,2023,2
+245,Sass,markup,IT,2023,2
+245,Pug,markup,IT,2023,2
+208,Astro,markup,IT,2023,2
+206,Twig,markup,IT,2023,2
+142,PostScript,markup,IT,2023,2
 23333,JavaScript,programming,IT,2023,2
 17436,Python,programming,IT,2023,2
 12880,Shell,programming,IT,2023,2
@@ -84472,17 +85591,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 210,Haskell,programming,IT,2023,2
 200,Julia,programming,IT,2023,2
 199,FreeMarker,programming,IT,2023,2
-197,Gnuplot,programming,IT,2023,2
 197,SWIG,programming,IT,2023,2
+197,Gnuplot,programming,IT,2023,2
 193,Raku,programming,IT,2023,2
 190,PLSQL,programming,IT,2023,2
-185,Scheme,programming,IT,2023,2
 185,VHDL,programming,IT,2023,2
+185,Scheme,programming,IT,2023,2
 180,Clojure,programming,IT,2023,2
-172,QML,programming,IT,2023,2
 172,M,programming,IT,2023,2
-170,Inno Setup,programming,IT,2023,2
+172,QML,programming,IT,2023,2
 170,ASP.NET,programming,IT,2023,2
+170,Inno Setup,programming,IT,2023,2
 169,GAP,programming,IT,2023,2
 156,Verilog,programming,IT,2023,2
 150,Mako,programming,IT,2023,2
@@ -84507,11 +85626,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Standard ML,programming,IT,2023,2
 106,VBScript,programming,IT,2023,2
 102,OCaml,programming,IT,2023,2
+589,HTML,markup,JM,2023,2
+539,CSS,markup,JM,2023,2
+119,Vue,markup,JM,2023,2
 548,JavaScript,programming,JM,2023,2
 282,Python,programming,JM,2023,2
 149,TypeScript,programming,JM,2023,2
 148,Java,programming,JM,2023,2
 116,Shell,programming,JM,2023,2
+2356,HTML,markup,JO,2023,2
+1956,CSS,markup,JO,2023,2
+486,SCSS,markup,JO,2023,2
+237,Jupyter Notebook,markup,JO,2023,2
+170,Blade,markup,JO,2023,2
 1942,JavaScript,programming,JO,2023,2
 682,Python,programming,JO,2023,2
 605,Java,programming,JO,2023,2
@@ -84530,6 +85657,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,Ruby,programming,JO,2023,2
 133,Makefile,programming,JO,2023,2
 106,PowerShell,programming,JO,2023,2
+62513,HTML,markup,JP,2023,2
+51002,CSS,markup,JP,2023,2
+15932,SCSS,markup,JP,2023,2
+8392,Vue,markup,JP,2023,2
+7500,Jupyter Notebook,markup,JP,2023,2
+3119,Blade,markup,JP,2023,2
+2719,Less,markup,JP,2023,2
+2598,Roff,markup,JP,2023,2
+2214,TeX,markup,JP,2023,2
+1585,EJS,markup,JP,2023,2
+1046,Pug,markup,JP,2023,2
+995,Astro,markup,JP,2023,2
+920,Handlebars,markup,JP,2023,2
+818,Jinja,markup,JP,2023,2
+782,Svelte,markup,JP,2023,2
+680,Mustache,markup,JP,2023,2
+602,Stylus,markup,JP,2023,2
+492,Sass,markup,JP,2023,2
+469,Rich Text Format,markup,JP,2023,2
+466,Vim Snippet,markup,JP,2023,2
+296,Haml,markup,JP,2023,2
+257,Slim,markup,JP,2023,2
+218,PostScript,markup,JP,2023,2
+186,Liquid,markup,JP,2023,2
+181,Nunjucks,markup,JP,2023,2
+170,Twig,markup,JP,2023,2
+157,YASnippet,markup,JP,2023,2
 58226,JavaScript,programming,JP,2023,2
 36853,Python,programming,JP,2023,2
 34421,Shell,programming,JP,2023,2
@@ -84606,8 +85760,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 336,ASP.NET,programming,JP,2023,2
 333,PLSQL,programming,JP,2023,2
 332,GAP,programming,JP,2023,2
-319,TSQL,programming,JP,2023,2
 319,SmPL,programming,JP,2023,2
+319,TSQL,programming,JP,2023,2
 317,Smalltalk,programming,JP,2023,2
 309,Gnuplot,programming,JP,2023,2
 305,SWIG,programming,JP,2023,2
@@ -84630,10 +85784,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 220,LLVM,programming,JP,2023,2
 216,F#,programming,JP,2023,2
 204,Inno Setup,programming,JP,2023,2
-202,M,programming,JP,2023,2
 202,Erlang,programming,JP,2023,2
-190,DTrace,programming,JP,2023,2
+202,M,programming,JP,2023,2
 190,Metal,programming,JP,2023,2
+190,DTrace,programming,JP,2023,2
 185,SystemVerilog,programming,JP,2023,2
 184,Bicep,programming,JP,2023,2
 183,POV-Ray SDL,programming,JP,2023,2
@@ -84651,8 +85805,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 134,Scilab,programming,JP,2023,2
 129,RPC,programming,JP,2023,2
 123,WebAssembly,programming,JP,2023,2
-116,Ada,programming,JP,2023,2
 116,Logos,programming,JP,2023,2
+116,Ada,programming,JP,2023,2
 111,Ragel,programming,JP,2023,2
 110,Reason,programming,JP,2023,2
 108,mcfunction,programming,JP,2023,2
@@ -84660,9 +85814,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 105,Fluent,programming,JP,2023,2
 104,Module Management System,programming,JP,2023,2
 103,Brainfuck,programming,JP,2023,2
-102,ASL,programming,JP,2023,2
 102,Classic ASP,programming,JP,2023,2
+102,ASL,programming,JP,2023,2
 101,RenderScript,programming,JP,2023,2
+234,Markdown,prose,JP,2023,2
+15164,HTML,markup,KE,2023,2
+13679,CSS,markup,KE,2023,2
+2726,SCSS,markup,KE,2023,2
+2065,Jupyter Notebook,markup,KE,2023,2
+892,Blade,markup,KE,2023,2
+726,Vue,markup,KE,2023,2
+398,EJS,markup,KE,2023,2
+387,Less,markup,KE,2023,2
+209,Roff,markup,KE,2023,2
+195,Handlebars,markup,KE,2023,2
+151,Pug,markup,KE,2023,2
+105,TeX,markup,KE,2023,2
 13287,JavaScript,programming,KE,2023,2
 9114,Shell,programming,KE,2023,2
 7437,Python,programming,KE,2023,2
@@ -84706,6 +85873,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 115,PLpgSQL,programming,KE,2023,2
 113,CoffeeScript,programming,KE,2023,2
 111,Perl,programming,KE,2023,2
+4380,HTML,markup,KG,2023,2
+3546,CSS,markup,KG,2023,2
+1047,SCSS,markup,KG,2023,2
+150,Vue,markup,KG,2023,2
+128,Jupyter Notebook,markup,KG,2023,2
 3372,JavaScript,programming,KG,2023,2
 1642,Python,programming,KG,2023,2
 956,Java,programming,KG,2023,2
@@ -84727,6 +85899,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 158,Batchfile,programming,KG,2023,2
 117,Go,programming,KG,2023,2
 105,Procfile,programming,KG,2023,2
+2008,HTML,markup,KH,2023,2
+1709,CSS,markup,KH,2023,2
+409,SCSS,markup,KH,2023,2
+355,Blade,markup,KH,2023,2
+283,Vue,markup,KH,2023,2
 1792,JavaScript,programming,KH,2023,2
 575,PHP,programming,KH,2023,2
 532,TypeScript,programming,KH,2023,2
@@ -84745,6 +85922,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 159,Makefile,programming,KH,2023,2
 143,C#,programming,KH,2023,2
 104,Hack,programming,KH,2023,2
+114,YAML,data,KR,2023,2
+113,JSON,data,KR,2023,2
+81763,HTML,markup,KR,2023,2
+58871,CSS,markup,KR,2023,2
+16104,SCSS,markup,KR,2023,2
+15294,Jupyter Notebook,markup,KR,2023,2
+5070,Vue,markup,KR,2023,2
+2004,EJS,markup,KR,2023,2
+1681,Roff,markup,KR,2023,2
+1487,Less,markup,KR,2023,2
+1287,TeX,markup,KR,2023,2
+1271,Pug,markup,KR,2023,2
+1000,Mustache,markup,KR,2023,2
+699,Svelte,markup,KR,2023,2
+670,Handlebars,markup,KR,2023,2
+390,Jinja,markup,KR,2023,2
+382,Rich Text Format,markup,KR,2023,2
+372,Sass,markup,KR,2023,2
+343,Vim Snippet,markup,KR,2023,2
+230,Blade,markup,KR,2023,2
+199,Liquid,markup,KR,2023,2
+151,Astro,markup,KR,2023,2
+147,Stylus,markup,KR,2023,2
+125,PostScript,markup,KR,2023,2
 67001,JavaScript,programming,KR,2023,2
 43290,Python,programming,KR,2023,2
 42060,Java,programming,KR,2023,2
@@ -84826,8 +86027,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,Processing,programming,KR,2023,2
 143,SmPL,programming,KR,2023,2
 141,Ada,programming,KR,2023,2
-140,XS,programming,KR,2023,2
 140,CoffeeScript,programming,KR,2023,2
+140,XS,programming,KR,2023,2
 139,ANTLR,programming,KR,2023,2
 133,Common Lisp,programming,KR,2023,2
 132,Thrift,programming,KR,2023,2
@@ -84837,16 +86038,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Elixir,programming,KR,2023,2
 118,Haskell,programming,KR,2023,2
 116,OpenEdge ABL,programming,KR,2023,2
-114,Pawn,programming,KR,2023,2
 114,Julia,programming,KR,2023,2
+114,Pawn,programming,KR,2023,2
 113,Scheme,programming,KR,2023,2
 111,Sage,programming,KR,2023,2
 109,UnrealScript,programming,KR,2023,2
 108,Inno Setup,programming,KR,2023,2
 103,LLVM,programming,KR,2023,2
+200,Markdown,prose,KR,2023,2
+458,HTML,markup,KW,2023,2
+366,CSS,markup,KW,2023,2
 392,JavaScript,programming,KW,2023,2
 222,Python,programming,KW,2023,2
 128,Shell,programming,KW,2023,2
+8500,HTML,markup,KZ,2023,2
+6867,CSS,markup,KZ,2023,2
+1844,SCSS,markup,KZ,2023,2
+675,Jupyter Notebook,markup,KZ,2023,2
+625,Vue,markup,KZ,2023,2
+379,Blade,markup,KZ,2023,2
+248,Less,markup,KZ,2023,2
+134,Sass,markup,KZ,2023,2
+127,Roff,markup,KZ,2023,2
+113,EJS,markup,KZ,2023,2
 6905,JavaScript,programming,KZ,2023,2
 5038,Python,programming,KZ,2023,2
 2270,Java,programming,KZ,2023,2
@@ -84875,7 +86089,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,Rust,programming,KZ,2023,2
 122,PLpgSQL,programming,KZ,2023,2
 101,Smarty,programming,KZ,2023,2
+289,HTML,markup,LA,2023,2
+233,CSS,markup,LA,2023,2
 272,JavaScript,programming,LA,2023,2
+2386,HTML,markup,LB,2023,2
+2188,CSS,markup,LB,2023,2
+371,SCSS,markup,LB,2023,2
+210,Jupyter Notebook,markup,LB,2023,2
+154,Blade,markup,LB,2023,2
 2097,JavaScript,programming,LB,2023,2
 787,Python,programming,LB,2023,2
 488,TypeScript,programming,LB,2023,2
@@ -84894,6 +86115,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 139,Hack,programming,LB,2023,2
 127,Ruby,programming,LB,2023,2
 114,Makefile,programming,LB,2023,2
+13501,HTML,markup,LK,2023,2
+11151,CSS,markup,LK,2023,2
+2070,SCSS,markup,LK,2023,2
+1594,Jupyter Notebook,markup,LK,2023,2
+575,Blade,markup,LK,2023,2
+485,Less,markup,LK,2023,2
+304,Vue,markup,LK,2023,2
+257,EJS,markup,LK,2023,2
+223,Handlebars,markup,LK,2023,2
+188,Jinja,markup,LK,2023,2
+145,Mustache,markup,LK,2023,2
+126,TeX,markup,LK,2023,2
 12309,JavaScript,programming,LK,2023,2
 5552,Python,programming,LK,2023,2
 4269,Java,programming,LK,2023,2
@@ -84927,12 +86160,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,Starlark,programming,LK,2023,2
 133,Lua,programming,LK,2023,2
 130,PLSQL,programming,LK,2023,2
-130,ASP.NET,programming,LK,2023,2
 130,R,programming,LK,2023,2
+130,ASP.NET,programming,LK,2023,2
 113,SQLPL,programming,LK,2023,2
 111,PLpgSQL,programming,LK,2023,2
 108,Groovy,programming,LK,2023,2
 104,Scala,programming,LK,2023,2
+144,HTML,markup,LR,2023,2
+125,CSS,markup,LR,2023,2
+111,HTML,markup,LS,2023,2
+104,CSS,markup,LS,2023,2
+3846,HTML,markup,LT,2023,2
+3313,CSS,markup,LT,2023,2
+986,SCSS,markup,LT,2023,2
+355,Jupyter Notebook,markup,LT,2023,2
+280,Blade,markup,LT,2023,2
+250,Vue,markup,LT,2023,2
+108,Roff,markup,LT,2023,2
 3638,JavaScript,programming,LT,2023,2
 1680,Python,programming,LT,2023,2
 1327,Shell,programming,LT,2023,2
@@ -84953,14 +86197,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 212,ShaderLab,programming,LT,2023,2
 211,Lua,programming,LT,2023,2
 203,Objective-C,programming,LT,2023,2
-178,PowerShell,programming,LT,2023,2
 178,Swift,programming,LT,2023,2
-141,Rust,programming,LT,2023,2
+178,PowerShell,programming,LT,2023,2
 141,Hack,programming,LT,2023,2
+141,Rust,programming,LT,2023,2
 139,Assembly,programming,LT,2023,2
 124,Smarty,programming,LT,2023,2
 114,Perl,programming,LT,2023,2
 106,Objective-C++,programming,LT,2023,2
+879,HTML,markup,LU,2023,2
+725,CSS,markup,LU,2023,2
+233,SCSS,markup,LU,2023,2
+166,Jupyter Notebook,markup,LU,2023,2
 823,JavaScript,programming,LU,2023,2
 647,Python,programming,LU,2023,2
 524,Shell,programming,LU,2023,2
@@ -84973,6 +86221,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,C,programming,LU,2023,2
 130,Ruby,programming,LU,2023,2
 118,Batchfile,programming,LU,2023,2
+2827,HTML,markup,LV,2023,2
+2381,CSS,markup,LV,2023,2
+541,SCSS,markup,LV,2023,2
+217,Vue,markup,LV,2023,2
+206,Blade,markup,LV,2023,2
+163,Jupyter Notebook,markup,LV,2023,2
 2509,JavaScript,programming,LV,2023,2
 1575,Python,programming,LV,2023,2
 825,Java,programming,LV,2023,2
@@ -84995,8 +86249,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,PowerShell,programming,LV,2023,2
 108,Lua,programming,LV,2023,2
 103,HLSL,programming,LV,2023,2
+270,HTML,markup,LY,2023,2
+206,CSS,markup,LY,2023,2
 229,JavaScript,programming,LY,2023,2
 116,Python,programming,LY,2023,2
+10363,HTML,markup,MA,2023,2
+9560,CSS,markup,MA,2023,2
+2449,SCSS,markup,MA,2023,2
+1538,Blade,markup,MA,2023,2
+1106,Jupyter Notebook,markup,MA,2023,2
+605,Vue,markup,MA,2023,2
+232,Less,markup,MA,2023,2
+217,EJS,markup,MA,2023,2
+181,Twig,markup,MA,2023,2
+156,Roff,markup,MA,2023,2
+112,Handlebars,markup,MA,2023,2
 9428,JavaScript,programming,MA,2023,2
 7234,Shell,programming,MA,2023,2
 5878,C,programming,MA,2023,2
@@ -85029,6 +86296,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 128,Objective-C++,programming,MA,2023,2
 122,Nix,programming,MA,2023,2
 101,Rust,programming,MA,2023,2
+2450,HTML,markup,MD,2023,2
+2020,CSS,markup,MD,2023,2
+659,SCSS,markup,MD,2023,2
+149,Vue,markup,MD,2023,2
+102,Jupyter Notebook,markup,MD,2023,2
 2084,JavaScript,programming,MD,2023,2
 750,TypeScript,programming,MD,2023,2
 744,Python,programming,MD,2023,2
@@ -85048,6 +86320,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Swift,programming,MD,2023,2
 104,CMake,programming,MD,2023,2
 102,Objective-C,programming,MD,2023,2
+916,HTML,markup,ME,2023,2
+796,CSS,markup,ME,2023,2
+272,SCSS,markup,ME,2023,2
 944,JavaScript,programming,ME,2023,2
 461,Python,programming,ME,2023,2
 400,TypeScript,programming,ME,2023,2
@@ -85060,6 +86335,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Ruby,programming,ME,2023,2
 111,C,programming,ME,2023,2
 101,C++,programming,ME,2023,2
+1650,HTML,markup,MG,2023,2
+1570,CSS,markup,MG,2023,2
+477,SCSS,markup,MG,2023,2
+192,Blade,markup,MG,2023,2
+106,Twig,markup,MG,2023,2
 1516,JavaScript,programming,MG,2023,2
 587,PHP,programming,MG,2023,2
 537,Java,programming,MG,2023,2
@@ -85069,6 +86349,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 209,Batchfile,programming,MG,2023,2
 195,Hack,programming,MG,2023,2
 187,Dockerfile,programming,MG,2023,2
+2130,HTML,markup,MK,2023,2
+1788,CSS,markup,MK,2023,2
+325,SCSS,markup,MK,2023,2
 1814,JavaScript,programming,MK,2023,2
 1045,Java,programming,MK,2023,2
 503,TypeScript,programming,MK,2023,2
@@ -85080,7 +86363,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 194,PHP,programming,MK,2023,2
 154,C,programming,MK,2023,2
 151,Kotlin,programming,MK,2023,2
+254,HTML,markup,ML,2023,2
+221,CSS,markup,ML,2023,2
 207,JavaScript,programming,ML,2023,2
+3091,HTML,markup,MM,2023,2
+2568,CSS,markup,MM,2023,2
+663,SCSS,markup,MM,2023,2
+568,Blade,markup,MM,2023,2
+251,Vue,markup,MM,2023,2
 2529,JavaScript,programming,MM,2023,2
 861,PHP,programming,MM,2023,2
 562,TypeScript,programming,MM,2023,2
@@ -85099,6 +86389,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 206,CMake,programming,MM,2023,2
 155,C#,programming,MM,2023,2
 113,Makefile,programming,MM,2023,2
+1296,CSS,markup,MN,2023,2
+1237,HTML,markup,MN,2023,2
+253,SCSS,markup,MN,2023,2
 1320,JavaScript,programming,MN,2023,2
 474,TypeScript,programming,MN,2023,2
 305,Python,programming,MN,2023,2
@@ -85112,10 +86405,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 105,CMake,programming,MN,2023,2
 105,Ruby,programming,MN,2023,2
 104,Kotlin,programming,MN,2023,2
+360,HTML,markup,MO,2023,2
+268,CSS,markup,MO,2023,2
 274,JavaScript,programming,MO,2023,2
 252,Python,programming,MO,2023,2
 153,Shell,programming,MO,2023,2
+166,HTML,markup,MR,2023,2
+120,CSS,markup,MR,2023,2
 120,JavaScript,programming,MR,2023,2
+556,HTML,markup,MT,2023,2
+476,CSS,markup,MT,2023,2
+129,SCSS,markup,MT,2023,2
 526,JavaScript,programming,MT,2023,2
 295,Python,programming,MT,2023,2
 239,Shell,programming,MT,2023,2
@@ -85124,17 +86424,42 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,C#,programming,MT,2023,2
 121,Java,programming,MT,2023,2
 105,Makefile,programming,MT,2023,2
+574,HTML,markup,MU,2023,2
+488,CSS,markup,MU,2023,2
+150,SCSS,markup,MU,2023,2
 527,JavaScript,programming,MU,2023,2
 231,Python,programming,MU,2023,2
 210,Shell,programming,MU,2023,2
 152,TypeScript,programming,MU,2023,2
 118,Java,programming,MU,2023,2
+176,HTML,markup,MV,2023,2
+167,CSS,markup,MV,2023,2
 167,JavaScript,programming,MV,2023,2
+473,HTML,markup,MW,2023,2
+434,CSS,markup,MW,2023,2
 446,JavaScript,programming,MW,2023,2
 234,Shell,programming,MW,2023,2
 182,C,programming,MW,2023,2
 172,PHP,programming,MW,2023,2
 170,Python,programming,MW,2023,2
+40856,HTML,markup,MX,2023,2
+35195,CSS,markup,MX,2023,2
+6869,SCSS,markup,MX,2023,2
+4397,Jupyter Notebook,markup,MX,2023,2
+2206,Blade,markup,MX,2023,2
+1687,Vue,markup,MX,2023,2
+905,Less,markup,MX,2023,2
+778,EJS,markup,MX,2023,2
+738,Handlebars,markup,MX,2023,2
+686,TeX,markup,MX,2023,2
+487,Roff,markup,MX,2023,2
+336,Pug,markup,MX,2023,2
+263,Svelte,markup,MX,2023,2
+251,Astro,markup,MX,2023,2
+241,Sass,markup,MX,2023,2
+194,Rich Text Format,markup,MX,2023,2
+143,Jinja,markup,MX,2023,2
+106,Stylus,markup,MX,2023,2
 34779,JavaScript,programming,MX,2023,2
 13548,Python,programming,MX,2023,2
 8994,Java,programming,MX,2023,2
@@ -85208,6 +86533,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,VBScript,programming,MX,2023,2
 108,Raku,programming,MX,2023,2
 106,Standard ML,programming,MX,2023,2
+9620,HTML,markup,MY,2023,2
+8139,CSS,markup,MY,2023,2
+2016,SCSS,markup,MY,2023,2
+1415,Jupyter Notebook,markup,MY,2023,2
+894,Blade,markup,MY,2023,2
+733,Vue,markup,MY,2023,2
+459,Less,markup,MY,2023,2
+260,Roff,markup,MY,2023,2
+163,Handlebars,markup,MY,2023,2
+161,EJS,markup,MY,2023,2
+145,TeX,markup,MY,2023,2
+126,Svelte,markup,MY,2023,2
 8245,JavaScript,programming,MY,2023,2
 4303,Python,programming,MY,2023,2
 2773,PHP,programming,MY,2023,2
@@ -85245,13 +86582,34 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,ASP.NET,programming,MY,2023,2
 111,M4,programming,MY,2023,2
 103,Vim Script,programming,MY,2023,2
+609,HTML,markup,MZ,2023,2
+568,CSS,markup,MZ,2023,2
+133,SCSS,markup,MZ,2023,2
 543,JavaScript,programming,MZ,2023,2
 253,Java,programming,MZ,2023,2
 171,PHP,programming,MZ,2023,2
 153,Shell,programming,MZ,2023,2
 133,TypeScript,programming,MZ,2023,2
 122,Python,programming,MZ,2023,2
+185,HTML,markup,NA,2023,2
+143,CSS,markup,NA,2023,2
 162,JavaScript,programming,NA,2023,2
+35563,HTML,markup,NG,2023,2
+32112,CSS,markup,NG,2023,2
+6505,SCSS,markup,NG,2023,2
+3000,Jupyter Notebook,markup,NG,2023,2
+1371,Vue,markup,NG,2023,2
+1143,Blade,markup,NG,2023,2
+1092,EJS,markup,NG,2023,2
+931,Less,markup,NG,2023,2
+473,Handlebars,markup,NG,2023,2
+467,Pug,markup,NG,2023,2
+304,Roff,markup,NG,2023,2
+178,Svelte,markup,NG,2023,2
+132,Jinja,markup,NG,2023,2
+124,TeX,markup,NG,2023,2
+117,Sass,markup,NG,2023,2
+113,Astro,markup,NG,2023,2
 31135,JavaScript,programming,NG,2023,2
 15422,Shell,programming,NG,2023,2
 11861,Python,programming,NG,2023,2
@@ -85297,6 +86655,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 172,XSLT,programming,NG,2023,2
 159,Lua,programming,NG,2023,2
 110,Groovy,programming,NG,2023,2
+1234,HTML,markup,NI,2023,2
+1085,CSS,markup,NI,2023,2
+241,SCSS,markup,NI,2023,2
 1073,JavaScript,programming,NI,2023,2
 372,C#,programming,NI,2023,2
 308,TypeScript,programming,NI,2023,2
@@ -85309,6 +86670,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,C,programming,NI,2023,2
 127,C++,programming,NI,2023,2
 108,Dockerfile,programming,NI,2023,2
+30653,HTML,markup,NL,2023,2
+25943,CSS,markup,NL,2023,2
+7603,SCSS,markup,NL,2023,2
+6500,Jupyter Notebook,markup,NL,2023,2
+2501,Vue,markup,NL,2023,2
+1815,TeX,markup,NL,2023,2
+1365,Roff,markup,NL,2023,2
+1337,Blade,markup,NL,2023,2
+944,Jinja,markup,NL,2023,2
+885,Less,markup,NL,2023,2
+752,Handlebars,markup,NL,2023,2
+747,EJS,markup,NL,2023,2
+657,Svelte,markup,NL,2023,2
+590,Mustache,markup,NL,2023,2
+496,Twig,markup,NL,2023,2
+365,Rich Text Format,markup,NL,2023,2
+351,Pug,markup,NL,2023,2
+308,Sass,markup,NL,2023,2
+227,Astro,markup,NL,2023,2
+165,PostScript,markup,NL,2023,2
+160,Liquid,markup,NL,2023,2
+150,Nunjucks,markup,NL,2023,2
+128,Stylus,markup,NL,2023,2
+127,Vim Snippet,markup,NL,2023,2
 28805,JavaScript,programming,NL,2023,2
 22759,Python,programming,NL,2023,2
 18101,Shell,programming,NL,2023,2
@@ -85375,8 +86760,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 290,ANTLR,programming,NL,2023,2
 285,GDB,programming,NL,2023,2
 279,Meson,programming,NL,2023,2
-269,NASL,programming,NL,2023,2
 269,NSIS,programming,NL,2023,2
+269,NASL,programming,NL,2023,2
 259,Bicep,programming,NL,2023,2
 258,Clojure,programming,NL,2023,2
 247,ASP.NET,programming,NL,2023,2
@@ -85396,14 +86781,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 163,VHDL,programming,NL,2023,2
 158,Erlang,programming,NL,2023,2
 156,Standard ML,programming,NL,2023,2
-155,SmPL,programming,NL,2023,2
 155,Gnuplot,programming,NL,2023,2
+155,SmPL,programming,NL,2023,2
 152,D,programming,NL,2023,2
 151,Puppet,programming,NL,2023,2
 150,CoffeeScript,programming,NL,2023,2
 148,Processing,programming,NL,2023,2
-147,PureBasic,programming,NL,2023,2
 147,Verilog,programming,NL,2023,2
+147,PureBasic,programming,NL,2023,2
 146,AutoHotkey,programming,NL,2023,2
 137,F#,programming,NL,2023,2
 130,LLVM,programming,NL,2023,2
@@ -85419,6 +86804,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,POV-Ray SDL,programming,NL,2023,2
 111,Jsonnet,programming,NL,2023,2
 104,AMPL,programming,NL,2023,2
+207,Markdown,prose,NL,2023,2
+9341,HTML,markup,NO,2023,2
+8125,CSS,markup,NO,2023,2
+2076,SCSS,markup,NO,2023,2
+1630,Jupyter Notebook,markup,NO,2023,2
+644,TeX,markup,NO,2023,2
+538,Vue,markup,NO,2023,2
+495,Roff,markup,NO,2023,2
+329,Less,markup,NO,2023,2
+303,Svelte,markup,NO,2023,2
+296,Jinja,markup,NO,2023,2
+252,Handlebars,markup,NO,2023,2
+229,EJS,markup,NO,2023,2
+170,Mustache,markup,NO,2023,2
+106,Rich Text Format,markup,NO,2023,2
+101,Astro,markup,NO,2023,2
 8897,JavaScript,programming,NO,2023,2
 6510,Python,programming,NO,2023,2
 5536,Shell,programming,NO,2023,2
@@ -85434,8 +86835,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1056,Ruby,programming,NO,2023,2
 939,Go,programming,NO,2023,2
 881,Kotlin,programming,NO,2023,2
-747,PowerShell,programming,NO,2023,2
 747,PHP,programming,NO,2023,2
+747,PowerShell,programming,NO,2023,2
 692,R,programming,NO,2023,2
 686,Lua,programming,NO,2023,2
 679,Rust,programming,NO,2023,2
@@ -85476,13 +86877,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Julia,programming,NO,2023,2
 111,GDB,programming,NO,2023,2
 108,Bicep,programming,NO,2023,2
-107,Starlark,programming,NO,2023,2
 107,Cython,programming,NO,2023,2
+107,Starlark,programming,NO,2023,2
 103,Clojure,programming,NO,2023,2
 103,Cuda,programming,NO,2023,2
 103,Pascal,programming,NO,2023,2
 102,Verilog,programming,NO,2023,2
 101,Meson,programming,NO,2023,2
+12997,HTML,markup,NP,2023,2
+11253,CSS,markup,NP,2023,2
+1952,SCSS,markup,NP,2023,2
+1375,Jupyter Notebook,markup,NP,2023,2
+759,Blade,markup,NP,2023,2
+385,Vue,markup,NP,2023,2
+282,EJS,markup,NP,2023,2
+255,Less,markup,NP,2023,2
+136,Handlebars,markup,NP,2023,2
+130,Roff,markup,NP,2023,2
+102,TeX,markup,NP,2023,2
 10794,JavaScript,programming,NP,2023,2
 4263,Python,programming,NP,2023,2
 2460,PHP,programming,NP,2023,2
@@ -85510,6 +86922,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 162,Solidity,programming,NP,2023,2
 131,Objective-C++,programming,NP,2023,2
 107,Assembly,programming,NP,2023,2
+6997,HTML,markup,NZ,2023,2
+5886,CSS,markup,NZ,2023,2
+1491,SCSS,markup,NZ,2023,2
+654,Jupyter Notebook,markup,NZ,2023,2
+335,Vue,markup,NZ,2023,2
+294,TeX,markup,NZ,2023,2
+267,Roff,markup,NZ,2023,2
+203,Handlebars,markup,NZ,2023,2
+178,Svelte,markup,NZ,2023,2
+164,EJS,markup,NZ,2023,2
+161,Less,markup,NZ,2023,2
+126,Jinja,markup,NZ,2023,2
+113,Mustache,markup,NZ,2023,2
 6239,JavaScript,programming,NZ,2023,2
 3940,Python,programming,NZ,2023,2
 3227,Shell,programming,NZ,2023,2
@@ -85539,8 +86964,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 253,ShaderLab,programming,NZ,2023,2
 249,Assembly,programming,NZ,2023,2
 213,Smarty,programming,NZ,2023,2
-200,XSLT,programming,NZ,2023,2
 200,Procfile,programming,NZ,2023,2
+200,XSLT,programming,NZ,2023,2
 191,Vim Script,programming,NZ,2023,2
 180,Gherkin,programming,NZ,2023,2
 170,Objective-C++,programming,NZ,2023,2
@@ -85555,10 +86980,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Groovy,programming,NZ,2023,2
 116,PLpgSQL,programming,NZ,2023,2
 115,MATLAB,programming,NZ,2023,2
+473,HTML,markup,OM,2023,2
+394,CSS,markup,OM,2023,2
+130,Jupyter Notebook,markup,OM,2023,2
 361,JavaScript,programming,OM,2023,2
 243,Python,programming,OM,2023,2
 209,Java,programming,OM,2023,2
 101,Shell,programming,OM,2023,2
+993,HTML,markup,PA,2023,2
+793,CSS,markup,PA,2023,2
+141,SCSS,markup,PA,2023,2
 829,JavaScript,programming,PA,2023,2
 343,Python,programming,PA,2023,2
 208,Shell,programming,PA,2023,2
@@ -85566,6 +86997,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 204,TypeScript,programming,PA,2023,2
 142,Dockerfile,programming,PA,2023,2
 125,PHP,programming,PA,2023,2
+14946,HTML,markup,PE,2023,2
+12797,CSS,markup,PE,2023,2
+2834,SCSS,markup,PE,2023,2
+1400,Jupyter Notebook,markup,PE,2023,2
+867,Vue,markup,PE,2023,2
+743,Blade,markup,PE,2023,2
+402,Less,markup,PE,2023,2
+265,TeX,markup,PE,2023,2
+248,EJS,markup,PE,2023,2
+203,Handlebars,markup,PE,2023,2
+136,Astro,markup,PE,2023,2
+133,Roff,markup,PE,2023,2
+129,Pug,markup,PE,2023,2
 12790,JavaScript,programming,PE,2023,2
 4413,Java,programming,PE,2023,2
 4246,Python,programming,PE,2023,2
@@ -85598,11 +87042,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,Smarty,programming,PE,2023,2
 139,Rust,programming,PE,2023,2
 138,Nix,programming,PE,2023,2
-136,Vim Script,programming,PE,2023,2
 136,Assembly,programming,PE,2023,2
+136,Vim Script,programming,PE,2023,2
 118,Objective-C++,programming,PE,2023,2
 115,HCL,programming,PE,2023,2
 101,Perl,programming,PE,2023,2
+29471,HTML,markup,PH,2023,2
+26334,CSS,markup,PH,2023,2
+5306,SCSS,markup,PH,2023,2
+2878,Blade,markup,PH,2023,2
+1862,Vue,markup,PH,2023,2
+1634,Jupyter Notebook,markup,PH,2023,2
+766,Less,markup,PH,2023,2
+493,EJS,markup,PH,2023,2
+319,Roff,markup,PH,2023,2
+303,Svelte,markup,PH,2023,2
+301,Handlebars,markup,PH,2023,2
+169,TeX,markup,PH,2023,2
+156,Pug,markup,PH,2023,2
+119,Astro,markup,PH,2023,2
+104,Sass,markup,PH,2023,2
 24247,JavaScript,programming,PH,2023,2
 8168,PHP,programming,PH,2023,2
 6632,Python,programming,PH,2023,2
@@ -85647,6 +87106,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,Starlark,programming,PH,2023,2
 119,PLpgSQL,programming,PH,2023,2
 107,M4,programming,PH,2023,2
+32939,HTML,markup,PK,2023,2
+28344,CSS,markup,PK,2023,2
+5542,SCSS,markup,PK,2023,2
+4104,Jupyter Notebook,markup,PK,2023,2
+1918,Blade,markup,PK,2023,2
+1024,Vue,markup,PK,2023,2
+801,Less,markup,PK,2023,2
+762,EJS,markup,PK,2023,2
+407,Handlebars,markup,PK,2023,2
+328,Roff,markup,PK,2023,2
+302,Pug,markup,PK,2023,2
+227,TeX,markup,PK,2023,2
+174,Rich Text Format,markup,PK,2023,2
+158,Mustache,markup,PK,2023,2
+151,Jinja,markup,PK,2023,2
+125,Liquid,markup,PK,2023,2
+120,Sass,markup,PK,2023,2
+111,Svelte,markup,PK,2023,2
 30519,JavaScript,programming,PK,2023,2
 10007,Python,programming,PK,2023,2
 7215,TypeScript,programming,PK,2023,2
@@ -85695,6 +87172,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 108,M4,programming,PK,2023,2
 102,Verilog,programming,PK,2023,2
 101,Mako,programming,PK,2023,2
+43083,HTML,markup,PL,2023,2
+35427,CSS,markup,PL,2023,2
+10731,SCSS,markup,PL,2023,2
+5194,Jupyter Notebook,markup,PL,2023,2
+2394,Vue,markup,PL,2023,2
+1271,Roff,markup,PL,2023,2
+1100,TeX,markup,PL,2023,2
+923,Blade,markup,PL,2023,2
+817,Less,markup,PL,2023,2
+801,Handlebars,markup,PL,2023,2
+770,EJS,markup,PL,2023,2
+751,Jinja,markup,PL,2023,2
+654,Twig,markup,PL,2023,2
+548,Mustache,markup,PL,2023,2
+492,Svelte,markup,PL,2023,2
+414,Sass,markup,PL,2023,2
+347,Pug,markup,PL,2023,2
+346,Rich Text Format,markup,PL,2023,2
+270,Astro,markup,PL,2023,2
+108,Vim Snippet,markup,PL,2023,2
+108,Stylus,markup,PL,2023,2
 38021,JavaScript,programming,PL,2023,2
 25182,Python,programming,PL,2023,2
 16597,Shell,programming,PL,2023,2
@@ -85754,10 +87252,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 353,ASP.NET,programming,PL,2023,2
 325,Lex,programming,PL,2023,2
 323,Smalltalk,programming,PL,2023,2
-305,sed,programming,PL,2023,2
 305,Pascal,programming,PL,2023,2
-294,ANTLR,programming,PL,2023,2
+305,sed,programming,PL,2023,2
 294,PureBasic,programming,PL,2023,2
+294,ANTLR,programming,PL,2023,2
 278,Mathematica,programming,PL,2023,2
 275,Verilog,programming,PL,2023,2
 267,Meson,programming,PL,2023,2
@@ -85768,8 +87266,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 240,GAP,programming,PL,2023,2
 228,GDScript,programming,PL,2023,2
 227,Prolog,programming,PL,2023,2
-226,Clojure,programming,PL,2023,2
 226,SourcePawn,programming,PL,2023,2
+226,Clojure,programming,PL,2023,2
 222,Scheme,programming,PL,2023,2
 219,Forth,programming,PL,2023,2
 209,NSIS,programming,PL,2023,2
@@ -85786,8 +87284,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,Common Lisp,programming,PL,2023,2
 140,RobotFramework,programming,PL,2023,2
 131,F#,programming,PL,2023,2
-130,AMPL,programming,PL,2023,2
 130,SWIG,programming,PL,2023,2
+130,AMPL,programming,PL,2023,2
 127,Gnuplot,programming,PL,2023,2
 125,AIDL,programming,PL,2023,2
 124,CoffeeScript,programming,PL,2023,2
@@ -85804,6 +87302,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 102,OCaml,programming,PL,2023,2
 102,Zig,programming,PL,2023,2
 101,UnrealScript,programming,PL,2023,2
+611,HTML,markup,PR,2023,2
+558,CSS,markup,PR,2023,2
+117,SCSS,markup,PR,2023,2
 539,JavaScript,programming,PR,2023,2
 372,Python,programming,PR,2023,2
 272,Shell,programming,PR,2023,2
@@ -85812,6 +87313,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,C++,programming,PR,2023,2
 114,Makefile,programming,PR,2023,2
 106,Dockerfile,programming,PR,2023,2
+2437,HTML,markup,PS,2023,2
+2235,CSS,markup,PS,2023,2
+501,Blade,markup,PS,2023,2
+488,SCSS,markup,PS,2023,2
+151,Vue,markup,PS,2023,2
+151,Jupyter Notebook,markup,PS,2023,2
 2221,JavaScript,programming,PS,2023,2
 908,Java,programming,PS,2023,2
 827,PHP,programming,PS,2023,2
@@ -85830,6 +87337,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 170,C#,programming,PS,2023,2
 152,Dockerfile,programming,PS,2023,2
 119,Makefile,programming,PS,2023,2
+12813,HTML,markup,PT,2023,2
+11075,CSS,markup,PT,2023,2
+2649,SCSS,markup,PT,2023,2
+1878,Jupyter Notebook,markup,PT,2023,2
+715,Vue,markup,PT,2023,2
+541,TeX,markup,PT,2023,2
+519,Roff,markup,PT,2023,2
+326,Handlebars,markup,PT,2023,2
+317,Less,markup,PT,2023,2
+299,Blade,markup,PT,2023,2
+245,EJS,markup,PT,2023,2
+232,Pug,markup,PT,2023,2
+215,Svelte,markup,PT,2023,2
+194,Jinja,markup,PT,2023,2
+149,Mustache,markup,PT,2023,2
+125,Sass,markup,PT,2023,2
+104,Rich Text Format,markup,PT,2023,2
 12021,JavaScript,programming,PT,2023,2
 7107,Python,programming,PT,2023,2
 5589,Shell,programming,PT,2023,2
@@ -85874,8 +87398,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 200,M4,programming,PT,2023,2
 187,Haskell,programming,PT,2023,2
 168,Starlark,programming,PT,2023,2
-163,Awk,programming,PT,2023,2
 163,Groovy,programming,PT,2023,2
+163,Awk,programming,PT,2023,2
 162,Emacs Lisp,programming,PT,2023,2
 161,Scala,programming,PT,2023,2
 149,Mathematica,programming,PT,2023,2
@@ -85887,6 +87411,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Lex,programming,PT,2023,2
 107,Elixir,programming,PT,2023,2
 105,Tcl,programming,PT,2023,2
+1331,HTML,markup,PY,2023,2
+1104,CSS,markup,PY,2023,2
+234,SCSS,markup,PY,2023,2
 1181,JavaScript,programming,PY,2023,2
 466,Python,programming,PY,2023,2
 330,TypeScript,programming,PY,2023,2
@@ -85897,15 +87424,38 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,C,programming,PY,2023,2
 109,C#,programming,PY,2023,2
 102,Ruby,programming,PY,2023,2
+670,HTML,markup,QA,2023,2
+543,CSS,markup,QA,2023,2
+128,SCSS,markup,QA,2023,2
+123,Jupyter Notebook,markup,QA,2023,2
 577,JavaScript,programming,QA,2023,2
 337,Python,programming,QA,2023,2
 172,Shell,programming,QA,2023,2
 119,Dockerfile,programming,QA,2023,2
 115,TypeScript,programming,QA,2023,2
 105,Java,programming,QA,2023,2
+312,HTML,markup,RE,2023,2
+306,CSS,markup,RE,2023,2
 319,JavaScript,programming,RE,2023,2
 135,Python,programming,RE,2023,2
 119,Shell,programming,RE,2023,2
+13607,HTML,markup,RO,2023,2
+11659,CSS,markup,RO,2023,2
+2869,SCSS,markup,RO,2023,2
+839,Jupyter Notebook,markup,RO,2023,2
+575,Vue,markup,RO,2023,2
+396,Roff,markup,RO,2023,2
+365,EJS,markup,RO,2023,2
+297,Less,markup,RO,2023,2
+284,Blade,markup,RO,2023,2
+277,TeX,markup,RO,2023,2
+215,Handlebars,markup,RO,2023,2
+161,Svelte,markup,RO,2023,2
+153,Jinja,markup,RO,2023,2
+141,Twig,markup,RO,2023,2
+134,Mustache,markup,RO,2023,2
+106,Pug,markup,RO,2023,2
+103,Rich Text Format,markup,RO,2023,2
 12064,JavaScript,programming,RO,2023,2
 6092,Python,programming,RO,2023,2
 5662,Java,programming,RO,2023,2
@@ -85948,8 +87498,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 193,M4,programming,RO,2023,2
 190,Vim Script,programming,RO,2023,2
 187,ASP.NET,programming,RO,2023,2
-177,Awk,programming,RO,2023,2
 177,Haskell,programming,RO,2023,2
+177,Awk,programming,RO,2023,2
 170,Nix,programming,RO,2023,2
 156,R,programming,RO,2023,2
 154,Groovy,programming,RO,2023,2
@@ -85961,6 +87511,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,Scala,programming,RO,2023,2
 106,QMake,programming,RO,2023,2
 101,sed,programming,RO,2023,2
+7017,HTML,markup,RS,2023,2
+6094,CSS,markup,RS,2023,2
+1775,SCSS,markup,RS,2023,2
+593,Jupyter Notebook,markup,RS,2023,2
+376,Blade,markup,RS,2023,2
+376,Vue,markup,RS,2023,2
+156,Less,markup,RS,2023,2
+150,Roff,markup,RS,2023,2
+131,EJS,markup,RS,2023,2
+124,TeX,markup,RS,2023,2
+107,Handlebars,markup,RS,2023,2
 6638,JavaScript,programming,RS,2023,2
 2656,TypeScript,programming,RS,2023,2
 2553,Python,programming,RS,2023,2
@@ -85997,6 +87558,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,XSLT,programming,RS,2023,2
 109,Objective-C++,programming,RS,2023,2
 108,Procfile,programming,RS,2023,2
+95241,HTML,markup,RU,2023,2
+74803,CSS,markup,RU,2023,2
+20325,SCSS,markup,RU,2023,2
+14811,Jupyter Notebook,markup,RU,2023,2
+6590,Vue,markup,RU,2023,2
+2689,Blade,markup,RU,2023,2
+2559,Less,markup,RU,2023,2
+2547,Roff,markup,RU,2023,2
+2384,TeX,markup,RU,2023,2
+1557,Sass,markup,RU,2023,2
+1355,Jinja,markup,RU,2023,2
+1085,Handlebars,markup,RU,2023,2
+1014,Pug,markup,RU,2023,2
+810,EJS,markup,RU,2023,2
+722,Svelte,markup,RU,2023,2
+682,Twig,markup,RU,2023,2
+663,Rich Text Format,markup,RU,2023,2
+441,Mustache,markup,RU,2023,2
+358,Stylus,markup,RU,2023,2
+217,PostScript,markup,RU,2023,2
+180,kvlang,markup,RU,2023,2
+166,Astro,markup,RU,2023,2
+154,Slim,markup,RU,2023,2
+134,Vim Snippet,markup,RU,2023,2
+122,Nunjucks,markup,RU,2023,2
+121,Haml,markup,RU,2023,2
+116,Liquid,markup,RU,2023,2
 75270,JavaScript,programming,RU,2023,2
 69956,Python,programming,RU,2023,2
 33256,Java,programming,RU,2023,2
@@ -86096,8 +87684,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 219,Common Lisp,programming,RU,2023,2
 214,Visual Basic .NET,programming,RU,2023,2
 206,POV-Ray SDL,programming,RU,2023,2
-184,UnrealScript,programming,RU,2023,2
 184,D,programming,RU,2023,2
+184,UnrealScript,programming,RU,2023,2
 181,AMPL,programming,RU,2023,2
 177,Elixir,programming,RU,2023,2
 170,AutoHotkey,programming,RU,2023,2
@@ -86118,6 +87706,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,Ren'Py,programming,RU,2023,2
 103,Standard ML,programming,RU,2023,2
 101,G-code,programming,RU,2023,2
+2847,HTML,markup,RW,2023,2
+2348,CSS,markup,RW,2023,2
+469,SCSS,markup,RW,2023,2
+140,Jupyter Notebook,markup,RW,2023,2
+124,Blade,markup,RW,2023,2
+122,EJS,markup,RW,2023,2
 2002,JavaScript,programming,RW,2023,2
 1165,Shell,programming,RW,2023,2
 895,Python,programming,RW,2023,2
@@ -86135,6 +87729,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,Swift,programming,RW,2023,2
 129,Dart,programming,RW,2023,2
 117,CMake,programming,RW,2023,2
+4740,HTML,markup,SA,2023,2
+3928,CSS,markup,SA,2023,2
+907,Jupyter Notebook,markup,SA,2023,2
+843,SCSS,markup,SA,2023,2
+255,Blade,markup,SA,2023,2
+160,EJS,markup,SA,2023,2
+158,Vue,markup,SA,2023,2
+124,Handlebars,markup,SA,2023,2
+111,Rich Text Format,markup,SA,2023,2
 3713,JavaScript,programming,SA,2023,2
 2357,Python,programming,SA,2023,2
 1475,Java,programming,SA,2023,2
@@ -86158,13 +87761,36 @@ num_pushers,language,language_type,iso2_code,year,quarter
 180,PowerShell,programming,SA,2023,2
 146,Go,programming,SA,2023,2
 145,Lua,programming,SA,2023,2
+233,HTML,markup,SC,2023,2
+165,CSS,markup,SC,2023,2
 220,JavaScript,programming,SC,2023,2
 153,Shell,programming,SC,2023,2
 143,Python,programming,SC,2023,2
+323,HTML,markup,SD,2023,2
+289,CSS,markup,SD,2023,2
 283,JavaScript,programming,SD,2023,2
 133,Python,programming,SD,2023,2
 127,Shell,programming,SD,2023,2
 105,C,programming,SD,2023,2
+17886,HTML,markup,SE,2023,2
+15478,CSS,markup,SE,2023,2
+3771,SCSS,markup,SE,2023,2
+2261,Jupyter Notebook,markup,SE,2023,2
+976,Vue,markup,SE,2023,2
+957,TeX,markup,SE,2023,2
+877,Roff,markup,SE,2023,2
+477,Svelte,markup,SE,2023,2
+418,Jinja,markup,SE,2023,2
+389,Handlebars,markup,SE,2023,2
+352,Less,markup,SE,2023,2
+327,EJS,markup,SE,2023,2
+287,Mustache,markup,SE,2023,2
+225,Rich Text Format,markup,SE,2023,2
+186,Blade,markup,SE,2023,2
+148,Pug,markup,SE,2023,2
+145,Sass,markup,SE,2023,2
+144,Twig,markup,SE,2023,2
+132,Astro,markup,SE,2023,2
 16914,JavaScript,programming,SE,2023,2
 11145,Python,programming,SE,2023,2
 9384,Shell,programming,SE,2023,2
@@ -86220,8 +87846,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 196,Scheme,programming,SE,2023,2
 195,Elixir,programming,SE,2023,2
 192,Fortran,programming,SE,2023,2
-187,Erlang,programming,SE,2023,2
 187,Julia,programming,SE,2023,2
+187,Erlang,programming,SE,2023,2
 181,GDB,programming,SE,2023,2
 177,ASP.NET,programming,SE,2023,2
 177,SourcePawn,programming,SE,2023,2
@@ -86243,16 +87869,36 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,GDScript,programming,SE,2023,2
 113,Solidity,programming,SE,2023,2
 110,Bicep,programming,SE,2023,2
-107,ANTLR,programming,SE,2023,2
 107,Raku,programming,SE,2023,2
+107,ANTLR,programming,SE,2023,2
 107,Inno Setup,programming,SE,2023,2
 106,Gnuplot,programming,SE,2023,2
 104,SWIG,programming,SE,2023,2
-103,D,programming,SE,2023,2
 103,DIGITAL Command Language,programming,SE,2023,2
 103,VHDL,programming,SE,2023,2
+103,D,programming,SE,2023,2
 102,GAP,programming,SE,2023,2
 101,F#,programming,SE,2023,2
+26053,HTML,markup,SG,2023,2
+19897,CSS,markup,SG,2023,2
+7211,SCSS,markup,SG,2023,2
+5743,Jupyter Notebook,markup,SG,2023,2
+3424,Vue,markup,SG,2023,2
+1782,Less,markup,SG,2023,2
+1097,Roff,markup,SG,2023,2
+987,TeX,markup,SG,2023,2
+658,EJS,markup,SG,2023,2
+516,Handlebars,markup,SG,2023,2
+454,Jinja,markup,SG,2023,2
+410,Mustache,markup,SG,2023,2
+316,Pug,markup,SG,2023,2
+310,Stylus,markup,SG,2023,2
+264,Astro,markup,SG,2023,2
+257,Svelte,markup,SG,2023,2
+246,Blade,markup,SG,2023,2
+226,Rich Text Format,markup,SG,2023,2
+134,Sass,markup,SG,2023,2
+126,Vim Snippet,markup,SG,2023,2
 23786,JavaScript,programming,SG,2023,2
 18371,Python,programming,SG,2023,2
 15515,Shell,programming,SG,2023,2
@@ -86295,8 +87941,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 484,PLpgSQL,programming,SG,2023,2
 470,ShaderLab,programming,SG,2023,2
 442,Lex,programming,SG,2023,2
-427,Awk,programming,SG,2023,2
 427,Starlark,programming,SG,2023,2
+427,Awk,programming,SG,2023,2
 424,Scala,programming,SG,2023,2
 416,Cython,programming,SG,2023,2
 411,Thrift,programming,SG,2023,2
@@ -86306,8 +87952,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 340,Emacs Lisp,programming,SG,2023,2
 313,Tcl,programming,SG,2023,2
 305,FreeMarker,programming,SG,2023,2
-280,QMake,programming,SG,2023,2
 280,sed,programming,SG,2023,2
+280,QMake,programming,SG,2023,2
 267,Gherkin,programming,SG,2023,2
 247,GDB,programming,SG,2023,2
 246,TSQL,programming,SG,2023,2
@@ -86333,19 +87979,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,Mathematica,programming,SG,2023,2
 128,Meson,programming,SG,2023,2
 127,CoffeeScript,programming,SG,2023,2
-126,Pawn,programming,SG,2023,2
 126,Jsonnet,programming,SG,2023,2
+126,Pawn,programming,SG,2023,2
 124,XS,programming,SG,2023,2
 120,Scheme,programming,SG,2023,2
 112,Forth,programming,SG,2023,2
 112,Smalltalk,programming,SG,2023,2
-111,LLVM,programming,SG,2023,2
 111,Sage,programming,SG,2023,2
+111,LLVM,programming,SG,2023,2
 109,DIGITAL Command Language,programming,SG,2023,2
 107,Inno Setup,programming,SG,2023,2
 105,AppleScript,programming,SG,2023,2
 105,Julia,programming,SG,2023,2
 101,VBScript,programming,SG,2023,2
+2120,HTML,markup,SI,2023,2
+1790,CSS,markup,SI,2023,2
+476,SCSS,markup,SI,2023,2
+393,Jupyter Notebook,markup,SI,2023,2
+180,Vue,markup,SI,2023,2
+155,TeX,markup,SI,2023,2
 1996,JavaScript,programming,SI,2023,2
 1617,Python,programming,SI,2023,2
 1080,Shell,programming,SI,2023,2
@@ -86369,6 +88021,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 124,Assembly,programming,SI,2023,2
 114,Lua,programming,SI,2023,2
 101,Hack,programming,SI,2023,2
+3584,HTML,markup,SK,2023,2
+3026,CSS,markup,SK,2023,2
+883,SCSS,markup,SK,2023,2
+350,Vue,markup,SK,2023,2
+278,Jupyter Notebook,markup,SK,2023,2
+243,Blade,markup,SK,2023,2
+225,TeX,markup,SK,2023,2
+136,Roff,markup,SK,2023,2
+105,Less,markup,SK,2023,2
 3357,JavaScript,programming,SK,2023,2
 2019,Python,programming,SK,2023,2
 1543,Shell,programming,SK,2023,2
@@ -86393,12 +88054,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 175,Swift,programming,SK,2023,2
 155,Assembly,programming,SK,2023,2
 147,Perl,programming,SK,2023,2
-114,ShaderLab,programming,SK,2023,2
 114,HLSL,programming,SK,2023,2
+114,ShaderLab,programming,SK,2023,2
 112,Procfile,programming,SK,2023,2
 107,Smarty,programming,SK,2023,2
 103,XSLT,programming,SK,2023,2
 102,Vim Script,programming,SK,2023,2
+115,HTML,markup,SL,2023,2
+103,CSS,markup,SL,2023,2
+1465,HTML,markup,SN,2023,2
+1320,CSS,markup,SN,2023,2
+334,SCSS,markup,SN,2023,2
+164,Blade,markup,SN,2023,2
+151,Jupyter Notebook,markup,SN,2023,2
 1085,JavaScript,programming,SN,2023,2
 478,PHP,programming,SN,2023,2
 371,Python,programming,SN,2023,2
@@ -86410,11 +88078,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,Kotlin,programming,SN,2023,2
 143,Dockerfile,programming,SN,2023,2
 135,Hack,programming,SN,2023,2
-135,Objective-C,programming,SN,2023,2
 135,Swift,programming,SN,2023,2
+135,Objective-C,programming,SN,2023,2
 133,Dart,programming,SN,2023,2
 128,CMake,programming,SN,2023,2
+535,HTML,markup,SO,2023,2
+442,CSS,markup,SO,2023,2
 399,JavaScript,programming,SO,2023,2
+2699,HTML,markup,SV,2023,2
+2374,CSS,markup,SV,2023,2
+537,SCSS,markup,SV,2023,2
+423,Blade,markup,SV,2023,2
+202,Vue,markup,SV,2023,2
 2501,JavaScript,programming,SV,2023,2
 887,PHP,programming,SV,2023,2
 782,Java,programming,SV,2023,2
@@ -86429,6 +88104,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,TSQL,programming,SV,2023,2
 124,C,programming,SV,2023,2
 106,Objective-C,programming,SV,2023,2
+1058,HTML,markup,SY,2023,2
+913,CSS,markup,SY,2023,2
+248,Blade,markup,SY,2023,2
+237,SCSS,markup,SY,2023,2
 910,JavaScript,programming,SY,2023,2
 337,PHP,programming,SY,2023,2
 251,Python,programming,SY,2023,2
@@ -86442,6 +88121,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,CMake,programming,SY,2023,2
 123,C#,programming,SY,2023,2
 107,Java,programming,SY,2023,2
+519,HTML,markup,TG,2023,2
+452,CSS,markup,TG,2023,2
+137,SCSS,markup,TG,2023,2
 432,JavaScript,programming,TG,2023,2
 235,Python,programming,TG,2023,2
 184,Java,programming,TG,2023,2
@@ -86449,6 +88131,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 134,Shell,programming,TG,2023,2
 118,C,programming,TG,2023,2
 113,TypeScript,programming,TG,2023,2
+14074,HTML,markup,TH,2023,2
+11649,CSS,markup,TH,2023,2
+2587,SCSS,markup,TH,2023,2
+1923,Jupyter Notebook,markup,TH,2023,2
+1315,Vue,markup,TH,2023,2
+548,Blade,markup,TH,2023,2
+483,EJS,markup,TH,2023,2
+366,Less,markup,TH,2023,2
+270,Roff,markup,TH,2023,2
+266,Svelte,markup,TH,2023,2
+188,TeX,markup,TH,2023,2
+180,Handlebars,markup,TH,2023,2
+180,Pug,markup,TH,2023,2
+115,Astro,markup,TH,2023,2
+111,Sass,markup,TH,2023,2
 13625,JavaScript,programming,TH,2023,2
 6436,Python,programming,TH,2023,2
 5026,TypeScript,programming,TH,2023,2
@@ -86493,10 +88190,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Starlark,programming,TH,2023,2
 114,ASP.NET,programming,TH,2023,2
 104,Cython,programming,TH,2023,2
+444,HTML,markup,TJ,2023,2
+366,CSS,markup,TJ,2023,2
+109,SCSS,markup,TJ,2023,2
 369,JavaScript,programming,TJ,2023,2
 106,Python,programming,TJ,2023,2
 103,C#,programming,TJ,2023,2
+243,HTML,markup,TM,2023,2
+207,CSS,markup,TM,2023,2
 200,JavaScript,programming,TM,2023,2
+8852,HTML,markup,TN,2023,2
+8427,CSS,markup,TN,2023,2
+2581,SCSS,markup,TN,2023,2
+952,Twig,markup,TN,2023,2
+895,Jupyter Notebook,markup,TN,2023,2
+340,Blade,markup,TN,2023,2
+326,Less,markup,TN,2023,2
+315,Vue,markup,TN,2023,2
+202,EJS,markup,TN,2023,2
+115,Handlebars,markup,TN,2023,2
+110,Pug,markup,TN,2023,2
 8318,JavaScript,programming,TN,2023,2
 3699,Java,programming,TN,2023,2
 2992,TypeScript,programming,TN,2023,2
@@ -86520,6 +88233,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 145,Procfile,programming,TN,2023,2
 137,Go,programming,TN,2023,2
 136,Assembly,programming,TN,2023,2
+31954,HTML,markup,TR,2023,2
+26009,CSS,markup,TR,2023,2
+6338,SCSS,markup,TR,2023,2
+4472,Jupyter Notebook,markup,TR,2023,2
+1553,Vue,markup,TR,2023,2
+1157,Less,markup,TR,2023,2
+1027,Blade,markup,TR,2023,2
+697,EJS,markup,TR,2023,2
+620,TeX,markup,TR,2023,2
+544,Roff,markup,TR,2023,2
+383,Handlebars,markup,TR,2023,2
+295,Pug,markup,TR,2023,2
+244,Svelte,markup,TR,2023,2
+207,Sass,markup,TR,2023,2
+204,Jinja,markup,TR,2023,2
+184,Rich Text Format,markup,TR,2023,2
+157,Mustache,markup,TR,2023,2
 27997,JavaScript,programming,TR,2023,2
 15280,Python,programming,TR,2023,2
 11267,C#,programming,TR,2023,2
@@ -86584,9 +88314,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,Fortran,programming,TR,2023,2
 110,PureBasic,programming,TR,2023,2
 104,sed,programming,TR,2023,2
+484,HTML,markup,TT,2023,2
+393,CSS,markup,TT,2023,2
 435,JavaScript,programming,TT,2023,2
 239,Python,programming,TT,2023,2
 190,Shell,programming,TT,2023,2
+27682,HTML,markup,TW,2023,2
+21144,CSS,markup,TW,2023,2
+6663,SCSS,markup,TW,2023,2
+5114,Jupyter Notebook,markup,TW,2023,2
+3788,Vue,markup,TW,2023,2
+1232,Less,markup,TW,2023,2
+972,TeX,markup,TW,2023,2
+947,Roff,markup,TW,2023,2
+803,EJS,markup,TW,2023,2
+610,Handlebars,markup,TW,2023,2
+442,Blade,markup,TW,2023,2
+439,Pug,markup,TW,2023,2
+330,Sass,markup,TW,2023,2
+295,Jinja,markup,TW,2023,2
+258,Stylus,markup,TW,2023,2
+222,Mustache,markup,TW,2023,2
+214,Svelte,markup,TW,2023,2
+208,Rich Text Format,markup,TW,2023,2
+133,Astro,markup,TW,2023,2
 24017,JavaScript,programming,TW,2023,2
 17523,Python,programming,TW,2023,2
 11467,Shell,programming,TW,2023,2
@@ -86646,8 +88397,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 199,Raku,programming,TW,2023,2
 198,Groovy,programming,TW,2023,2
 192,NASL,programming,TW,2023,2
-182,Clojure,programming,TW,2023,2
 182,Scala,programming,TW,2023,2
+182,Clojure,programming,TW,2023,2
 176,SmPL,programming,TW,2023,2
 172,Pascal,programming,TW,2023,2
 168,Processing,programming,TW,2023,2
@@ -86661,8 +88412,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,UnrealScript,programming,TW,2023,2
 139,SystemVerilog,programming,TW,2023,2
 138,SourcePawn,programming,TW,2023,2
-134,CoffeeScript,programming,TW,2023,2
 134,FreeMarker,programming,TW,2023,2
+134,CoffeeScript,programming,TW,2023,2
 131,SWIG,programming,TW,2023,2
 128,Mathematica,programming,TW,2023,2
 118,Pawn,programming,TW,2023,2
@@ -86673,6 +88424,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,GAP,programming,TW,2023,2
 104,Gnuplot,programming,TW,2023,2
 102,Scheme,programming,TW,2023,2
+101,Markdown,prose,TW,2023,2
+1314,HTML,markup,TZ,2023,2
+1144,CSS,markup,TZ,2023,2
+316,SCSS,markup,TZ,2023,2
+192,Blade,markup,TZ,2023,2
 1097,JavaScript,programming,TZ,2023,2
 451,Python,programming,TZ,2023,2
 427,PHP,programming,TZ,2023,2
@@ -86689,6 +88445,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,CMake,programming,TZ,2023,2
 132,Hack,programming,TZ,2023,2
 102,Ruby,programming,TZ,2023,2
+44631,HTML,markup,UA,2023,2
+36710,CSS,markup,UA,2023,2
+14138,SCSS,markup,UA,2023,2
+2252,Vue,markup,UA,2023,2
+1846,Jupyter Notebook,markup,UA,2023,2
+1111,Blade,markup,UA,2023,2
+1097,Handlebars,markup,UA,2023,2
+1001,Less,markup,UA,2023,2
+699,Sass,markup,UA,2023,2
+604,Roff,markup,UA,2023,2
+510,EJS,markup,UA,2023,2
+492,Pug,markup,UA,2023,2
+342,Twig,markup,UA,2023,2
+304,Jinja,markup,UA,2023,2
+300,TeX,markup,UA,2023,2
+223,Mustache,markup,UA,2023,2
+194,Rich Text Format,markup,UA,2023,2
+188,Svelte,markup,UA,2023,2
+120,Liquid,markup,UA,2023,2
 39348,JavaScript,programming,UA,2023,2
 14493,Python,programming,UA,2023,2
 11713,TypeScript,programming,UA,2023,2
@@ -86741,8 +88516,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 177,Emacs Lisp,programming,UA,2023,2
 174,Cython,programming,UA,2023,2
 161,MATLAB,programming,UA,2023,2
-158,Yacc,programming,UA,2023,2
 158,Pascal,programming,UA,2023,2
+158,Yacc,programming,UA,2023,2
 133,FreeMarker,programming,UA,2023,2
 132,GAP,programming,UA,2023,2
 130,Clojure,programming,UA,2023,2
@@ -86750,8 +88525,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,Haskell,programming,UA,2023,2
 125,Mathematica,programming,UA,2023,2
 118,PLSQL,programming,UA,2023,2
-115,Tcl,programming,UA,2023,2
 115,Raku,programming,UA,2023,2
+115,Tcl,programming,UA,2023,2
 110,CoffeeScript,programming,UA,2023,2
 110,QML,programming,UA,2023,2
 108,NSIS,programming,UA,2023,2
@@ -86759,6 +88534,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,GDB,programming,UA,2023,2
 103,Elixir,programming,UA,2023,2
 102,Fortran,programming,UA,2023,2
+2355,HTML,markup,UG,2023,2
+2046,CSS,markup,UG,2023,2
+515,SCSS,markup,UG,2023,2
+297,Jupyter Notebook,markup,UG,2023,2
+181,Blade,markup,UG,2023,2
+121,Vue,markup,UG,2023,2
 1996,JavaScript,programming,UG,2023,2
 1003,Python,programming,UG,2023,2
 774,Shell,programming,UG,2023,2
@@ -86772,13 +88553,50 @@ num_pushers,language,language_type,iso2_code,year,quarter
 223,C++,programming,UG,2023,2
 202,Objective-C,programming,UG,2023,2
 187,Swift,programming,UG,2023,2
-181,Dart,programming,UG,2023,2
 181,Assembly,programming,UG,2023,2
+181,Dart,programming,UG,2023,2
 161,Hack,programming,UG,2023,2
 150,Batchfile,programming,UG,2023,2
 144,Makefile,programming,UG,2023,2
 136,CMake,programming,UG,2023,2
 117,Procfile,programming,UG,2023,2
+688,YAML,data,US,2023,2
+580,JSON,data,US,2023,2
+125,SQL,data,US,2023,2
+426796,HTML,markup,US,2023,2
+349581,CSS,markup,US,2023,2
+98203,Jupyter Notebook,markup,US,2023,2
+89937,SCSS,markup,US,2023,2
+23530,TeX,markup,US,2023,2
+20557,Roff,markup,US,2023,2
+19266,Vue,markup,US,2023,2
+12285,Less,markup,US,2023,2
+11386,Handlebars,markup,US,2023,2
+10601,Jinja,markup,US,2023,2
+10577,EJS,markup,US,2023,2
+7096,Mustache,markup,US,2023,2
+6647,Svelte,markup,US,2023,2
+5871,Rich Text Format,markup,US,2023,2
+5085,Pug,markup,US,2023,2
+3161,Sass,markup,US,2023,2
+2924,Astro,markup,US,2023,2
+2534,Blade,markup,US,2023,2
+2005,PostScript,markup,US,2023,2
+1915,Nunjucks,markup,US,2023,2
+1869,Liquid,markup,US,2023,2
+1863,Stylus,markup,US,2023,2
+1601,Vim Snippet,markup,US,2023,2
+1538,Twig,markup,US,2023,2
+965,Haml,markup,US,2023,2
+571,YASnippet,markup,US,2023,2
+498,kvlang,markup,US,2023,2
+482,Slim,markup,US,2023,2
+451,Mermaid,markup,US,2023,2
+251,Velocity Template Language,markup,US,2023,2
+237,Bikeshed,markup,US,2023,2
+207,RAML,markup,US,2023,2
+205,StringTemplate,markup,US,2023,2
+200,Closure Templates,markup,US,2023,2
 378181,JavaScript,programming,US,2023,2
 306100,Python,programming,US,2023,2
 225989,Shell,programming,US,2023,2
@@ -86876,8 +88694,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1928,SmPL,programming,US,2023,2
 1888,Thrift,programming,US,2023,2
 1861,Processing,programming,US,2023,2
-1834,SystemVerilog,programming,US,2023,2
 1834,AutoHotkey,programming,US,2023,2
+1834,SystemVerilog,programming,US,2023,2
 1771,Standard ML,programming,US,2023,2
 1734,D,programming,US,2023,2
 1724,DTrace,programming,US,2023,2
@@ -86958,8 +88776,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 366,Io,programming,US,2023,2
 365,XQuery,programming,US,2023,2
 364,Terra,programming,US,2023,2
-360,Vala,programming,US,2023,2
 360,TLA,programming,US,2023,2
+360,Vala,programming,US,2023,2
 357,Euphoria,programming,US,2023,2
 348,Arc,programming,US,2023,2
 342,ColdFusion,programming,US,2023,2
@@ -86985,27 +88803,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 253,Motoko,programming,US,2023,2
 253,Mercury,programming,US,2023,2
 238,xBase,programming,US,2023,2
-234,AspectJ,programming,US,2023,2
 234,nesC,programming,US,2023,2
+234,AspectJ,programming,US,2023,2
 229,Ink,programming,US,2023,2
-227,Cadence,programming,US,2023,2
 227,Boogie,programming,US,2023,2
+227,Cadence,programming,US,2023,2
 216,ZenScript,programming,US,2023,2
 214,Ren'Py,programming,US,2023,2
 210,SQLPL,programming,US,2023,2
-209,Cypher,programming,US,2023,2
 209,PigLatin,programming,US,2023,2
+209,Cypher,programming,US,2023,2
 208,Eiffel,programming,US,2023,2
 205,AngelScript,programming,US,2023,2
-202,Witcher Script,programming,US,2023,2
 202,eC,programming,US,2023,2
+202,Witcher Script,programming,US,2023,2
 199,Xonsh,programming,US,2023,2
 198,LiveScript,programming,US,2023,2
 194,Common Workflow Language,programming,US,2023,2
 191,Q#,programming,US,2023,2
 190,CWeb,programming,US,2023,2
-189,Odin,programming,US,2023,2
 189,KRL,programming,US,2023,2
+189,Odin,programming,US,2023,2
 187,REXX,programming,US,2023,2
 186,Elvish,programming,US,2023,2
 184,GSC,programming,US,2023,2
@@ -87014,8 +88832,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 167,LilyPond,programming,US,2023,2
 166,E,programming,US,2023,2
 163,Monkey C,programming,US,2023,2
-162,Vyper,programming,US,2023,2
 162,Slash,programming,US,2023,2
+162,Vyper,programming,US,2023,2
 161,P4,programming,US,2023,2
 161,Modula-3,programming,US,2023,2
 161,CLIPS,programming,US,2023,2
@@ -87026,17 +88844,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,Clarion,programming,US,2023,2
 150,Agda,programming,US,2023,2
 145,J,programming,US,2023,2
-144,Pike,programming,US,2023,2
 144,AutoIt,programming,US,2023,2
+144,Pike,programming,US,2023,2
 143,Fennel,programming,US,2023,2
 142,Squirrel,programming,US,2023,2
 142,Hy,programming,US,2023,2
 142,Nasal,programming,US,2023,2
 141,Berry,programming,US,2023,2
 141,Promela,programming,US,2023,2
+139,Smithy,programming,US,2023,2
 139,mIRC Script,programming,US,2023,2
 139,Cool,programming,US,2023,2
-139,Smithy,programming,US,2023,2
 137,Sieve,programming,US,2023,2
 136,BlitzBasic,programming,US,2023,2
 135,Modelica,programming,US,2023,2
@@ -87050,13 +88868,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,Turing,programming,US,2023,2
 125,Filebench WML,programming,US,2023,2
 125,Asymptote,programming,US,2023,2
-124,Macaulay2,programming,US,2023,2
-124,LSL,programming,US,2023,2
 124,ABAP,programming,US,2023,2
+124,LSL,programming,US,2023,2
+124,Macaulay2,programming,US,2023,2
 123,F*,programming,US,2023,2
 120,Chapel,programming,US,2023,2
-117,NetLogo,programming,US,2023,2
 117,Zeek,programming,US,2023,2
+117,NetLogo,programming,US,2023,2
 111,GAMS,programming,US,2023,2
 108,ChucK,programming,US,2023,2
 107,Smali,programming,US,2023,2
@@ -87064,6 +88882,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,IGOR Pro,programming,US,2023,2
 101,Lasso,programming,US,2023,2
 101,KakouneScript,programming,US,2023,2
+1043,Markdown,prose,US,2023,2
+3488,HTML,markup,UY,2023,2
+3063,CSS,markup,UY,2023,2
+863,SCSS,markup,UY,2023,2
+247,Jupyter Notebook,markup,UY,2023,2
+129,Handlebars,markup,UY,2023,2
 3169,JavaScript,programming,UY,2023,2
 1053,Python,programming,UY,2023,2
 969,Shell,programming,UY,2023,2
@@ -87083,6 +88907,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,Kotlin,programming,UY,2023,2
 118,CMake,programming,UY,2023,2
 103,Procfile,programming,UY,2023,2
+9719,HTML,markup,UZ,2023,2
+8275,CSS,markup,UZ,2023,2
+2719,SCSS,markup,UZ,2023,2
+687,Vue,markup,UZ,2023,2
+395,Blade,markup,UZ,2023,2
+277,Jupyter Notebook,markup,UZ,2023,2
+222,Less,markup,UZ,2023,2
+156,Handlebars,markup,UZ,2023,2
+140,Pug,markup,UZ,2023,2
+115,EJS,markup,UZ,2023,2
 7541,JavaScript,programming,UZ,2023,2
 3096,Python,programming,UZ,2023,2
 1477,TypeScript,programming,UZ,2023,2
@@ -87105,6 +88939,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 283,Go,programming,UZ,2023,2
 271,PowerShell,programming,UZ,2023,2
 179,Hack,programming,UZ,2023,2
+5039,HTML,markup,VE,2023,2
+4624,CSS,markup,VE,2023,2
+1097,SCSS,markup,VE,2023,2
+400,Blade,markup,VE,2023,2
+303,Vue,markup,VE,2023,2
+171,Jupyter Notebook,markup,VE,2023,2
+139,EJS,markup,VE,2023,2
+132,Less,markup,VE,2023,2
 4894,JavaScript,programming,VE,2023,2
 1458,Python,programming,VE,2023,2
 1437,TypeScript,programming,VE,2023,2
@@ -87126,8 +88968,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 154,Dart,programming,VE,2023,2
 152,CMake,programming,VE,2023,2
 135,Lua,programming,VE,2023,2
-123,PowerShell,programming,VE,2023,2
 123,Go,programming,VE,2023,2
+123,PowerShell,programming,VE,2023,2
+58949,HTML,markup,VN,2023,2
+52699,CSS,markup,VN,2023,2
+19714,SCSS,markup,VN,2023,2
+5650,Jupyter Notebook,markup,VN,2023,2
+4794,Less,markup,VN,2023,2
+3774,Blade,markup,VN,2023,2
+3513,Vue,markup,VN,2023,2
+2487,EJS,markup,VN,2023,2
+2217,Handlebars,markup,VN,2023,2
+751,Roff,markup,VN,2023,2
+709,Pug,markup,VN,2023,2
+624,TeX,markup,VN,2023,2
+306,Jinja,markup,VN,2023,2
+300,Mustache,markup,VN,2023,2
+277,Sass,markup,VN,2023,2
+263,Svelte,markup,VN,2023,2
+199,Rich Text Format,markup,VN,2023,2
+172,Twig,markup,VN,2023,2
+128,Stylus,markup,VN,2023,2
+121,Liquid,markup,VN,2023,2
+112,Astro,markup,VN,2023,2
 57461,JavaScript,programming,VN,2023,2
 21238,Java,programming,VN,2023,2
 17665,Python,programming,VN,2023,2
@@ -87172,8 +89035,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 355,R,programming,VN,2023,2
 345,MATLAB,programming,VN,2023,2
 332,Nix,programming,VN,2023,2
-303,Cython,programming,VN,2023,2
 303,Groovy,programming,VN,2023,2
+303,Cython,programming,VN,2023,2
 290,Smalltalk,programming,VN,2023,2
 262,Cuda,programming,VN,2023,2
 250,Scala,programming,VN,2023,2
@@ -87196,14 +89059,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 137,Lex,programming,VN,2023,2
 134,Scheme,programming,VN,2023,2
 128,Fortran,programming,VN,2023,2
-124,AIDL,programming,VN,2023,2
 124,Raku,programming,VN,2023,2
+124,AIDL,programming,VN,2023,2
 120,ANTLR,programming,VN,2023,2
 119,Clojure,programming,VN,2023,2
 113,sed,programming,VN,2023,2
 110,Classic ASP,programming,VN,2023,2
 102,GDB,programming,VN,2023,2
 101,QML,programming,VN,2023,2
+1373,HTML,markup,XK,2023,2
+1312,CSS,markup,XK,2023,2
+281,SCSS,markup,XK,2023,2
 1299,JavaScript,programming,XK,2023,2
 392,PHP,programming,XK,2023,2
 277,Python,programming,XK,2023,2
@@ -87212,6 +89078,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 256,TypeScript,programming,XK,2023,2
 196,Hack,programming,XK,2023,2
 113,Dockerfile,programming,XK,2023,2
+626,HTML,markup,YE,2023,2
+496,CSS,markup,YE,2023,2
+117,SCSS,markup,YE,2023,2
 517,JavaScript,programming,YE,2023,2
 250,Python,programming,YE,2023,2
 216,PHP,programming,YE,2023,2
@@ -87224,6 +89093,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,C#,programming,YE,2023,2
 116,C,programming,YE,2023,2
 115,Dockerfile,programming,YE,2023,2
+11256,HTML,markup,ZA,2023,2
+9646,CSS,markup,ZA,2023,2
+2206,SCSS,markup,ZA,2023,2
+1190,Jupyter Notebook,markup,ZA,2023,2
+505,Vue,markup,ZA,2023,2
+265,Less,markup,ZA,2023,2
+262,EJS,markup,ZA,2023,2
+243,Blade,markup,ZA,2023,2
+223,Roff,markup,ZA,2023,2
+182,TeX,markup,ZA,2023,2
+157,Handlebars,markup,ZA,2023,2
+137,Svelte,markup,ZA,2023,2
 9793,JavaScript,programming,ZA,2023,2
 6791,Shell,programming,ZA,2023,2
 4795,Python,programming,ZA,2023,2
@@ -87258,14 +89139,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 193,HLSL,programming,ZA,2023,2
 185,ShaderLab,programming,ZA,2023,2
 165,MATLAB,programming,ZA,2023,2
-157,Smarty,programming,ZA,2023,2
 157,Nix,programming,ZA,2023,2
+157,Smarty,programming,ZA,2023,2
 134,Gherkin,programming,ZA,2023,2
 132,XSLT,programming,ZA,2023,2
 130,Objective-C++,programming,ZA,2023,2
 112,PLpgSQL,programming,ZA,2023,2
 105,Vim Script,programming,ZA,2023,2
 101,Solidity,programming,ZA,2023,2
+645,HTML,markup,ZM,2023,2
+570,CSS,markup,ZM,2023,2
+125,SCSS,markup,ZM,2023,2
 580,JavaScript,programming,ZM,2023,2
 219,Shell,programming,ZM,2023,2
 201,Python,programming,ZM,2023,2
@@ -87273,6 +89157,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,TypeScript,programming,ZM,2023,2
 110,Java,programming,ZM,2023,2
 109,PHP,programming,ZM,2023,2
+885,HTML,markup,ZW,2023,2
+793,CSS,markup,ZW,2023,2
+219,SCSS,markup,ZW,2023,2
+101,Jupyter Notebook,markup,ZW,2023,2
 784,JavaScript,programming,ZW,2023,2
 411,Python,programming,ZW,2023,2
 330,Shell,programming,ZW,2023,2
@@ -87281,6 +89169,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 163,TypeScript,programming,ZW,2023,2
 153,Java,programming,ZW,2023,2
 115,Dockerfile,programming,ZW,2023,2
+5289,HTML,markup,AE,2023,3
+4445,CSS,markup,AE,2023,3
+1067,SCSS,markup,AE,2023,3
+982,Jupyter Notebook,markup,AE,2023,3
+241,Vue,markup,AE,2023,3
+229,Blade,markup,AE,2023,3
+145,Roff,markup,AE,2023,3
+143,Less,markup,AE,2023,3
+105,EJS,markup,AE,2023,3
 4743,JavaScript,programming,AE,2023,3
 2865,Python,programming,AE,2023,3
 1950,Shell,programming,AE,2023,3
@@ -87312,8 +89209,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Smarty,programming,AE,2023,3
 107,Nix,programming,AE,2023,3
 103,Hack,programming,AE,2023,3
+545,HTML,markup,AF,2023,3
+496,CSS,markup,AF,2023,3
 452,JavaScript,programming,AF,2023,3
 251,Python,programming,AF,2023,3
+1158,HTML,markup,AL,2023,3
+1015,CSS,markup,AL,2023,3
+225,SCSS,markup,AL,2023,3
 1055,JavaScript,programming,AL,2023,3
 371,TypeScript,programming,AL,2023,3
 335,Python,programming,AL,2023,3
@@ -87322,6 +89224,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 179,Dockerfile,programming,AL,2023,3
 159,PHP,programming,AL,2023,3
 154,C#,programming,AL,2023,3
+3796,HTML,markup,AM,2023,3
+3168,CSS,markup,AM,2023,3
+1014,SCSS,markup,AM,2023,3
+330,Jupyter Notebook,markup,AM,2023,3
+258,Vue,markup,AM,2023,3
+181,Blade,markup,AM,2023,3
+118,Roff,markup,AM,2023,3
 3700,JavaScript,programming,AM,2023,3
 1652,Python,programming,AM,2023,3
 1431,TypeScript,programming,AM,2023,3
@@ -87345,11 +89254,38 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,Rust,programming,AM,2023,3
 107,Objective-C++,programming,AM,2023,3
 103,Lua,programming,AM,2023,3
+1005,HTML,markup,AO,2023,3
+922,CSS,markup,AO,2023,3
+171,SCSS,markup,AO,2023,3
+128,Blade,markup,AO,2023,3
 920,JavaScript,programming,AO,2023,3
 345,TypeScript,programming,AO,2023,3
 261,PHP,programming,AO,2023,3
 177,Python,programming,AO,2023,3
 115,Java,programming,AO,2023,3
+110,YAML,data,AR,2023,3
+109,JSON,data,AR,2023,3
+54271,HTML,markup,AR,2023,3
+49564,CSS,markup,AR,2023,3
+9833,SCSS,markup,AR,2023,3
+3515,Jupyter Notebook,markup,AR,2023,3
+2276,Handlebars,markup,AR,2023,3
+1923,EJS,markup,AR,2023,3
+1095,Vue,markup,AR,2023,3
+841,Blade,markup,AR,2023,3
+659,Less,markup,AR,2023,3
+548,Astro,markup,AR,2023,3
+528,TeX,markup,AR,2023,3
+438,Roff,markup,AR,2023,3
+304,Pug,markup,AR,2023,3
+269,Nunjucks,markup,AR,2023,3
+251,Svelte,markup,AR,2023,3
+210,Jinja,markup,AR,2023,3
+193,Sass,markup,AR,2023,3
+169,Rich Text Format,markup,AR,2023,3
+137,Mustache,markup,AR,2023,3
+120,Twig,markup,AR,2023,3
+103,StringTemplate,markup,AR,2023,3
 47859,JavaScript,programming,AR,2023,3
 14175,Python,programming,AR,2023,3
 11276,TypeScript,programming,AR,2023,3
@@ -87422,6 +89358,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,GAP,programming,AR,2023,3
 110,Emacs Lisp,programming,AR,2023,3
 109,Scheme,programming,AR,2023,3
+122,Markdown,prose,AR,2023,3
+7971,HTML,markup,AT,2023,3
+6506,CSS,markup,AT,2023,3
+2208,SCSS,markup,AT,2023,3
+1293,Jupyter Notebook,markup,AT,2023,3
+648,Vue,markup,AT,2023,3
+629,TeX,markup,AT,2023,3
+536,Roff,markup,AT,2023,3
+307,Jinja,markup,AT,2023,3
+295,Less,markup,AT,2023,3
+256,Handlebars,markup,AT,2023,3
+221,Svelte,markup,AT,2023,3
+197,EJS,markup,AT,2023,3
+184,Mustache,markup,AT,2023,3
+145,Twig,markup,AT,2023,3
+141,Blade,markup,AT,2023,3
+140,Rich Text Format,markup,AT,2023,3
 7416,JavaScript,programming,AT,2023,3
 5857,Python,programming,AT,2023,3
 5538,Shell,programming,AT,2023,3
@@ -87484,11 +89437,34 @@ num_pushers,language,language_type,iso2_code,year,quarter
 108,Pascal,programming,AT,2023,3
 106,ANTLR,programming,AT,2023,3
 106,Smalltalk,programming,AT,2023,3
-104,Solidity,programming,AT,2023,3
 104,GDB,programming,AT,2023,3
+104,Solidity,programming,AT,2023,3
 103,SourcePawn,programming,AT,2023,3
 102,NSIS,programming,AT,2023,3
 101,Clojure,programming,AT,2023,3
+29665,HTML,markup,AU,2023,3
+24869,CSS,markup,AU,2023,3
+6109,SCSS,markup,AU,2023,3
+5136,Jupyter Notebook,markup,AU,2023,3
+1576,Vue,markup,AU,2023,3
+1399,TeX,markup,AU,2023,3
+1324,Roff,markup,AU,2023,3
+804,EJS,markup,AU,2023,3
+745,Less,markup,AU,2023,3
+695,Handlebars,markup,AU,2023,3
+669,Jinja,markup,AU,2023,3
+613,Svelte,markup,AU,2023,3
+448,Mustache,markup,AU,2023,3
+415,Rich Text Format,markup,AU,2023,3
+382,Blade,markup,AU,2023,3
+352,Astro,markup,AU,2023,3
+319,Pug,markup,AU,2023,3
+194,Sass,markup,AU,2023,3
+145,Twig,markup,AU,2023,3
+131,Liquid,markup,AU,2023,3
+120,Nunjucks,markup,AU,2023,3
+113,PostScript,markup,AU,2023,3
+104,Vim Snippet,markup,AU,2023,3
 27260,JavaScript,programming,AU,2023,3
 19520,Python,programming,AU,2023,3
 15816,Shell,programming,AU,2023,3
@@ -87556,13 +89532,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 228,Mako,programming,AU,2023,3
 227,Inno Setup,programming,AU,2023,3
 224,NSIS,programming,AU,2023,3
-206,QMake,programming,AU,2023,3
 206,SourcePawn,programming,AU,2023,3
+206,QMake,programming,AU,2023,3
 195,GDScript,programming,AU,2023,3
 193,Clojure,programming,AU,2023,3
 191,AutoHotkey,programming,AU,2023,3
-188,Raku,programming,AU,2023,3
 188,CoffeeScript,programming,AU,2023,3
+188,Raku,programming,AU,2023,3
 184,GAP,programming,AU,2023,3
 177,PLSQL,programming,AU,2023,3
 174,NASL,programming,AU,2023,3
@@ -87581,11 +89557,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,PureBasic,programming,AU,2023,3
 129,D,programming,AU,2023,3
 125,SmPL,programming,AU,2023,3
-122,Erlang,programming,AU,2023,3
 122,QML,programming,AU,2023,3
+122,Erlang,programming,AU,2023,3
 113,Pawn,programming,AU,2023,3
-113,Zig,programming,AU,2023,3
 113,Jsonnet,programming,AU,2023,3
+113,Zig,programming,AU,2023,3
 111,VHDL,programming,AU,2023,3
 111,G-code,programming,AU,2023,3
 108,Nim,programming,AU,2023,3
@@ -87594,6 +89570,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,DIGITAL Command Language,programming,AU,2023,3
 104,AMPL,programming,AU,2023,3
 101,Standard ML,programming,AU,2023,3
+106,Markdown,prose,AU,2023,3
+4271,HTML,markup,AZ,2023,3
+3669,CSS,markup,AZ,2023,3
+1293,SCSS,markup,AZ,2023,3
+262,Jupyter Notebook,markup,AZ,2023,3
+134,Blade,markup,AZ,2023,3
+103,Less,markup,AZ,2023,3
 3424,JavaScript,programming,AZ,2023,3
 1061,C#,programming,AZ,2023,3
 942,Python,programming,AZ,2023,3
@@ -87612,6 +89595,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,Makefile,programming,AZ,2023,3
 141,Dart,programming,AZ,2023,3
 118,Batchfile,programming,AZ,2023,3
+1767,HTML,markup,BA,2023,3
+1532,CSS,markup,BA,2023,3
+352,SCSS,markup,BA,2023,3
+114,Vue,markup,BA,2023,3
 1603,JavaScript,programming,BA,2023,3
 601,TypeScript,programming,BA,2023,3
 446,Python,programming,BA,2023,3
@@ -87627,8 +89614,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,Objective-C,programming,BA,2023,3
 138,Swift,programming,BA,2023,3
 119,Makefile,programming,BA,2023,3
-117,Dart,programming,BA,2023,3
 117,Ruby,programming,BA,2023,3
+117,Dart,programming,BA,2023,3
+36358,HTML,markup,BD,2023,3
+33404,CSS,markup,BD,2023,3
+5626,SCSS,markup,BD,2023,3
+3148,Blade,markup,BD,2023,3
+3117,Jupyter Notebook,markup,BD,2023,3
+1409,Vue,markup,BD,2023,3
+843,Less,markup,BD,2023,3
+585,EJS,markup,BD,2023,3
+374,Handlebars,markup,BD,2023,3
+307,TeX,markup,BD,2023,3
+258,Roff,markup,BD,2023,3
+211,Svelte,markup,BD,2023,3
+126,Rich Text Format,markup,BD,2023,3
+104,Pug,markup,BD,2023,3
 30454,JavaScript,programming,BD,2023,3
 8623,Python,programming,BD,2023,3
 7289,PHP,programming,BD,2023,3
@@ -87667,12 +89668,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,Gherkin,programming,BD,2023,3
 142,PLpgSQL,programming,BD,2023,3
 129,HCL,programming,BD,2023,3
-107,Vim Script,programming,BD,2023,3
 107,Cython,programming,BD,2023,3
+107,Vim Script,programming,BD,2023,3
 107,Lex,programming,BD,2023,3
 103,Starlark,programming,BD,2023,3
 103,ShaderLab,programming,BD,2023,3
 101,HLSL,programming,BD,2023,3
+9343,HTML,markup,BE,2023,3
+7646,CSS,markup,BE,2023,3
+2686,SCSS,markup,BE,2023,3
+1320,Jupyter Notebook,markup,BE,2023,3
+670,Vue,markup,BE,2023,3
+662,TeX,markup,BE,2023,3
+407,Roff,markup,BE,2023,3
+313,Blade,markup,BE,2023,3
+307,Jinja,markup,BE,2023,3
+285,Less,markup,BE,2023,3
+263,Twig,markup,BE,2023,3
+244,Handlebars,markup,BE,2023,3
+213,Svelte,markup,BE,2023,3
+175,EJS,markup,BE,2023,3
+162,Mustache,markup,BE,2023,3
+137,Sass,markup,BE,2023,3
+134,Rich Text Format,markup,BE,2023,3
+123,Liquid,markup,BE,2023,3
 8657,JavaScript,programming,BE,2023,3
 5820,Python,programming,BE,2023,3
 5084,Shell,programming,BE,2023,3
@@ -87716,8 +89735,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 166,TSQL,programming,BE,2023,3
 163,Fortran,programming,BE,2023,3
 153,ShaderLab,programming,BE,2023,3
-146,Julia,programming,BE,2023,3
 146,Objective-C++,programming,BE,2023,3
+146,Julia,programming,BE,2023,3
 145,Emacs Lisp,programming,BE,2023,3
 140,Awk,programming,BE,2023,3
 137,Scheme,programming,BE,2023,3
@@ -87728,16 +89747,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,Common Lisp,programming,BE,2023,3
 117,Cython,programming,BE,2023,3
 115,Solidity,programming,BE,2023,3
-109,NSIS,programming,BE,2023,3
 109,Starlark,programming,BE,2023,3
 109,Yacc,programming,BE,2023,3
+109,NSIS,programming,BE,2023,3
 105,Elixir,programming,BE,2023,3
 105,Pascal,programming,BE,2023,3
 103,sed,programming,BE,2023,3
 102,QMake,programming,BE,2023,3
+348,HTML,markup,BF,2023,3
+317,CSS,markup,BF,2023,3
+127,SCSS,markup,BF,2023,3
+111,Blade,markup,BF,2023,3
 321,JavaScript,programming,BF,2023,3
 181,PHP,programming,BF,2023,3
 126,Python,programming,BF,2023,3
+6535,HTML,markup,BG,2023,3
+5774,CSS,markup,BG,2023,3
+1475,SCSS,markup,BG,2023,3
+339,Jupyter Notebook,markup,BG,2023,3
+321,Handlebars,markup,BG,2023,3
+294,Vue,markup,BG,2023,3
+190,Pug,markup,BG,2023,3
+175,Roff,markup,BG,2023,3
+166,Less,markup,BG,2023,3
+152,Blade,markup,BG,2023,3
+145,Mustache,markup,BG,2023,3
+106,TeX,markup,BG,2023,3
+105,Jinja,markup,BG,2023,3
 6430,JavaScript,programming,BG,2023,3
 2633,Python,programming,BG,2023,3
 2423,TypeScript,programming,BG,2023,3
@@ -87754,8 +89790,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 512,Go,programming,BG,2023,3
 432,CMake,programming,BG,2023,3
 302,PowerShell,programming,BG,2023,3
-298,Objective-C,programming,BG,2023,3
 298,Kotlin,programming,BG,2023,3
+298,Objective-C,programming,BG,2023,3
 276,Lua,programming,BG,2023,3
 263,Rust,programming,BG,2023,3
 255,Swift,programming,BG,2023,3
@@ -87773,10 +89809,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,Dart,programming,BG,2023,3
 106,Objective-C++,programming,BG,2023,3
 101,Smalltalk,programming,BG,2023,3
+397,HTML,markup,BH,2023,3
+338,CSS,markup,BH,2023,3
 351,JavaScript,programming,BH,2023,3
 167,Python,programming,BH,2023,3
 107,Shell,programming,BH,2023,3
+174,HTML,markup,BI,2023,3
+122,CSS,markup,BI,2023,3
 112,JavaScript,programming,BI,2023,3
+920,HTML,markup,BJ,2023,3
+857,CSS,markup,BJ,2023,3
+219,Blade,markup,BJ,2023,3
+213,SCSS,markup,BJ,2023,3
+117,Vue,markup,BJ,2023,3
 841,JavaScript,programming,BJ,2023,3
 408,PHP,programming,BJ,2023,3
 308,Python,programming,BJ,2023,3
@@ -87785,6 +89830,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,C,programming,BJ,2023,3
 103,Hack,programming,BJ,2023,3
 101,C++,programming,BJ,2023,3
+104,HTML,markup,BN,2023,3
+3317,HTML,markup,BO,2023,3
+2892,CSS,markup,BO,2023,3
+729,SCSS,markup,BO,2023,3
+479,Blade,markup,BO,2023,3
+246,Jupyter Notebook,markup,BO,2023,3
+232,Vue,markup,BO,2023,3
+105,Less,markup,BO,2023,3
 3104,JavaScript,programming,BO,2023,3
 1030,TypeScript,programming,BO,2023,3
 947,PHP,programming,BO,2023,3
@@ -87804,6 +89857,31 @@ num_pushers,language,language_type,iso2_code,year,quarter
 186,Ruby,programming,BO,2023,3
 143,Batchfile,programming,BO,2023,3
 114,Makefile,programming,BO,2023,3
+192256,HTML,markup,BR,2023,3
+164134,CSS,markup,BR,2023,3
+22913,SCSS,markup,BR,2023,3
+16032,Jupyter Notebook,markup,BR,2023,3
+6651,Vue,markup,BR,2023,3
+5797,Blade,markup,BR,2023,3
+2925,EJS,markup,BR,2023,3
+2554,Handlebars,markup,BR,2023,3
+2386,Less,markup,BR,2023,3
+2215,Roff,markup,BR,2023,3
+2141,TeX,markup,BR,2023,3
+1218,Sass,markup,BR,2023,3
+962,Svelte,markup,BR,2023,3
+760,Pug,markup,BR,2023,3
+740,Jinja,markup,BR,2023,3
+633,Mustache,markup,BR,2023,3
+499,Astro,markup,BR,2023,3
+491,Rich Text Format,markup,BR,2023,3
+285,Twig,markup,BR,2023,3
+218,kvlang,markup,BR,2023,3
+203,Stylus,markup,BR,2023,3
+203,Liquid,markup,BR,2023,3
+167,PostScript,markup,BR,2023,3
+158,Vim Snippet,markup,BR,2023,3
+135,Nunjucks,markup,BR,2023,3
 156704,JavaScript,programming,BR,2023,3
 61127,Python,programming,BR,2023,3
 54793,TypeScript,programming,BR,2023,3
@@ -87867,8 +89945,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 488,Meson,programming,BR,2023,3
 484,Awk,programming,BR,2023,3
 465,Clojure,programming,BR,2023,3
-448,Mathematica,programming,BR,2023,3
 448,ANTLR,programming,BR,2023,3
+448,Mathematica,programming,BR,2023,3
 444,Verilog,programming,BR,2023,3
 440,Smalltalk,programming,BR,2023,3
 436,VHDL,programming,BR,2023,3
@@ -87916,19 +89994,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,UnrealScript,programming,BR,2023,3
 129,M,programming,BR,2023,3
 124,DTrace,programming,BR,2023,3
-124,Scilab,programming,BR,2023,3
 124,Pawn,programming,BR,2023,3
+124,Scilab,programming,BR,2023,3
 123,Nim,programming,BR,2023,3
 121,DIGITAL Command Language,programming,BR,2023,3
-119,Apex,programming,BR,2023,3
 119,AutoHotkey,programming,BR,2023,3
+119,Apex,programming,BR,2023,3
 119,Haxe,programming,BR,2023,3
-114,ASL,programming,BR,2023,3
 114,Bicep,programming,BR,2023,3
+114,ASL,programming,BR,2023,3
 108,AMPL,programming,BR,2023,3
 106,VBA,programming,BR,2023,3
+114,Markdown,prose,BR,2023,3
+168,HTML,markup,BT,2023,3
+136,CSS,markup,BT,2023,3
 135,JavaScript,programming,BT,2023,3
+249,HTML,markup,BW,2023,3
+204,CSS,markup,BW,2023,3
 172,JavaScript,programming,BW,2023,3
+8734,HTML,markup,BY,2023,3
+6878,CSS,markup,BY,2023,3
+2474,SCSS,markup,BY,2023,3
+398,Jupyter Notebook,markup,BY,2023,3
+340,Vue,markup,BY,2023,3
+207,Less,markup,BY,2023,3
+177,Blade,markup,BY,2023,3
+139,Sass,markup,BY,2023,3
+131,Roff,markup,BY,2023,3
 7397,JavaScript,programming,BY,2023,3
 3512,Python,programming,BY,2023,3
 3116,TypeScript,programming,BY,2023,3
@@ -87964,6 +90056,31 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,QMake,programming,BY,2023,3
 105,PLpgSQL,programming,BY,2023,3
 104,TSQL,programming,BY,2023,3
+101,HTML,markup,BZ,2023,3
+66413,HTML,markup,CA,2023,3
+56352,CSS,markup,CA,2023,3
+14437,SCSS,markup,CA,2023,3
+12198,Jupyter Notebook,markup,CA,2023,3
+2987,TeX,markup,CA,2023,3
+2784,Vue,markup,CA,2023,3
+2405,Roff,markup,CA,2023,3
+2215,EJS,markup,CA,2023,3
+1661,Handlebars,markup,CA,2023,3
+1368,Jinja,markup,CA,2023,3
+1318,Less,markup,CA,2023,3
+1145,Svelte,markup,CA,2023,3
+879,Mustache,markup,CA,2023,3
+760,Blade,markup,CA,2023,3
+748,Pug,markup,CA,2023,3
+720,Rich Text Format,markup,CA,2023,3
+561,Astro,markup,CA,2023,3
+446,Sass,markup,CA,2023,3
+312,Liquid,markup,CA,2023,3
+282,Twig,markup,CA,2023,3
+230,PostScript,markup,CA,2023,3
+225,Nunjucks,markup,CA,2023,3
+210,Stylus,markup,CA,2023,3
+198,Vim Snippet,markup,CA,2023,3
 60501,JavaScript,programming,CA,2023,3
 40365,Python,programming,CA,2023,3
 28276,Shell,programming,CA,2023,3
@@ -88039,12 +90156,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 348,Elixir,programming,CA,2023,3
 342,ANTLR,programming,CA,2023,3
 329,FreeMarker,programming,CA,2023,3
-328,Common Lisp,programming,CA,2023,3
 328,Raku,programming,CA,2023,3
+328,Common Lisp,programming,CA,2023,3
 314,Verilog,programming,CA,2023,3
 312,CoffeeScript,programming,CA,2023,3
-282,AutoHotkey,programming,CA,2023,3
 282,Forth,programming,CA,2023,3
+282,AutoHotkey,programming,CA,2023,3
 273,Pawn,programming,CA,2023,3
 271,PureBasic,programming,CA,2023,3
 268,Prolog,programming,CA,2023,3
@@ -88086,8 +90203,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,Thrift,programming,CA,2023,3
 115,Scilab,programming,CA,2023,3
 115,WebAssembly,programming,CA,2023,3
-114,VBA,programming,CA,2023,3
 114,PureScript,programming,CA,2023,3
+114,VBA,programming,CA,2023,3
 113,G-code,programming,CA,2023,3
 110,SAS,programming,CA,2023,3
 109,Stan,programming,CA,2023,3
@@ -88096,12 +90213,38 @@ num_pushers,language,language_type,iso2_code,year,quarter
 105,Racket,programming,CA,2023,3
 103,Cap'n Proto,programming,CA,2023,3
 102,Ada,programming,CA,2023,3
+150,Markdown,prose,CA,2023,3
+797,HTML,markup,CD,2023,3
+749,CSS,markup,CD,2023,3
+160,SCSS,markup,CD,2023,3
 706,JavaScript,programming,CD,2023,3
 251,PHP,programming,CD,2023,3
 181,Python,programming,CD,2023,3
 145,TypeScript,programming,CD,2023,3
 130,Shell,programming,CD,2023,3
+126,HTML,markup,CG,2023,3
+108,CSS,markup,CG,2023,3
 110,JavaScript,programming,CG,2023,3
+13224,HTML,markup,CH,2023,3
+10553,CSS,markup,CH,2023,3
+3711,SCSS,markup,CH,2023,3
+3648,Jupyter Notebook,markup,CH,2023,3
+1705,TeX,markup,CH,2023,3
+1004,Roff,markup,CH,2023,3
+921,Vue,markup,CH,2023,3
+531,Jinja,markup,CH,2023,3
+441,Less,markup,CH,2023,3
+384,Handlebars,markup,CH,2023,3
+362,Svelte,markup,CH,2023,3
+330,Mustache,markup,CH,2023,3
+211,Blade,markup,CH,2023,3
+211,EJS,markup,CH,2023,3
+209,Rich Text Format,markup,CH,2023,3
+202,Twig,markup,CH,2023,3
+185,Sass,markup,CH,2023,3
+128,Pug,markup,CH,2023,3
+122,Astro,markup,CH,2023,3
+117,PostScript,markup,CH,2023,3
 11654,JavaScript,programming,CH,2023,3
 11652,Python,programming,CH,2023,3
 10370,Shell,programming,CH,2023,3
@@ -88191,6 +90334,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Elixir,programming,CH,2023,3
 110,PureBasic,programming,CH,2023,3
 103,Inno Setup,programming,CH,2023,3
+1089,HTML,markup,CI,2023,3
+998,CSS,markup,CI,2023,3
+289,SCSS,markup,CI,2023,3
+169,Blade,markup,CI,2023,3
 975,JavaScript,programming,CI,2023,3
 391,PHP,programming,CI,2023,3
 307,Python,programming,CI,2023,3
@@ -88202,10 +90349,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Kotlin,programming,CI,2023,3
 135,Objective-C,programming,CI,2023,3
 133,Dart,programming,CI,2023,3
-123,Swift,programming,CI,2023,3
 123,C++,programming,CI,2023,3
+123,Swift,programming,CI,2023,3
 113,CMake,programming,CI,2023,3
 101,Hack,programming,CI,2023,3
+13549,HTML,markup,CL,2023,3
+11327,CSS,markup,CL,2023,3
+3186,SCSS,markup,CL,2023,3
+1852,Jupyter Notebook,markup,CL,2023,3
+620,Vue,markup,CL,2023,3
+478,Blade,markup,CL,2023,3
+342,TeX,markup,CL,2023,3
+332,Handlebars,markup,CL,2023,3
+227,Less,markup,CL,2023,3
+181,Roff,markup,CL,2023,3
+169,Astro,markup,CL,2023,3
+151,EJS,markup,CL,2023,3
 12277,JavaScript,programming,CL,2023,3
 6944,Python,programming,CL,2023,3
 3835,TypeScript,programming,CL,2023,3
@@ -88246,6 +90405,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,Objective-C++,programming,CL,2023,3
 108,ASP.NET,programming,CL,2023,3
 107,Mako,programming,CL,2023,3
+2649,HTML,markup,CM,2023,3
+2397,CSS,markup,CM,2023,3
+615,SCSS,markup,CM,2023,3
+322,Blade,markup,CM,2023,3
+166,Jupyter Notebook,markup,CM,2023,3
+158,Vue,markup,CM,2023,3
+104,Less,markup,CM,2023,3
 2374,JavaScript,programming,CM,2023,3
 783,Python,programming,CM,2023,3
 683,PHP,programming,CM,2023,3
@@ -88264,6 +90430,28 @@ num_pushers,language,language_type,iso2_code,year,quarter
 158,Hack,programming,CM,2023,3
 117,Procfile,programming,CM,2023,3
 115,Makefile,programming,CM,2023,3
+49840,HTML,markup,CN,2023,3
+34716,CSS,markup,CN,2023,3
+12878,Vue,markup,CN,2023,3
+11784,SCSS,markup,CN,2023,3
+5307,Less,markup,CN,2023,3
+4436,Jupyter Notebook,markup,CN,2023,3
+2613,Roff,markup,CN,2023,3
+1550,TeX,markup,CN,2023,3
+1229,EJS,markup,CN,2023,3
+982,Stylus,markup,CN,2023,3
+717,Handlebars,markup,CN,2023,3
+562,Mustache,markup,CN,2023,3
+560,Jinja,markup,CN,2023,3
+527,Pug,markup,CN,2023,3
+381,Rich Text Format,markup,CN,2023,3
+227,Blade,markup,CN,2023,3
+216,Astro,markup,CN,2023,3
+215,Vim Snippet,markup,CN,2023,3
+210,Sass,markup,CN,2023,3
+203,Svelte,markup,CN,2023,3
+193,PostScript,markup,CN,2023,3
+158,Nunjucks,markup,CN,2023,3
 44854,JavaScript,programming,CN,2023,3
 29409,Python,programming,CN,2023,3
 26514,Shell,programming,CN,2023,3
@@ -88339,8 +90527,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 323,HCL,programming,CN,2023,3
 321,Procfile,programming,CN,2023,3
 314,Pawn,programming,CN,2023,3
-312,Meson,programming,CN,2023,3
 312,VBScript,programming,CN,2023,3
+312,Meson,programming,CN,2023,3
 308,LLVM,programming,CN,2023,3
 280,Inno Setup,programming,CN,2023,3
 276,DIGITAL Command Language,programming,CN,2023,3
@@ -88348,8 +90536,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 243,Mathematica,programming,CN,2023,3
 239,CoffeeScript,programming,CN,2023,3
 236,Mako,programming,CN,2023,3
-234,ASL,programming,CN,2023,3
 234,Classic ASP,programming,CN,2023,3
+234,ASL,programming,CN,2023,3
 230,QML,programming,CN,2023,3
 224,Visual Basic .NET,programming,CN,2023,3
 221,M,programming,CN,2023,3
@@ -88375,17 +90563,36 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,q,programming,CN,2023,3
 139,D,programming,CN,2023,3
 133,VHDL,programming,CN,2023,3
-132,Scilab,programming,CN,2023,3
 132,AutoHotkey,programming,CN,2023,3
+132,Scilab,programming,CN,2023,3
 122,Stata,programming,CN,2023,3
 121,Prolog,programming,CN,2023,3
 120,Erlang,programming,CN,2023,3
-119,Terra,programming,CN,2023,3
 119,V,programming,CN,2023,3
+119,Terra,programming,CN,2023,3
 115,Module Management System,programming,CN,2023,3
 115,F#,programming,CN,2023,3
 110,Visual Basic 6.0,programming,CN,2023,3
 108,GDScript,programming,CN,2023,3
+139,Markdown,prose,CN,2023,3
+36378,HTML,markup,CO,2023,3
+31622,CSS,markup,CO,2023,3
+6507,SCSS,markup,CO,2023,3
+4165,Jupyter Notebook,markup,CO,2023,3
+1756,Blade,markup,CO,2023,3
+1496,Vue,markup,CO,2023,3
+815,Less,markup,CO,2023,3
+625,EJS,markup,CO,2023,3
+617,Handlebars,markup,CO,2023,3
+504,Astro,markup,CO,2023,3
+441,TeX,markup,CO,2023,3
+314,Roff,markup,CO,2023,3
+248,Sass,markup,CO,2023,3
+238,Pug,markup,CO,2023,3
+164,Svelte,markup,CO,2023,3
+149,Nunjucks,markup,CO,2023,3
+134,Rich Text Format,markup,CO,2023,3
+119,Mustache,markup,CO,2023,3
 31389,JavaScript,programming,CO,2023,3
 12142,Python,programming,CO,2023,3
 10098,Java,programming,CO,2023,3
@@ -88415,8 +90622,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 466,Lua,programming,CO,2023,3
 411,ASP.NET,programming,CO,2023,3
 357,Assembly,programming,CO,2023,3
-354,Rust,programming,CO,2023,3
 354,HCL,programming,CO,2023,3
+354,Rust,programming,CO,2023,3
 330,Objective-C++,programming,CO,2023,3
 329,TSQL,programming,CO,2023,3
 283,Smarty,programming,CO,2023,3
@@ -88442,6 +90649,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,Elixir,programming,CO,2023,3
 106,Racket,programming,CO,2023,3
 102,Visual Basic .NET,programming,CO,2023,3
+4014,HTML,markup,CR,2023,3
+3623,CSS,markup,CR,2023,3
+776,SCSS,markup,CR,2023,3
+340,Jupyter Notebook,markup,CR,2023,3
+120,Vue,markup,CR,2023,3
 3810,JavaScript,programming,CR,2023,3
 1485,Python,programming,CR,2023,3
 1350,Java,programming,CR,2023,3
@@ -88465,6 +90677,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,PowerShell,programming,CR,2023,3
 123,Objective-C,programming,CR,2023,3
 119,Swift,programming,CR,2023,3
+867,HTML,markup,CU,2023,3
+770,CSS,markup,CU,2023,3
+142,SCSS,markup,CU,2023,3
+126,TeX,markup,CU,2023,3
 748,JavaScript,programming,CU,2023,3
 382,Python,programming,CU,2023,3
 316,TypeScript,programming,CU,2023,3
@@ -88475,6 +90691,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Dockerfile,programming,CU,2023,3
 123,PHP,programming,CU,2023,3
 101,C,programming,CU,2023,3
+1423,HTML,markup,CY,2023,3
+1172,CSS,markup,CY,2023,3
+314,SCSS,markup,CY,2023,3
+165,Jupyter Notebook,markup,CY,2023,3
 1354,JavaScript,programming,CY,2023,3
 855,Python,programming,CY,2023,3
 812,Shell,programming,CY,2023,3
@@ -88494,6 +90714,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,Swift,programming,CY,2023,3
 142,Objective-C,programming,CY,2023,3
 107,Rust,programming,CY,2023,3
+9553,HTML,markup,CZ,2023,3
+7974,CSS,markup,CZ,2023,3
+2258,SCSS,markup,CZ,2023,3
+923,Jupyter Notebook,markup,CZ,2023,3
+696,Roff,markup,CZ,2023,3
+557,Vue,markup,CZ,2023,3
+503,TeX,markup,CZ,2023,3
+415,Jinja,markup,CZ,2023,3
+365,Less,markup,CZ,2023,3
+297,Svelte,markup,CZ,2023,3
+288,Mustache,markup,CZ,2023,3
+247,Handlebars,markup,CZ,2023,3
+194,Latte,markup,CZ,2023,3
+174,EJS,markup,CZ,2023,3
+161,Twig,markup,CZ,2023,3
+157,Sass,markup,CZ,2023,3
+142,Blade,markup,CZ,2023,3
+124,Rich Text Format,markup,CZ,2023,3
+107,Pug,markup,CZ,2023,3
 8783,JavaScript,programming,CZ,2023,3
 6622,Python,programming,CZ,2023,3
 5821,Shell,programming,CZ,2023,3
@@ -88554,8 +90793,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 115,PLSQL,programming,CZ,2023,3
 114,Cython,programming,CZ,2023,3
 112,Mako,programming,CZ,2023,3
-111,Solidity,programming,CZ,2023,3
 111,ANTLR,programming,CZ,2023,3
+111,Solidity,programming,CZ,2023,3
 107,Pascal,programming,CZ,2023,3
 106,Raku,programming,CZ,2023,3
 105,Prolog,programming,CZ,2023,3
@@ -88563,6 +90802,36 @@ num_pushers,language,language_type,iso2_code,year,quarter
 103,Cuda,programming,CZ,2023,3
 102,Jsonnet,programming,CZ,2023,3
 102,ASP.NET,programming,CZ,2023,3
+313,YAML,data,DE,2023,3
+254,JSON,data,DE,2023,3
+70812,HTML,markup,DE,2023,3
+57373,CSS,markup,DE,2023,3
+18331,SCSS,markup,DE,2023,3
+14713,Jupyter Notebook,markup,DE,2023,3
+6067,TeX,markup,DE,2023,3
+5818,Vue,markup,DE,2023,3
+5063,Roff,markup,DE,2023,3
+2788,Jinja,markup,DE,2023,3
+2350,Less,markup,DE,2023,3
+2187,Handlebars,markup,DE,2023,3
+1973,Svelte,markup,DE,2023,3
+1900,Mustache,markup,DE,2023,3
+1491,EJS,markup,DE,2023,3
+1153,Twig,markup,DE,2023,3
+1133,Rich Text Format,markup,DE,2023,3
+1091,Blade,markup,DE,2023,3
+852,Sass,markup,DE,2023,3
+799,Pug,markup,DE,2023,3
+736,Astro,markup,DE,2023,3
+452,PostScript,markup,DE,2023,3
+428,Vim Snippet,markup,DE,2023,3
+364,Nunjucks,markup,DE,2023,3
+333,Liquid,markup,DE,2023,3
+310,Stylus,markup,DE,2023,3
+220,Haml,markup,DE,2023,3
+167,Mermaid,markup,DE,2023,3
+132,YASnippet,markup,DE,2023,3
+129,Slim,markup,DE,2023,3
 66129,JavaScript,programming,DE,2023,3
 58755,Python,programming,DE,2023,3
 53391,Shell,programming,DE,2023,3
@@ -88674,14 +90943,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 363,Visual Basic .NET,programming,DE,2023,3
 359,POV-Ray SDL,programming,DE,2023,3
 351,UnrealScript,programming,DE,2023,3
-344,Zig,programming,DE,2023,3
 344,OpenSCAD,programming,DE,2023,3
+344,Zig,programming,DE,2023,3
 330,DTrace,programming,DE,2023,3
 311,AIDL,programming,DE,2023,3
 277,Processing,programming,DE,2023,3
 258,WebAssembly,programming,DE,2023,3
-256,Metal,programming,DE,2023,3
 256,SystemVerilog,programming,DE,2023,3
+256,Metal,programming,DE,2023,3
 250,G-code,programming,DE,2023,3
 249,Scilab,programming,DE,2023,3
 249,Open Policy Agent,programming,DE,2023,3
@@ -88711,11 +90980,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 158,Elm,programming,DE,2023,3
 157,Logos,programming,DE,2023,3
 157,ABAP,programming,DE,2023,3
-155,Max,programming,DE,2023,3
 155,Xtend,programming,DE,2023,3
+155,Max,programming,DE,2023,3
 149,Apex,programming,DE,2023,3
-146,Cap'n Proto,programming,DE,2023,3
 146,EmberScript,programming,DE,2023,3
+146,Cap'n Proto,programming,DE,2023,3
 145,FreeBasic,programming,DE,2023,3
 143,Brainfuck,programming,DE,2023,3
 140,ActionScript,programming,DE,2023,3
@@ -88739,6 +91008,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Classic ASP,programming,DE,2023,3
 101,Euphoria,programming,DE,2023,3
 101,Limbo,programming,DE,2023,3
+392,Markdown,prose,DE,2023,3
+7913,HTML,markup,DK,2023,3
+6559,CSS,markup,DK,2023,3
+1689,SCSS,markup,DK,2023,3
+1531,Jupyter Notebook,markup,DK,2023,3
+627,TeX,markup,DK,2023,3
+458,Vue,markup,DK,2023,3
+378,Roff,markup,DK,2023,3
+261,Svelte,markup,DK,2023,3
+208,Astro,markup,DK,2023,3
+194,Less,markup,DK,2023,3
+192,Jinja,markup,DK,2023,3
+161,Handlebars,markup,DK,2023,3
+141,Blade,markup,DK,2023,3
+127,EJS,markup,DK,2023,3
+107,Mustache,markup,DK,2023,3
 7388,JavaScript,programming,DK,2023,3
 5342,Python,programming,DK,2023,3
 4396,Shell,programming,DK,2023,3
@@ -88784,15 +91069,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,Smalltalk,programming,DK,2023,3
 127,Groovy,programming,DK,2023,3
 125,F#,programming,DK,2023,3
-122,Awk,programming,DK,2023,3
 122,Tcl,programming,DK,2023,3
-117,Yacc,programming,DK,2023,3
+122,Awk,programming,DK,2023,3
 117,Fortran,programming,DK,2023,3
+117,Yacc,programming,DK,2023,3
 116,Processing,programming,DK,2023,3
 114,Gherkin,programming,DK,2023,3
 112,Scala,programming,DK,2023,3
 108,Starlark,programming,DK,2023,3
 108,Cuda,programming,DK,2023,3
+3202,HTML,markup,DO,2023,3
+2712,CSS,markup,DO,2023,3
+478,SCSS,markup,DO,2023,3
+144,Vue,markup,DO,2023,3
+112,Jupyter Notebook,markup,DO,2023,3
 2788,JavaScript,programming,DO,2023,3
 943,TypeScript,programming,DO,2023,3
 847,C#,programming,DO,2023,3
@@ -88812,6 +91102,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,Makefile,programming,DO,2023,3
 131,Batchfile,programming,DO,2023,3
 117,Hack,programming,DO,2023,3
+3732,HTML,markup,DZ,2023,3
+3354,CSS,markup,DZ,2023,3
+523,SCSS,markup,DZ,2023,3
+388,Jupyter Notebook,markup,DZ,2023,3
+211,Blade,markup,DZ,2023,3
+166,Vue,markup,DZ,2023,3
 3238,JavaScript,programming,DZ,2023,3
 1279,Python,programming,DZ,2023,3
 815,Shell,programming,DZ,2023,3
@@ -88833,6 +91129,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,Hack,programming,DZ,2023,3
 108,Assembly,programming,DZ,2023,3
 105,Lua,programming,DZ,2023,3
+6877,HTML,markup,EC,2023,3
+6008,CSS,markup,EC,2023,3
+1552,SCSS,markup,EC,2023,3
+683,Jupyter Notebook,markup,EC,2023,3
+375,Blade,markup,EC,2023,3
+318,Vue,markup,EC,2023,3
+209,Less,markup,EC,2023,3
+145,EJS,markup,EC,2023,3
+128,Handlebars,markup,EC,2023,3
+127,TeX,markup,EC,2023,3
 6118,JavaScript,programming,EC,2023,3
 2539,Python,programming,EC,2023,3
 2439,Java,programming,EC,2023,3
@@ -88859,6 +91165,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,TSQL,programming,EC,2023,3
 112,Go,programming,EC,2023,3
 105,ASP.NET,programming,EC,2023,3
+2750,HTML,markup,EE,2023,3
+2191,CSS,markup,EE,2023,3
+555,SCSS,markup,EE,2023,3
+255,Vue,markup,EE,2023,3
+195,Jupyter Notebook,markup,EE,2023,3
 2593,JavaScript,programming,EE,2023,3
 1243,Python,programming,EE,2023,3
 1207,Shell,programming,EE,2023,3
@@ -88881,6 +91192,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,Rust,programming,EE,2023,3
 123,Swift,programming,EE,2023,3
 105,Perl,programming,EE,2023,3
+25282,HTML,markup,EG,2023,3
+20579,CSS,markup,EG,2023,3
+5014,SCSS,markup,EG,2023,3
+3713,Jupyter Notebook,markup,EG,2023,3
+1915,Blade,markup,EG,2023,3
+1008,Vue,markup,EG,2023,3
+712,Less,markup,EG,2023,3
+565,EJS,markup,EG,2023,3
+437,Handlebars,markup,EG,2023,3
+393,Roff,markup,EG,2023,3
+277,Pug,markup,EG,2023,3
+273,TeX,markup,EG,2023,3
+169,Rich Text Format,markup,EG,2023,3
+142,Sass,markup,EG,2023,3
+126,Svelte,markup,EG,2023,3
+107,Jinja,markup,EG,2023,3
 19843,JavaScript,programming,EG,2023,3
 10161,C,programming,EG,2023,3
 8250,Python,programming,EG,2023,3
@@ -88929,9 +91256,32 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,Tcl,programming,EG,2023,3
 122,CoffeeScript,programming,EG,2023,3
 106,Forth,programming,EG,2023,3
-102,M,programming,EG,2023,3
 102,SWIG,programming,EG,2023,3
+102,M,programming,EG,2023,3
 101,Solidity,programming,EG,2023,3
+110,YAML,data,ES,2023,3
+33932,HTML,markup,ES,2023,3
+27741,CSS,markup,ES,2023,3
+8021,SCSS,markup,ES,2023,3
+5378,Jupyter Notebook,markup,ES,2023,3
+1888,Vue,markup,ES,2023,3
+1292,TeX,markup,ES,2023,3
+1208,Roff,markup,ES,2023,3
+939,Blade,markup,ES,2023,3
+886,Handlebars,markup,ES,2023,3
+799,Less,markup,ES,2023,3
+724,Astro,markup,ES,2023,3
+703,EJS,markup,ES,2023,3
+694,Jinja,markup,ES,2023,3
+581,Mustache,markup,ES,2023,3
+524,Svelte,markup,ES,2023,3
+378,Pug,markup,ES,2023,3
+370,Twig,markup,ES,2023,3
+352,Sass,markup,ES,2023,3
+320,Rich Text Format,markup,ES,2023,3
+118,PostScript,markup,ES,2023,3
+116,Nunjucks,markup,ES,2023,3
+101,Liquid,markup,ES,2023,3
 31060,JavaScript,programming,ES,2023,3
 19391,Python,programming,ES,2023,3
 15206,Shell,programming,ES,2023,3
@@ -89012,21 +91362,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 248,Pawn,programming,ES,2023,3
 245,OCaml,programming,ES,2023,3
 238,PLSQL,programming,ES,2023,3
-236,BASIC,programming,ES,2023,3
 236,QMake,programming,ES,2023,3
+236,BASIC,programming,ES,2023,3
 234,Zig,programming,ES,2023,3
 234,Nim,programming,ES,2023,3
 233,Standard ML,programming,ES,2023,3
 229,Apex,programming,ES,2023,3
 223,Meson,programming,ES,2023,3
-206,GAP,programming,ES,2023,3
 206,COBOL,programming,ES,2023,3
+206,GAP,programming,ES,2023,3
 205,GDScript,programming,ES,2023,3
 204,ActionScript,programming,ES,2023,3
 200,Rebol,programming,ES,2023,3
 198,Elm,programming,ES,2023,3
-197,GDB,programming,ES,2023,3
 197,Jasmin,programming,ES,2023,3
+197,GDB,programming,ES,2023,3
 196,ABAP,programming,ES,2023,3
 196,xBase,programming,ES,2023,3
 195,Crystal,programming,ES,2023,3
@@ -89037,40 +91387,40 @@ num_pushers,language,language_type,iso2_code,year,quarter
 186,Racket,programming,ES,2023,3
 186,Limbo,programming,ES,2023,3
 185,Gnuplot,programming,ES,2023,3
-184,Vala,programming,ES,2023,3
 184,Lasso,programming,ES,2023,3
+184,Vala,programming,ES,2023,3
 182,Brainfuck,programming,ES,2023,3
 180,Arc,programming,ES,2023,3
 174,CWeb,programming,ES,2023,3
 174,Red,programming,ES,2023,3
 173,FreeMarker,programming,ES,2023,3
 172,Turing,programming,ES,2023,3
-171,Hy,programming,ES,2023,3
 171,Agda,programming,ES,2023,3
+171,Hy,programming,ES,2023,3
 169,LOLCODE,programming,ES,2023,3
 169,Boo,programming,ES,2023,3
 169,Eiffel,programming,ES,2023,3
-168,Dylan,programming,ES,2023,3
-168,LiveScript,programming,ES,2023,3
 168,Cool,programming,ES,2023,3
-167,Modula-2,programming,ES,2023,3
+168,LiveScript,programming,ES,2023,3
+168,Dylan,programming,ES,2023,3
 167,Alloy,programming,ES,2023,3
 167,HolyC,programming,ES,2023,3
-166,Fantom,programming,ES,2023,3
-166,Genie,programming,ES,2023,3
+167,Modula-2,programming,ES,2023,3
 166,Mercury,programming,ES,2023,3
+166,Genie,programming,ES,2023,3
+166,Fantom,programming,ES,2023,3
 165,Grace,programming,ES,2023,3
-165,Idris,programming,ES,2023,3
 165,Pony,programming,ES,2023,3
+165,Idris,programming,ES,2023,3
 165,Chapel,programming,ES,2023,3
 164,Ballerina,programming,ES,2023,3
+164,Befunge,programming,ES,2023,3
+164,ANTLR,programming,ES,2023,3
 164,Ioke,programming,ES,2023,3
 164,Witcher Script,programming,ES,2023,3
-164,Befunge,programming,ES,2023,3
-164,Self,programming,ES,2023,3
 164,Nit,programming,ES,2023,3
+164,Self,programming,ES,2023,3
 164,Ceylon,programming,ES,2023,3
-164,ANTLR,programming,ES,2023,3
 155,SWIG,programming,ES,2023,3
 154,NASL,programming,ES,2023,3
 148,Jsonnet,programming,ES,2023,3
@@ -89083,6 +91433,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 115,PureBasic,programming,ES,2023,3
 115,QML,programming,ES,2023,3
 113,Visual Basic 6.0,programming,ES,2023,3
+136,Markdown,prose,ES,2023,3
+3817,HTML,markup,ET,2023,3
+3376,CSS,markup,ET,2023,3
+551,SCSS,markup,ET,2023,3
+232,Jupyter Notebook,markup,ET,2023,3
+157,Blade,markup,ET,2023,3
+114,Vue,markup,ET,2023,3
 3469,JavaScript,programming,ET,2023,3
 1991,Shell,programming,ET,2023,3
 1793,Python,programming,ET,2023,3
@@ -89104,6 +91461,37 @@ num_pushers,language,language_type,iso2_code,year,quarter
 150,Batchfile,programming,ET,2023,3
 145,Makefile,programming,ET,2023,3
 141,Hack,programming,ET,2023,3
+596,YAML,data,EU,2023,3
+409,JSON,data,EU,2023,3
+374300,HTML,markup,EU,2023,3
+313181,CSS,markup,EU,2023,3
+93742,SCSS,markup,EU,2023,3
+56919,Jupyter Notebook,markup,EU,2023,3
+25734,Vue,markup,EU,2023,3
+19911,TeX,markup,EU,2023,3
+17996,Roff,markup,EU,2023,3
+10135,Jinja,markup,EU,2023,3
+9807,Less,markup,EU,2023,3
+9216,Handlebars,markup,EU,2023,3
+8952,Blade,markup,EU,2023,3
+7766,Svelte,markup,EU,2023,3
+7569,Twig,markup,EU,2023,3
+6949,Mustache,markup,EU,2023,3
+6836,EJS,markup,EU,2023,3
+3773,Rich Text Format,markup,EU,2023,3
+3383,Pug,markup,EU,2023,3
+3362,Astro,markup,EU,2023,3
+3358,Sass,markup,EU,2023,3
+1069,PostScript,markup,EU,2023,3
+1001,Liquid,markup,EU,2023,3
+869,Nunjucks,markup,EU,2023,3
+739,Vim Snippet,markup,EU,2023,3
+645,Stylus,markup,EU,2023,3
+337,Haml,markup,EU,2023,3
+194,Latte,markup,EU,2023,3
+167,Mermaid,markup,EU,2023,3
+132,YASnippet,markup,EU,2023,3
+129,Slim,markup,EU,2023,3
 348543,JavaScript,programming,EU,2023,3
 241131,Python,programming,EU,2023,3
 206902,Shell,programming,EU,2023,3
@@ -89266,41 +91654,41 @@ num_pushers,language,language_type,iso2_code,year,quarter
 184,Lasso,programming,EU,2023,3
 181,Elvish,programming,EU,2023,3
 180,Arc,programming,EU,2023,3
-174,Red,programming,EU,2023,3
 174,CWeb,programming,EU,2023,3
+174,Red,programming,EU,2023,3
 172,Turing,programming,EU,2023,3
-171,Agda,programming,EU,2023,3
 171,Hy,programming,EU,2023,3
+171,Agda,programming,EU,2023,3
 169,LOLCODE,programming,EU,2023,3
 169,Eiffel,programming,EU,2023,3
 169,Boo,programming,EU,2023,3
-168,LiveScript,programming,EU,2023,3
 168,Cool,programming,EU,2023,3
+168,LiveScript,programming,EU,2023,3
 168,Dylan,programming,EU,2023,3
-167,Alloy,programming,EU,2023,3
 167,Modula-2,programming,EU,2023,3
 167,HolyC,programming,EU,2023,3
-166,Mercury,programming,EU,2023,3
-166,Genie,programming,EU,2023,3
+167,Alloy,programming,EU,2023,3
 166,Fantom,programming,EU,2023,3
+166,Genie,programming,EU,2023,3
+166,Mercury,programming,EU,2023,3
+165,Idris,programming,EU,2023,3
+165,Pony,programming,EU,2023,3
 165,Chapel,programming,EU,2023,3
 165,Grace,programming,EU,2023,3
-165,Pony,programming,EU,2023,3
-165,Idris,programming,EU,2023,3
-164,Witcher Script,programming,EU,2023,3
-164,Befunge,programming,EU,2023,3
-164,Ceylon,programming,EU,2023,3
-164,Nit,programming,EU,2023,3
-164,Ballerina,programming,EU,2023,3
 164,Self,programming,EU,2023,3
 164,Ioke,programming,EU,2023,3
+164,Witcher Script,programming,EU,2023,3
+164,Ballerina,programming,EU,2023,3
+164,Befunge,programming,EU,2023,3
+164,Nit,programming,EU,2023,3
+164,Ceylon,programming,EU,2023,3
 163,AGS Script,programming,EU,2023,3
 162,SAS,programming,EU,2023,3
-155,Xtend,programming,EU,2023,3
 155,Max,programming,EU,2023,3
+155,Xtend,programming,EU,2023,3
 150,Coq,programming,EU,2023,3
-146,Cap'n Proto,programming,EU,2023,3
 146,EmberScript,programming,EU,2023,3
+146,Cap'n Proto,programming,EU,2023,3
 145,FreeBasic,programming,EU,2023,3
 139,VBA,programming,EU,2023,3
 139,Boogie,programming,EU,2023,3
@@ -89316,6 +91704,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Classic ASP,programming,EU,2023,3
 103,Cairo,programming,EU,2023,3
 101,Euphoria,programming,EU,2023,3
+947,Markdown,prose,EU,2023,3
+9262,HTML,markup,FI,2023,3
+7662,CSS,markup,FI,2023,3
+1817,SCSS,markup,FI,2023,3
+1003,Jupyter Notebook,markup,FI,2023,3
+476,Roff,markup,FI,2023,3
+381,Vue,markup,FI,2023,3
+372,TeX,markup,FI,2023,3
+256,Jinja,markup,FI,2023,3
+251,Less,markup,FI,2023,3
+209,Svelte,markup,FI,2023,3
+164,Handlebars,markup,FI,2023,3
+138,EJS,markup,FI,2023,3
+133,Pug,markup,FI,2023,3
+121,Mustache,markup,FI,2023,3
 8668,JavaScript,programming,FI,2023,3
 5960,Python,programming,FI,2023,3
 5008,Shell,programming,FI,2023,3
@@ -89335,8 +91738,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 726,Rust,programming,FI,2023,3
 584,Kotlin,programming,FI,2023,3
 554,Objective-C,programming,FI,2023,3
-534,Perl,programming,FI,2023,3
 534,PowerShell,programming,FI,2023,3
+534,Perl,programming,FI,2023,3
 432,Assembly,programming,FI,2023,3
 403,Swift,programming,FI,2023,3
 384,R,programming,FI,2023,3
@@ -89372,6 +91775,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Scheme,programming,FI,2023,3
 107,Lex,programming,FI,2023,3
 102,Gherkin,programming,FI,2023,3
+173,YAML,data,FR,2023,3
+155,JSON,data,FR,2023,3
+59277,HTML,markup,FR,2023,3
+52177,CSS,markup,FR,2023,3
+17539,SCSS,markup,FR,2023,3
+8202,Jupyter Notebook,markup,FR,2023,3
+4968,Vue,markup,FR,2023,3
+4162,Twig,markup,FR,2023,3
+3084,TeX,markup,FR,2023,3
+2768,Roff,markup,FR,2023,3
+1788,Less,markup,FR,2023,3
+1671,Jinja,markup,FR,2023,3
+1546,Handlebars,markup,FR,2023,3
+1325,Svelte,markup,FR,2023,3
+1266,Blade,markup,FR,2023,3
+1169,EJS,markup,FR,2023,3
+1117,Mustache,markup,FR,2023,3
+705,Sass,markup,FR,2023,3
+652,Rich Text Format,markup,FR,2023,3
+629,Pug,markup,FR,2023,3
+582,Astro,markup,FR,2023,3
+253,PostScript,markup,FR,2023,3
+242,Nunjucks,markup,FR,2023,3
+229,Stylus,markup,FR,2023,3
+201,Vim Snippet,markup,FR,2023,3
+200,Liquid,markup,FR,2023,3
+117,Haml,markup,FR,2023,3
 57422,JavaScript,programming,FR,2023,3
 34611,Python,programming,FR,2023,3
 31370,Shell,programming,FR,2023,3
@@ -89444,8 +91874,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 408,Smalltalk,programming,FR,2023,3
 405,FreeMarker,programming,FR,2023,3
 390,SourcePawn,programming,FR,2023,3
-377,Standard ML,programming,FR,2023,3
 377,GDScript,programming,FR,2023,3
+377,Standard ML,programming,FR,2023,3
 371,Prolog,programming,FR,2023,3
 366,Common Lisp,programming,FR,2023,3
 361,SWIG,programming,FR,2023,3
@@ -89500,9 +91930,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Thrift,programming,FR,2023,3
 119,Elm,programming,FR,2023,3
 116,Jasmin,programming,FR,2023,3
-116,Bicep,programming,FR,2023,3
-116,WebAssembly,programming,FR,2023,3
 116,Metal,programming,FR,2023,3
+116,WebAssembly,programming,FR,2023,3
+116,Bicep,programming,FR,2023,3
 113,Haxe,programming,FR,2023,3
 112,Logos,programming,FR,2023,3
 111,OpenEdge ABL,programming,FR,2023,3
@@ -89512,6 +91942,40 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,RPC,programming,FR,2023,3
 103,Cairo,programming,FR,2023,3
 101,ActionScript,programming,FR,2023,3
+238,Markdown,prose,FR,2023,3
+150,HTML,markup,GA,2023,3
+138,CSS,markup,GA,2023,3
+198,YAML,data,GB,2023,3
+174,JSON,data,GB,2023,3
+72651,HTML,markup,GB,2023,3
+59608,CSS,markup,GB,2023,3
+18588,SCSS,markup,GB,2023,3
+14748,Jupyter Notebook,markup,GB,2023,3
+4139,TeX,markup,GB,2023,3
+3288,Roff,markup,GB,2023,3
+3196,Vue,markup,GB,2023,3
+2111,Jinja,markup,GB,2023,3
+1874,Handlebars,markup,GB,2023,3
+1645,EJS,markup,GB,2023,3
+1634,Less,markup,GB,2023,3
+1437,Nunjucks,markup,GB,2023,3
+1377,Mustache,markup,GB,2023,3
+1348,Svelte,markup,GB,2023,3
+1258,Blade,markup,GB,2023,3
+1004,Rich Text Format,markup,GB,2023,3
+783,Astro,markup,GB,2023,3
+710,Pug,markup,GB,2023,3
+640,Sass,markup,GB,2023,3
+475,Twig,markup,GB,2023,3
+360,Liquid,markup,GB,2023,3
+343,PostScript,markup,GB,2023,3
+288,Vim Snippet,markup,GB,2023,3
+215,Stylus,markup,GB,2023,3
+178,Mermaid,markup,GB,2023,3
+171,Haml,markup,GB,2023,3
+127,RAML,markup,GB,2023,3
+122,Slim,markup,GB,2023,3
+106,YASnippet,markup,GB,2023,3
 67093,JavaScript,programming,GB,2023,3
 52040,Python,programming,GB,2023,3
 41809,Shell,programming,GB,2023,3
@@ -89586,8 +92050,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 519,SourcePawn,programming,GB,2023,3
 508,Common Lisp,programming,GB,2023,3
 492,ANTLR,programming,GB,2023,3
-467,Elixir,programming,GB,2023,3
 467,GAP,programming,GB,2023,3
+467,Elixir,programming,GB,2023,3
 465,Prolog,programming,GB,2023,3
 448,GDScript,programming,GB,2023,3
 448,SWIG,programming,GB,2023,3
@@ -89638,16 +92102,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 172,Visual Basic 6.0,programming,GB,2023,3
 168,WebAssembly,programming,GB,2023,3
 166,Scilab,programming,GB,2023,3
-166,jq,programming,GB,2023,3
 166,Processing,programming,GB,2023,3
 166,Elm,programming,GB,2023,3
+166,jq,programming,GB,2023,3
 164,DM,programming,GB,2023,3
 161,PureScript,programming,GB,2023,3
 157,OpenSCAD,programming,GB,2023,3
 156,Fluent,programming,GB,2023,3
 152,Jasmin,programming,GB,2023,3
-148,OpenEdge ABL,programming,GB,2023,3
 148,Stan,programming,GB,2023,3
+148,OpenEdge ABL,programming,GB,2023,3
 145,RenderScript,programming,GB,2023,3
 144,Module Management System,programming,GB,2023,3
 142,RPC,programming,GB,2023,3
@@ -89667,6 +92131,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 105,Sage,programming,GB,2023,3
 104,Brainfuck,programming,GB,2023,3
 101,NewLisp,programming,GB,2023,3
+283,Markdown,prose,GB,2023,3
+5693,HTML,markup,GE,2023,3
+4821,CSS,markup,GE,2023,3
+1349,SCSS,markup,GE,2023,3
+363,Vue,markup,GE,2023,3
+332,Jupyter Notebook,markup,GE,2023,3
+186,Blade,markup,GE,2023,3
+114,Less,markup,GE,2023,3
 5047,JavaScript,programming,GE,2023,3
 2226,TypeScript,programming,GE,2023,3
 2118,Python,programming,GE,2023,3
@@ -89695,6 +92167,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,Dart,programming,GE,2023,3
 109,Smarty,programming,GE,2023,3
 108,Objective-C++,programming,GE,2023,3
+5699,HTML,markup,GH,2023,3
+5201,CSS,markup,GH,2023,3
+933,SCSS,markup,GH,2023,3
+661,Jupyter Notebook,markup,GH,2023,3
+261,Blade,markup,GH,2023,3
+199,Vue,markup,GH,2023,3
+140,EJS,markup,GH,2023,3
+115,Less,markup,GH,2023,3
 5049,JavaScript,programming,GH,2023,3
 3123,Shell,programming,GH,2023,3
 2523,C,programming,GH,2023,3
@@ -89712,15 +92192,31 @@ num_pushers,language,language_type,iso2_code,year,quarter
 492,Dart,programming,GH,2023,3
 428,CMake,programming,GH,2023,3
 276,Makefile,programming,GH,2023,3
-266,Puppet,programming,GH,2023,3
 266,C#,programming,GH,2023,3
+266,Puppet,programming,GH,2023,3
 223,Batchfile,programming,GH,2023,3
 203,Hack,programming,GH,2023,3
 196,Procfile,programming,GH,2023,3
 178,PowerShell,programming,GH,2023,3
 149,Go,programming,GH,2023,3
 144,Solidity,programming,GH,2023,3
+115,HTML,markup,GM,2023,3
+102,CSS,markup,GM,2023,3
+163,HTML,markup,GN,2023,3
+159,CSS,markup,GN,2023,3
 126,JavaScript,programming,GN,2023,3
+5155,HTML,markup,GR,2023,3
+4359,CSS,markup,GR,2023,3
+1134,Jupyter Notebook,markup,GR,2023,3
+1094,SCSS,markup,GR,2023,3
+277,TeX,markup,GR,2023,3
+259,Roff,markup,GR,2023,3
+241,Vue,markup,GR,2023,3
+151,EJS,markup,GR,2023,3
+150,Less,markup,GR,2023,3
+143,Handlebars,markup,GR,2023,3
+138,Jinja,markup,GR,2023,3
+127,Blade,markup,GR,2023,3
 4690,JavaScript,programming,GR,2023,3
 3835,Python,programming,GR,2023,3
 2594,Shell,programming,GR,2023,3
@@ -89757,12 +92253,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,HLSL,programming,GR,2023,3
 124,M4,programming,GR,2023,3
 123,Dart,programming,GR,2023,3
+111,Nix,programming,GR,2023,3
 111,Solidity,programming,GR,2023,3
 111,Groovy,programming,GR,2023,3
-111,Nix,programming,GR,2023,3
 105,ShaderLab,programming,GR,2023,3
 104,Yacc,programming,GR,2023,3
 104,Objective-C++,programming,GR,2023,3
+3237,HTML,markup,GT,2023,3
+2805,CSS,markup,GT,2023,3
+486,SCSS,markup,GT,2023,3
+264,Jupyter Notebook,markup,GT,2023,3
+189,Blade,markup,GT,2023,3
+123,Vue,markup,GT,2023,3
 2799,JavaScript,programming,GT,2023,3
 1237,Java,programming,GT,2023,3
 1210,Python,programming,GT,2023,3
@@ -89781,6 +92283,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Ruby,programming,GT,2023,3
 117,Swift,programming,GT,2023,3
 116,Batchfile,programming,GT,2023,3
+44275,HTML,markup,HK,2023,3
+33058,CSS,markup,HK,2023,3
+12980,SCSS,markup,HK,2023,3
+9568,Vue,markup,HK,2023,3
+6556,Jupyter Notebook,markup,HK,2023,3
+5003,Less,markup,HK,2023,3
+2935,Roff,markup,HK,2023,3
+2231,TeX,markup,HK,2023,3
+1619,EJS,markup,HK,2023,3
+1167,Mustache,markup,HK,2023,3
+1032,Jinja,markup,HK,2023,3
+1022,Handlebars,markup,HK,2023,3
+1004,Stylus,markup,HK,2023,3
+539,Pug,markup,HK,2023,3
+472,Svelte,markup,HK,2023,3
+470,Rich Text Format,markup,HK,2023,3
+390,Vim Snippet,markup,HK,2023,3
+380,Blade,markup,HK,2023,3
+367,Astro,markup,HK,2023,3
+358,Sass,markup,HK,2023,3
+200,Nunjucks,markup,HK,2023,3
+171,PostScript,markup,HK,2023,3
+110,Liquid,markup,HK,2023,3
 43539,JavaScript,programming,HK,2023,3
 34335,Shell,programming,HK,2023,3
 33395,Python,programming,HK,2023,3
@@ -89877,8 +92402,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 237,Forth,programming,HK,2023,3
 235,PureBasic,programming,HK,2023,3
 226,DTrace,programming,HK,2023,3
-224,POV-Ray SDL,programming,HK,2023,3
 224,Common Lisp,programming,HK,2023,3
+224,POV-Ray SDL,programming,HK,2023,3
 223,ASP.NET,programming,HK,2023,3
 222,ASL,programming,HK,2023,3
 216,M,programming,HK,2023,3
@@ -89894,13 +92419,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 160,AutoHotkey,programming,HK,2023,3
 155,OCaml,programming,HK,2023,3
 153,AMPL,programming,HK,2023,3
-147,Classic ASP,programming,HK,2023,3
 147,WebAssembly,programming,HK,2023,3
+147,Classic ASP,programming,HK,2023,3
 145,Zig,programming,HK,2023,3
 143,VHDL,programming,HK,2023,3
-138,Visual Basic .NET,programming,HK,2023,3
-138,AspectJ,programming,HK,2023,3
 138,Brainfuck,programming,HK,2023,3
+138,AspectJ,programming,HK,2023,3
+138,Visual Basic .NET,programming,HK,2023,3
 133,Ragel,programming,HK,2023,3
 130,F#,programming,HK,2023,3
 125,GDScript,programming,HK,2023,3
@@ -89913,9 +92438,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Terra,programming,HK,2023,3
 112,Fluent,programming,HK,2023,3
 108,Visual Basic 6.0,programming,HK,2023,3
-107,Logos,programming,HK,2023,3
 107,MLIR,programming,HK,2023,3
+107,Logos,programming,HK,2023,3
 105,Stata,programming,HK,2023,3
+205,Markdown,prose,HK,2023,3
+1576,HTML,markup,HN,2023,3
+1348,CSS,markup,HN,2023,3
+251,SCSS,markup,HN,2023,3
+125,Blade,markup,HN,2023,3
 1383,JavaScript,programming,HN,2023,3
 385,Java,programming,HN,2023,3
 383,TypeScript,programming,HN,2023,3
@@ -89925,10 +92455,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 163,Shell,programming,HN,2023,3
 159,C++,programming,HN,2023,3
 107,C,programming,HN,2023,3
-106,Kotlin,programming,HN,2023,3
 106,Hack,programming,HN,2023,3
+106,Kotlin,programming,HN,2023,3
 105,Dockerfile,programming,HN,2023,3
 102,Objective-C,programming,HN,2023,3
+3483,HTML,markup,HR,2023,3
+2932,CSS,markup,HR,2023,3
+821,SCSS,markup,HR,2023,3
+311,Jupyter Notebook,markup,HR,2023,3
+275,Vue,markup,HR,2023,3
+115,Blade,markup,HR,2023,3
+113,Roff,markup,HR,2023,3
 3363,JavaScript,programming,HR,2023,3
 1538,Python,programming,HR,2023,3
 1304,Shell,programming,HR,2023,3
@@ -89955,8 +92492,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Hack,programming,HR,2023,3
 102,ShaderLab,programming,HR,2023,3
 101,HLSL,programming,HR,2023,3
+262,HTML,markup,HT,2023,3
+227,CSS,markup,HT,2023,3
 225,JavaScript,programming,HT,2023,3
 103,Python,programming,HT,2023,3
+7123,HTML,markup,HU,2023,3
+5803,CSS,markup,HU,2023,3
+1441,SCSS,markup,HU,2023,3
+619,Jupyter Notebook,markup,HU,2023,3
+377,Vue,markup,HU,2023,3
+304,Blade,markup,HU,2023,3
+257,Roff,markup,HU,2023,3
+225,TeX,markup,HU,2023,3
+179,Svelte,markup,HU,2023,3
+154,Mustache,markup,HU,2023,3
+145,Less,markup,HU,2023,3
+141,EJS,markup,HU,2023,3
+139,Jinja,markup,HU,2023,3
+134,Handlebars,markup,HU,2023,3
 6161,JavaScript,programming,HU,2023,3
 3565,Python,programming,HU,2023,3
 2885,Shell,programming,HU,2023,3
@@ -89988,9 +92541,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 172,Groovy,programming,HU,2023,3
 166,R,programming,HU,2023,3
 164,Vim Script,programming,HU,2023,3
-159,M4,programming,HU,2023,3
 159,Nix,programming,HU,2023,3
 159,Hack,programming,HU,2023,3
+159,M4,programming,HU,2023,3
 133,PLpgSQL,programming,HU,2023,3
 129,Objective-C++,programming,HU,2023,3
 124,MATLAB,programming,HU,2023,3
@@ -90000,6 +92553,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,Yacc,programming,HU,2023,3
 107,Awk,programming,HU,2023,3
 104,Scala,programming,HU,2023,3
+73753,HTML,markup,ID,2023,3
+64865,CSS,markup,ID,2023,3
+15988,SCSS,markup,ID,2023,3
+15504,Blade,markup,ID,2023,3
+7914,Jupyter Notebook,markup,ID,2023,3
+4689,Vue,markup,ID,2023,3
+3671,Less,markup,ID,2023,3
+1605,EJS,markup,ID,2023,3
+937,Handlebars,markup,ID,2023,3
+882,Roff,markup,ID,2023,3
+634,Svelte,markup,ID,2023,3
+588,Pug,markup,ID,2023,3
+472,TeX,markup,ID,2023,3
+437,Astro,markup,ID,2023,3
+349,Stylus,markup,ID,2023,3
+290,Sass,markup,ID,2023,3
+263,Rich Text Format,markup,ID,2023,3
+194,Jinja,markup,ID,2023,3
+163,Mustache,markup,ID,2023,3
+108,Twig,markup,ID,2023,3
 66367,JavaScript,programming,ID,2023,3
 29909,PHP,programming,ID,2023,3
 20382,Python,programming,ID,2023,3
@@ -90053,8 +92626,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 246,ASP.NET,programming,ID,2023,3
 242,Raku,programming,ID,2023,3
 225,SmPL,programming,ID,2023,3
-214,TSQL,programming,ID,2023,3
 214,Forth,programming,ID,2023,3
+214,TSQL,programming,ID,2023,3
 212,XS,programming,ID,2023,3
 209,UnrealScript,programming,ID,2023,3
 202,MATLAB,programming,ID,2023,3
@@ -90070,6 +92643,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Cuda,programming,ID,2023,3
 108,ActionScript,programming,ID,2023,3
 104,Inno Setup,programming,ID,2023,3
+104,Markdown,prose,ID,2023,3
+7220,HTML,markup,IE,2023,3
+6016,CSS,markup,IE,2023,3
+1452,SCSS,markup,IE,2023,3
+1405,Jupyter Notebook,markup,IE,2023,3
+288,Roff,markup,IE,2023,3
+261,Vue,markup,IE,2023,3
+256,TeX,markup,IE,2023,3
+198,Handlebars,markup,IE,2023,3
+186,Jinja,markup,IE,2023,3
+180,EJS,markup,IE,2023,3
+163,Less,markup,IE,2023,3
+156,Mustache,markup,IE,2023,3
+107,Svelte,markup,IE,2023,3
 6662,JavaScript,programming,IE,2023,3
 4869,Python,programming,IE,2023,3
 3773,Shell,programming,IE,2023,3
@@ -90115,6 +92702,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Hack,programming,IE,2023,3
 105,Starlark,programming,IE,2023,3
 103,PLpgSQL,programming,IE,2023,3
+16049,HTML,markup,IL,2023,3
+13158,CSS,markup,IL,2023,3
+3250,SCSS,markup,IL,2023,3
+2884,Jupyter Notebook,markup,IL,2023,3
+719,EJS,markup,IL,2023,3
+651,Vue,markup,IL,2023,3
+616,Roff,markup,IL,2023,3
+421,Jinja,markup,IL,2023,3
+387,Mustache,markup,IL,2023,3
+370,Handlebars,markup,IL,2023,3
+368,TeX,markup,IL,2023,3
+259,Less,markup,IL,2023,3
+229,Pug,markup,IL,2023,3
+206,Rich Text Format,markup,IL,2023,3
+180,Svelte,markup,IL,2023,3
+105,Sass,markup,IL,2023,3
+103,Blade,markup,IL,2023,3
 15430,JavaScript,programming,IL,2023,3
 12659,Python,programming,IL,2023,3
 7863,Shell,programming,IL,2023,3
@@ -90176,6 +92780,37 @@ num_pushers,language,language_type,iso2_code,year,quarter
 115,Meson,programming,IL,2023,3
 109,Bicep,programming,IL,2023,3
 107,Jsonnet,programming,IL,2023,3
+155,YAML,data,IN,2023,3
+145,JSON,data,IN,2023,3
+526143,HTML,markup,IN,2023,3
+439385,CSS,markup,IN,2023,3
+108588,Jupyter Notebook,markup,IN,2023,3
+59556,SCSS,markup,IN,2023,3
+19683,EJS,markup,IN,2023,3
+8452,Roff,markup,IN,2023,3
+7563,Less,markup,IN,2023,3
+6294,Handlebars,markup,IN,2023,3
+6113,Vue,markup,IN,2023,3
+5343,Blade,markup,IN,2023,3
+3843,Pug,markup,IN,2023,3
+3511,Jinja,markup,IN,2023,3
+3421,TeX,markup,IN,2023,3
+2776,Mustache,markup,IN,2023,3
+2092,Rich Text Format,markup,IN,2023,3
+1997,Svelte,markup,IN,2023,3
+1348,Astro,markup,IN,2023,3
+1333,Sass,markup,IN,2023,3
+621,Twig,markup,IN,2023,3
+565,Liquid,markup,IN,2023,3
+438,Stylus,markup,IN,2023,3
+429,kvlang,markup,IN,2023,3
+298,PostScript,markup,IN,2023,3
+290,Nunjucks,markup,IN,2023,3
+248,Vim Snippet,markup,IN,2023,3
+201,RAML,markup,IN,2023,3
+189,Haml,markup,IN,2023,3
+182,Mermaid,markup,IN,2023,3
+115,Slim,markup,IN,2023,3
 421160,JavaScript,programming,IN,2023,3
 228630,Python,programming,IN,2023,3
 138539,Java,programming,IN,2023,3
@@ -90309,8 +92944,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 190,Puppet,programming,IN,2023,3
 187,Crystal,programming,IN,2023,3
 186,Metal,programming,IN,2023,3
-184,AMPL,programming,IN,2023,3
 184,Motoko,programming,IN,2023,3
+184,AMPL,programming,IN,2023,3
 174,Stata,programming,IN,2023,3
 168,LookML,programming,IN,2023,3
 167,Cadence,programming,IN,2023,3
@@ -90333,9 +92968,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,BitBake,programming,IN,2023,3
 110,Xonsh,programming,IN,2023,3
 108,Vyper,programming,IN,2023,3
-107,NewLisp,programming,IN,2023,3
-107,Coq,programming,IN,2023,3
 107,Io,programming,IN,2023,3
+107,Coq,programming,IN,2023,3
+107,NewLisp,programming,IN,2023,3
+377,Markdown,prose,IN,2023,3
+1661,HTML,markup,IQ,2023,3
+1338,CSS,markup,IQ,2023,3
+204,SCSS,markup,IQ,2023,3
+123,Vue,markup,IQ,2023,3
+117,Blade,markup,IQ,2023,3
 1380,JavaScript,programming,IQ,2023,3
 769,Python,programming,IQ,2023,3
 365,Shell,programming,IQ,2023,3
@@ -90344,8 +92985,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 282,PHP,programming,IQ,2023,3
 271,Kotlin,programming,IQ,2023,3
 263,Dart,programming,IQ,2023,3
-256,Swift,programming,IQ,2023,3
 256,C,programming,IQ,2023,3
+256,Swift,programming,IQ,2023,3
 253,C++,programming,IQ,2023,3
 241,Objective-C,programming,IQ,2023,3
 201,Procfile,programming,IQ,2023,3
@@ -90354,6 +92995,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 145,C#,programming,IQ,2023,3
 132,Ruby,programming,IQ,2023,3
 113,Makefile,programming,IQ,2023,3
+12326,HTML,markup,IR,2023,3
+10891,CSS,markup,IR,2023,3
+2814,SCSS,markup,IR,2023,3
+2356,Jupyter Notebook,markup,IR,2023,3
+792,Blade,markup,IR,2023,3
+781,Vue,markup,IR,2023,3
+556,Less,markup,IR,2023,3
+249,TeX,markup,IR,2023,3
+189,Roff,markup,IR,2023,3
+166,EJS,markup,IR,2023,3
+111,Handlebars,markup,IR,2023,3
 10953,JavaScript,programming,IR,2023,3
 7341,Python,programming,IR,2023,3
 3071,TypeScript,programming,IR,2023,3
@@ -90379,8 +93031,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 260,Assembly,programming,IR,2023,3
 252,Rust,programming,IR,2023,3
 250,Lua,programming,IR,2023,3
-180,Perl,programming,IR,2023,3
 180,Smarty,programming,IR,2023,3
+180,Perl,programming,IR,2023,3
 158,Procfile,programming,IR,2023,3
 140,QMake,programming,IR,2023,3
 134,Solidity,programming,IR,2023,3
@@ -90393,6 +93045,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,Verilog,programming,IR,2023,3
 105,ShaderLab,programming,IR,2023,3
 102,ASP.NET,programming,IR,2023,3
+626,HTML,markup,IS,2023,3
+519,CSS,markup,IS,2023,3
+162,SCSS,markup,IS,2023,3
 568,JavaScript,programming,IS,2023,3
 389,Python,programming,IS,2023,3
 356,Shell,programming,IS,2023,3
@@ -90403,6 +93058,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 131,Java,programming,IS,2023,3
 123,C++,programming,IS,2023,3
 111,Ruby,programming,IS,2023,3
+23042,HTML,markup,IT,2023,3
+19306,CSS,markup,IT,2023,3
+5897,SCSS,markup,IT,2023,3
+5165,Jupyter Notebook,markup,IT,2023,3
+1868,Vue,markup,IT,2023,3
+1829,TeX,markup,IT,2023,3
+1133,Roff,markup,IT,2023,3
+1073,Blade,markup,IT,2023,3
+559,Less,markup,IT,2023,3
+516,Jinja,markup,IT,2023,3
+489,Handlebars,markup,IT,2023,3
+423,Svelte,markup,IT,2023,3
+382,Rich Text Format,markup,IT,2023,3
+381,Mustache,markup,IT,2023,3
+355,EJS,markup,IT,2023,3
+253,Astro,markup,IT,2023,3
+232,Sass,markup,IT,2023,3
+221,Pug,markup,IT,2023,3
+165,Twig,markup,IT,2023,3
+112,PostScript,markup,IT,2023,3
+107,Liquid,markup,IT,2023,3
 20379,JavaScript,programming,IT,2023,3
 16166,Python,programming,IT,2023,3
 12328,Shell,programming,IT,2023,3
@@ -90458,8 +93134,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 259,Cython,programming,IT,2023,3
 250,Prolog,programming,IT,2023,3
 249,sed,programming,IT,2023,3
-246,Meson,programming,IT,2023,3
 246,NASL,programming,IT,2023,3
+246,Meson,programming,IT,2023,3
 231,TSQL,programming,IT,2023,3
 229,Pascal,programming,IT,2023,3
 222,Haskell,programming,IT,2023,3
@@ -90475,8 +93151,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 184,Mathematica,programming,IT,2023,3
 182,FreeMarker,programming,IT,2023,3
 170,Clojure,programming,IT,2023,3
-169,Common Lisp,programming,IT,2023,3
 169,VHDL,programming,IT,2023,3
+169,Common Lisp,programming,IT,2023,3
 162,ASP.NET,programming,IT,2023,3
 160,Smalltalk,programming,IT,2023,3
 157,QML,programming,IT,2023,3
@@ -90487,8 +93163,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Mako,programming,IT,2023,3
 137,SmPL,programming,IT,2023,3
 136,Verilog,programming,IT,2023,3
-133,PureBasic,programming,IT,2023,3
 133,Elixir,programming,IT,2023,3
+133,PureBasic,programming,IT,2023,3
 132,GAP,programming,IT,2023,3
 128,M,programming,IT,2023,3
 126,Pawn,programming,IT,2023,3
@@ -90499,10 +93175,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,OCaml,programming,IT,2023,3
 108,Visual Basic .NET,programming,IT,2023,3
 108,Processing,programming,IT,2023,3
+536,HTML,markup,JM,2023,3
+512,CSS,markup,JM,2023,3
 423,JavaScript,programming,JM,2023,3
 160,Python,programming,JM,2023,3
 140,TypeScript,programming,JM,2023,3
 101,Shell,programming,JM,2023,3
+2694,HTML,markup,JO,2023,3
+2253,CSS,markup,JO,2023,3
+593,SCSS,markup,JO,2023,3
+272,Jupyter Notebook,markup,JO,2023,3
+216,Blade,markup,JO,2023,3
 2237,JavaScript,programming,JO,2023,3
 798,Python,programming,JO,2023,3
 547,Java,programming,JO,2023,3
@@ -90519,10 +93202,39 @@ num_pushers,language,language_type,iso2_code,year,quarter
 286,Dart,programming,JO,2023,3
 249,CMake,programming,JO,2023,3
 190,Ruby,programming,JO,2023,3
-149,Hack,programming,JO,2023,3
 149,Makefile,programming,JO,2023,3
+149,Hack,programming,JO,2023,3
 110,PowerShell,programming,JO,2023,3
 103,Batchfile,programming,JO,2023,3
+115,YAML,data,JP,2023,3
+103,JSON,data,JP,2023,3
+62628,HTML,markup,JP,2023,3
+51518,CSS,markup,JP,2023,3
+16003,SCSS,markup,JP,2023,3
+8435,Vue,markup,JP,2023,3
+7472,Jupyter Notebook,markup,JP,2023,3
+3331,Blade,markup,JP,2023,3
+2750,Roff,markup,JP,2023,3
+2712,Less,markup,JP,2023,3
+2261,TeX,markup,JP,2023,3
+1524,EJS,markup,JP,2023,3
+1022,Pug,markup,JP,2023,3
+1021,Handlebars,markup,JP,2023,3
+982,Astro,markup,JP,2023,3
+950,Jinja,markup,JP,2023,3
+885,Svelte,markup,JP,2023,3
+687,Mustache,markup,JP,2023,3
+637,Stylus,markup,JP,2023,3
+486,Rich Text Format,markup,JP,2023,3
+468,Sass,markup,JP,2023,3
+433,Vim Snippet,markup,JP,2023,3
+291,Haml,markup,JP,2023,3
+220,Slim,markup,JP,2023,3
+217,PostScript,markup,JP,2023,3
+205,Twig,markup,JP,2023,3
+200,Nunjucks,markup,JP,2023,3
+199,Liquid,markup,JP,2023,3
+146,YASnippet,markup,JP,2023,3
 59178,JavaScript,programming,JP,2023,3
 37080,Python,programming,JP,2023,3
 35336,Shell,programming,JP,2023,3
@@ -90585,8 +93297,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 494,FreeMarker,programming,JP,2023,3
 491,Clojure,programming,JP,2023,3
 472,Scheme,programming,JP,2023,3
-459,Verilog,programming,JP,2023,3
 459,Mako,programming,JP,2023,3
+459,Verilog,programming,JP,2023,3
 435,NSIS,programming,JP,2023,3
 431,AutoHotkey,programming,JP,2023,3
 425,NASL,programming,JP,2023,3
@@ -90613,8 +93325,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 296,Gnuplot,programming,JP,2023,3
 283,UnrealScript,programming,JP,2023,3
 276,D,programming,JP,2023,3
-260,Jsonnet,programming,JP,2023,3
 260,AIDL,programming,JP,2023,3
+260,Jsonnet,programming,JP,2023,3
 259,Pawn,programming,JP,2023,3
 258,AppleScript,programming,JP,2023,3
 254,Prolog,programming,JP,2023,3
@@ -90622,10 +93334,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 247,Visual Basic .NET,programming,JP,2023,3
 237,F#,programming,JP,2023,3
 230,Inno Setup,programming,JP,2023,3
-221,Metal,programming,JP,2023,3
 221,DIGITAL Command Language,programming,JP,2023,3
-220,Erlang,programming,JP,2023,3
+221,Metal,programming,JP,2023,3
 220,Processing,programming,JP,2023,3
+220,Erlang,programming,JP,2023,3
 219,SystemVerilog,programming,JP,2023,3
 203,DTrace,programming,JP,2023,3
 196,M,programming,JP,2023,3
@@ -90656,6 +93368,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,Module Management System,programming,JP,2023,3
 108,Reason,programming,JP,2023,3
 104,CUE,programming,JP,2023,3
+255,Markdown,prose,JP,2023,3
+15315,HTML,markup,KE,2023,3
+13910,CSS,markup,KE,2023,3
+2713,SCSS,markup,KE,2023,3
+2079,Jupyter Notebook,markup,KE,2023,3
+897,Blade,markup,KE,2023,3
+676,Vue,markup,KE,2023,3
+392,EJS,markup,KE,2023,3
+366,Less,markup,KE,2023,3
+316,Roff,markup,KE,2023,3
+236,Handlebars,markup,KE,2023,3
+160,Pug,markup,KE,2023,3
+113,TeX,markup,KE,2023,3
 13812,JavaScript,programming,KE,2023,3
 8716,Shell,programming,KE,2023,3
 8210,Python,programming,KE,2023,3
@@ -90699,6 +93424,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 129,PLpgSQL,programming,KE,2023,3
 114,Objective-C++,programming,KE,2023,3
 114,CoffeeScript,programming,KE,2023,3
+3605,HTML,markup,KG,2023,3
+2899,CSS,markup,KG,2023,3
+853,SCSS,markup,KG,2023,3
+143,Vue,markup,KG,2023,3
 2722,JavaScript,programming,KG,2023,3
 1324,Python,programming,KG,2023,3
 796,TypeScript,programming,KG,2023,3
@@ -90718,6 +93447,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 178,CMake,programming,KG,2023,3
 178,PowerShell,programming,KG,2023,3
 142,Batchfile,programming,KG,2023,3
+2627,HTML,markup,KH,2023,3
+2193,CSS,markup,KH,2023,3
+525,SCSS,markup,KH,2023,3
+365,Vue,markup,KH,2023,3
+365,Blade,markup,KH,2023,3
+153,Jupyter Notebook,markup,KH,2023,3
 2081,JavaScript,programming,KH,2023,3
 614,PHP,programming,KH,2023,3
 614,TypeScript,programming,KH,2023,3
@@ -90736,6 +93471,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,C#,programming,KH,2023,3
 155,Makefile,programming,KH,2023,3
 135,Hack,programming,KH,2023,3
+122,YAML,data,KR,2023,3
+117,JSON,data,KR,2023,3
+72455,HTML,markup,KR,2023,3
+55455,CSS,markup,KR,2023,3
+15158,SCSS,markup,KR,2023,3
+14040,Jupyter Notebook,markup,KR,2023,3
+3962,Vue,markup,KR,2023,3
+1919,EJS,markup,KR,2023,3
+1624,Roff,markup,KR,2023,3
+1288,Less,markup,KR,2023,3
+1283,TeX,markup,KR,2023,3
+1036,Pug,markup,KR,2023,3
+1015,Mustache,markup,KR,2023,3
+763,Svelte,markup,KR,2023,3
+646,Handlebars,markup,KR,2023,3
+433,Jinja,markup,KR,2023,3
+394,Vim Snippet,markup,KR,2023,3
+388,Rich Text Format,markup,KR,2023,3
+369,Sass,markup,KR,2023,3
+236,Blade,markup,KR,2023,3
+179,Liquid,markup,KR,2023,3
+157,Astro,markup,KR,2023,3
+135,Stylus,markup,KR,2023,3
 63781,JavaScript,programming,KR,2023,3
 40420,Python,programming,KR,2023,3
 39720,Java,programming,KR,2023,3
@@ -90808,19 +93566,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 182,TSQL,programming,KR,2023,3
 180,Visual Basic .NET,programming,KR,2023,3
 177,NASL,programming,KR,2023,3
-176,SWIG,programming,KR,2023,3
 176,Pascal,programming,KR,2023,3
+176,SWIG,programming,KR,2023,3
 174,XS,programming,KR,2023,3
 171,Ada,programming,KR,2023,3
 171,QML,programming,KR,2023,3
-151,VBScript,programming,KR,2023,3
 151,SmPL,programming,KR,2023,3
+151,VBScript,programming,KR,2023,3
 150,Jsonnet,programming,KR,2023,3
 143,Julia,programming,KR,2023,3
 141,ANTLR,programming,KR,2023,3
 138,Elixir,programming,KR,2023,3
-137,Common Lisp,programming,KR,2023,3
 137,AIDL,programming,KR,2023,3
+137,Common Lisp,programming,KR,2023,3
 134,Haskell,programming,KR,2023,3
 125,UnrealScript,programming,KR,2023,3
 121,DIGITAL Command Language,programming,KR,2023,3
@@ -90833,10 +93591,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Thrift,programming,KR,2023,3
 103,Processing,programming,KR,2023,3
 102,DTrace,programming,KR,2023,3
+188,Markdown,prose,KR,2023,3
+581,HTML,markup,KW,2023,3
+448,CSS,markup,KW,2023,3
 458,JavaScript,programming,KW,2023,3
 350,Python,programming,KW,2023,3
 140,Shell,programming,KW,2023,3
 114,C,programming,KW,2023,3
+6373,HTML,markup,KZ,2023,3
+5119,CSS,markup,KZ,2023,3
+1376,SCSS,markup,KZ,2023,3
+588,Vue,markup,KZ,2023,3
+524,Jupyter Notebook,markup,KZ,2023,3
+276,Blade,markup,KZ,2023,3
+181,Less,markup,KZ,2023,3
+106,Roff,markup,KZ,2023,3
+106,Sass,markup,KZ,2023,3
 5176,JavaScript,programming,KZ,2023,3
 3280,Python,programming,KZ,2023,3
 1794,TypeScript,programming,KZ,2023,3
@@ -90863,8 +93633,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Rust,programming,KZ,2023,3
 126,Procfile,programming,KZ,2023,3
 126,Hack,programming,KZ,2023,3
+321,HTML,markup,LA,2023,3
+285,CSS,markup,LA,2023,3
 349,JavaScript,programming,LA,2023,3
 119,TypeScript,programming,LA,2023,3
+2359,HTML,markup,LB,2023,3
+2118,CSS,markup,LB,2023,3
+385,SCSS,markup,LB,2023,3
+195,Blade,markup,LB,2023,3
+187,Jupyter Notebook,markup,LB,2023,3
 2121,JavaScript,programming,LB,2023,3
 834,Python,programming,LB,2023,3
 515,TypeScript,programming,LB,2023,3
@@ -90883,6 +93660,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,Dart,programming,LB,2023,3
 120,Makefile,programming,LB,2023,3
 102,Hack,programming,LB,2023,3
+13972,HTML,markup,LK,2023,3
+11511,CSS,markup,LK,2023,3
+2143,SCSS,markup,LK,2023,3
+1384,Jupyter Notebook,markup,LK,2023,3
+652,Blade,markup,LK,2023,3
+416,Less,markup,LK,2023,3
+328,Vue,markup,LK,2023,3
+254,Handlebars,markup,LK,2023,3
+204,EJS,markup,LK,2023,3
+194,Jinja,markup,LK,2023,3
+126,Mustache,markup,LK,2023,3
+109,Roff,markup,LK,2023,3
 12457,JavaScript,programming,LK,2023,3
 5118,Java,programming,LK,2023,3
 4824,Python,programming,LK,2023,3
@@ -90918,6 +93707,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,SQLPL,programming,LK,2023,3
 109,Perl,programming,LK,2023,3
 102,Rust,programming,LK,2023,3
+141,HTML,markup,LR,2023,3
+120,CSS,markup,LR,2023,3
+3228,HTML,markup,LT,2023,3
+2782,CSS,markup,LT,2023,3
+729,SCSS,markup,LT,2023,3
+272,Jupyter Notebook,markup,LT,2023,3
+207,Vue,markup,LT,2023,3
+149,Blade,markup,LT,2023,3
 3055,JavaScript,programming,LT,2023,3
 1491,Python,programming,LT,2023,3
 1295,Shell,programming,LT,2023,3
@@ -90944,6 +93741,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,Smarty,programming,LT,2023,3
 115,Perl,programming,LT,2023,3
 115,Assembly,programming,LT,2023,3
+768,HTML,markup,LU,2023,3
+618,CSS,markup,LU,2023,3
+230,SCSS,markup,LU,2023,3
+156,Jupyter Notebook,markup,LU,2023,3
 753,JavaScript,programming,LU,2023,3
 595,Python,programming,LU,2023,3
 495,Shell,programming,LU,2023,3
@@ -90955,8 +93756,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,C++,programming,LU,2023,3
 149,PHP,programming,LU,2023,3
 144,Ruby,programming,LU,2023,3
-103,CMake,programming,LU,2023,3
 103,Batchfile,programming,LU,2023,3
+103,CMake,programming,LU,2023,3
+2153,HTML,markup,LV,2023,3
+1793,CSS,markup,LV,2023,3
+466,SCSS,markup,LV,2023,3
+174,Vue,markup,LV,2023,3
+158,Blade,markup,LV,2023,3
+150,Jupyter Notebook,markup,LV,2023,3
 1983,JavaScript,programming,LV,2023,3
 1060,Python,programming,LV,2023,3
 836,Shell,programming,LV,2023,3
@@ -90974,8 +93781,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 151,CMake,programming,LV,2023,3
 118,Lua,programming,LV,2023,3
 115,Kotlin,programming,LV,2023,3
+322,HTML,markup,LY,2023,3
+256,CSS,markup,LY,2023,3
 246,JavaScript,programming,LY,2023,3
 116,Python,programming,LY,2023,3
+8864,HTML,markup,MA,2023,3
+8255,CSS,markup,MA,2023,3
+1805,SCSS,markup,MA,2023,3
+930,Blade,markup,MA,2023,3
+928,Jupyter Notebook,markup,MA,2023,3
+488,Vue,markup,MA,2023,3
+204,EJS,markup,MA,2023,3
+175,Roff,markup,MA,2023,3
+170,Less,markup,MA,2023,3
+151,Twig,markup,MA,2023,3
 8171,JavaScript,programming,MA,2023,3
 6435,Shell,programming,MA,2023,3
 5614,C,programming,MA,2023,3
@@ -91008,6 +93827,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,Rust,programming,MA,2023,3
 122,Nix,programming,MA,2023,3
 109,Perl,programming,MA,2023,3
+1916,HTML,markup,MD,2023,3
+1600,CSS,markup,MD,2023,3
+570,SCSS,markup,MD,2023,3
+158,Vue,markup,MD,2023,3
 1834,JavaScript,programming,MD,2023,3
 715,TypeScript,programming,MD,2023,3
 689,Python,programming,MD,2023,3
@@ -91024,6 +93847,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Go,programming,MD,2023,3
 125,Kotlin,programming,MD,2023,3
 106,Swift,programming,MD,2023,3
+864,HTML,markup,ME,2023,3
+717,CSS,markup,ME,2023,3
+259,SCSS,markup,ME,2023,3
 870,JavaScript,programming,ME,2023,3
 410,Python,programming,ME,2023,3
 350,TypeScript,programming,ME,2023,3
@@ -91037,6 +93863,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,C++,programming,ME,2023,3
 110,Ruby,programming,ME,2023,3
 102,Kotlin,programming,ME,2023,3
+1744,HTML,markup,MG,2023,3
+1658,CSS,markup,MG,2023,3
+567,SCSS,markup,MG,2023,3
+143,Blade,markup,MG,2023,3
+102,Vue,markup,MG,2023,3
 1698,JavaScript,programming,MG,2023,3
 688,PHP,programming,MG,2023,3
 626,Java,programming,MG,2023,3
@@ -91047,6 +93878,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 240,Batchfile,programming,MG,2023,3
 162,Dockerfile,programming,MG,2023,3
 125,C,programming,MG,2023,3
+1827,HTML,markup,MK,2023,3
+1566,CSS,markup,MK,2023,3
+306,SCSS,markup,MK,2023,3
+123,Jupyter Notebook,markup,MK,2023,3
 1506,JavaScript,programming,MK,2023,3
 519,C#,programming,MK,2023,3
 453,TypeScript,programming,MK,2023,3
@@ -91060,7 +93895,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 128,Kotlin,programming,MK,2023,3
 105,Swift,programming,MK,2023,3
 102,Objective-C,programming,MK,2023,3
+263,HTML,markup,ML,2023,3
+216,CSS,markup,ML,2023,3
 217,JavaScript,programming,ML,2023,3
+3363,HTML,markup,MM,2023,3
+2924,CSS,markup,MM,2023,3
+715,SCSS,markup,MM,2023,3
+624,Blade,markup,MM,2023,3
+277,Vue,markup,MM,2023,3
+106,Jupyter Notebook,markup,MM,2023,3
 2845,JavaScript,programming,MM,2023,3
 945,PHP,programming,MM,2023,3
 687,TypeScript,programming,MM,2023,3
@@ -91079,6 +93922,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 203,Ruby,programming,MM,2023,3
 166,C#,programming,MM,2023,3
 114,Makefile,programming,MM,2023,3
+944,HTML,markup,MN,2023,3
+910,CSS,markup,MN,2023,3
+160,SCSS,markup,MN,2023,3
 922,JavaScript,programming,MN,2023,3
 352,TypeScript,programming,MN,2023,3
 225,Python,programming,MN,2023,3
@@ -91087,30 +93933,61 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,C,programming,MN,2023,3
 112,Objective-C,programming,MN,2023,3
 110,Dockerfile,programming,MN,2023,3
-103,Swift,programming,MN,2023,3
 103,CMake,programming,MN,2023,3
+103,Swift,programming,MN,2023,3
+273,HTML,markup,MO,2023,3
+224,CSS,markup,MO,2023,3
 253,JavaScript,programming,MO,2023,3
 190,Python,programming,MO,2023,3
 127,Shell,programming,MO,2023,3
+136,HTML,markup,MR,2023,3
+108,CSS,markup,MR,2023,3
 117,JavaScript,programming,MR,2023,3
+447,HTML,markup,MT,2023,3
+381,CSS,markup,MT,2023,3
+115,SCSS,markup,MT,2023,3
 440,JavaScript,programming,MT,2023,3
 233,Python,programming,MT,2023,3
 212,TypeScript,programming,MT,2023,3
 189,Shell,programming,MT,2023,3
 134,Dockerfile,programming,MT,2023,3
 108,Java,programming,MT,2023,3
+545,HTML,markup,MU,2023,3
+480,CSS,markup,MU,2023,3
+113,SCSS,markup,MU,2023,3
 476,JavaScript,programming,MU,2023,3
 227,Python,programming,MU,2023,3
 179,Shell,programming,MU,2023,3
 141,TypeScript,programming,MU,2023,3
 109,PHP,programming,MU,2023,3
 107,Java,programming,MU,2023,3
+157,HTML,markup,MV,2023,3
+145,CSS,markup,MV,2023,3
 176,JavaScript,programming,MV,2023,3
+468,HTML,markup,MW,2023,3
+434,CSS,markup,MW,2023,3
 422,JavaScript,programming,MW,2023,3
 184,Python,programming,MW,2023,3
 179,Shell,programming,MW,2023,3
 153,PHP,programming,MW,2023,3
 141,C,programming,MW,2023,3
+34619,HTML,markup,MX,2023,3
+29526,CSS,markup,MX,2023,3
+5788,SCSS,markup,MX,2023,3
+4442,Jupyter Notebook,markup,MX,2023,3
+1795,Blade,markup,MX,2023,3
+1430,Vue,markup,MX,2023,3
+710,Less,markup,MX,2023,3
+617,Handlebars,markup,MX,2023,3
+560,TeX,markup,MX,2023,3
+539,EJS,markup,MX,2023,3
+437,Roff,markup,MX,2023,3
+394,Astro,markup,MX,2023,3
+296,Pug,markup,MX,2023,3
+254,Svelte,markup,MX,2023,3
+211,Sass,markup,MX,2023,3
+195,Jinja,markup,MX,2023,3
+167,Rich Text Format,markup,MX,2023,3
 30085,JavaScript,programming,MX,2023,3
 12497,Python,programming,MX,2023,3
 8414,TypeScript,programming,MX,2023,3
@@ -91178,6 +94055,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Common Lisp,programming,MX,2023,3
 107,Smalltalk,programming,MX,2023,3
 105,Pascal,programming,MX,2023,3
+9926,HTML,markup,MY,2023,3
+8469,CSS,markup,MY,2023,3
+1954,SCSS,markup,MY,2023,3
+1428,Jupyter Notebook,markup,MY,2023,3
+862,Blade,markup,MY,2023,3
+710,Vue,markup,MY,2023,3
+370,Less,markup,MY,2023,3
+244,Roff,markup,MY,2023,3
+206,EJS,markup,MY,2023,3
+190,Handlebars,markup,MY,2023,3
+170,TeX,markup,MY,2023,3
+145,Svelte,markup,MY,2023,3
+117,Rich Text Format,markup,MY,2023,3
 8578,JavaScript,programming,MY,2023,3
 4355,Python,programming,MY,2023,3
 2758,Shell,programming,MY,2023,3
@@ -91218,6 +94108,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,GLSL,programming,MY,2023,3
 105,Starlark,programming,MY,2023,3
 102,XSLT,programming,MY,2023,3
+678,HTML,markup,MZ,2023,3
+603,CSS,markup,MZ,2023,3
+126,SCSS,markup,MZ,2023,3
 582,JavaScript,programming,MZ,2023,3
 215,Java,programming,MZ,2023,3
 177,TypeScript,programming,MZ,2023,3
@@ -91225,8 +94118,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,Python,programming,MZ,2023,3
 139,Shell,programming,MZ,2023,3
 103,C,programming,MZ,2023,3
+214,HTML,markup,NA,2023,3
+161,CSS,markup,NA,2023,3
 166,JavaScript,programming,NA,2023,3
 125,Ballerina,programming,NA,2023,3
+39651,HTML,markup,NG,2023,3
+35468,CSS,markup,NG,2023,3
+6657,SCSS,markup,NG,2023,3
+3342,Jupyter Notebook,markup,NG,2023,3
+1413,Vue,markup,NG,2023,3
+1286,Blade,markup,NG,2023,3
+1146,EJS,markup,NG,2023,3
+866,Less,markup,NG,2023,3
+524,Handlebars,markup,NG,2023,3
+401,Pug,markup,NG,2023,3
+393,Roff,markup,NG,2023,3
+216,Svelte,markup,NG,2023,3
+176,Jinja,markup,NG,2023,3
+150,Astro,markup,NG,2023,3
+135,TeX,markup,NG,2023,3
+120,Sass,markup,NG,2023,3
 34267,JavaScript,programming,NG,2023,3
 14600,Shell,programming,NG,2023,3
 12097,Python,programming,NG,2023,3
@@ -91274,6 +94185,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,M4,programming,NG,2023,3
 118,Tcl,programming,NG,2023,3
 116,Groovy,programming,NG,2023,3
+1375,HTML,markup,NI,2023,3
+1097,CSS,markup,NI,2023,3
+257,SCSS,markup,NI,2023,3
 1074,JavaScript,programming,NI,2023,3
 329,C#,programming,NI,2023,3
 319,TypeScript,programming,NI,2023,3
@@ -91283,6 +94197,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 148,Shell,programming,NI,2023,3
 131,Kotlin,programming,NI,2023,3
 101,Dockerfile,programming,NI,2023,3
+27490,HTML,markup,NL,2023,3
+23010,CSS,markup,NL,2023,3
+6867,SCSS,markup,NL,2023,3
+4838,Jupyter Notebook,markup,NL,2023,3
+2088,Vue,markup,NL,2023,3
+1616,TeX,markup,NL,2023,3
+1287,Roff,markup,NL,2023,3
+1230,Blade,markup,NL,2023,3
+940,Jinja,markup,NL,2023,3
+782,Less,markup,NL,2023,3
+739,Svelte,markup,NL,2023,3
+688,Handlebars,markup,NL,2023,3
+628,Mustache,markup,NL,2023,3
+544,EJS,markup,NL,2023,3
+421,Twig,markup,NL,2023,3
+363,Rich Text Format,markup,NL,2023,3
+285,Pug,markup,NL,2023,3
+278,Sass,markup,NL,2023,3
+266,Astro,markup,NL,2023,3
+147,Nunjucks,markup,NL,2023,3
+137,Liquid,markup,NL,2023,3
+134,PostScript,markup,NL,2023,3
+110,Vim Snippet,markup,NL,2023,3
+106,Stylus,markup,NL,2023,3
 25563,JavaScript,programming,NL,2023,3
 19344,Python,programming,NL,2023,3
 16512,Shell,programming,NL,2023,3
@@ -91299,8 +94237,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 3419,CMake,programming,NL,2023,3
 2851,Go,programming,NL,2023,3
 2369,PowerShell,programming,NL,2023,3
-2240,Kotlin,programming,NL,2023,3
 2240,Rust,programming,NL,2023,3
+2240,Kotlin,programming,NL,2023,3
 2088,Lua,programming,NL,2023,3
 1915,Objective-C,programming,NL,2023,3
 1702,R,programming,NL,2023,3
@@ -91355,10 +94293,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 233,SourcePawn,programming,NL,2023,3
 218,Clojure,programming,NL,2023,3
 212,ASP.NET,programming,NL,2023,3
-203,FreeMarker,programming,NL,2023,3
 203,Common Lisp,programming,NL,2023,3
-197,Prolog,programming,NL,2023,3
+203,FreeMarker,programming,NL,2023,3
 197,Elixir,programming,NL,2023,3
+197,Prolog,programming,NL,2023,3
 193,Inno Setup,programming,NL,2023,3
 193,Raku,programming,NL,2023,3
 179,GAP,programming,NL,2023,3
@@ -91380,8 +94318,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 123,F#,programming,NL,2023,3
 122,Jsonnet,programming,NL,2023,3
 120,Standard ML,programming,NL,2023,3
-120,RobotFramework,programming,NL,2023,3
 120,VHDL,programming,NL,2023,3
+120,RobotFramework,programming,NL,2023,3
 119,CoffeeScript,programming,NL,2023,3
 116,Nim,programming,NL,2023,3
 114,M,programming,NL,2023,3
@@ -91390,6 +94328,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Pawn,programming,NL,2023,3
 103,XS,programming,NL,2023,3
 102,Rebol,programming,NL,2023,3
+181,Markdown,prose,NL,2023,3
+9340,HTML,markup,NO,2023,3
+7878,CSS,markup,NO,2023,3
+1986,SCSS,markup,NO,2023,3
+1419,Jupyter Notebook,markup,NO,2023,3
+556,TeX,markup,NO,2023,3
+468,Vue,markup,NO,2023,3
+460,Roff,markup,NO,2023,3
+333,Svelte,markup,NO,2023,3
+330,Jinja,markup,NO,2023,3
+303,Less,markup,NO,2023,3
+246,Handlebars,markup,NO,2023,3
+168,EJS,markup,NO,2023,3
+164,Mustache,markup,NO,2023,3
+132,Astro,markup,NO,2023,3
+119,Rich Text Format,markup,NO,2023,3
 8145,JavaScript,programming,NO,2023,3
 5994,Python,programming,NO,2023,3
 5327,Shell,programming,NO,2023,3
@@ -91447,6 +94401,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,Cuda,programming,NO,2023,3
 104,Scheme,programming,NO,2023,3
 101,TSQL,programming,NO,2023,3
+13598,HTML,markup,NP,2023,3
+12125,CSS,markup,NP,2023,3
+2177,SCSS,markup,NP,2023,3
+1380,Jupyter Notebook,markup,NP,2023,3
+695,Blade,markup,NP,2023,3
+411,EJS,markup,NP,2023,3
+345,Vue,markup,NP,2023,3
+286,Less,markup,NP,2023,3
+148,Handlebars,markup,NP,2023,3
+145,Roff,markup,NP,2023,3
+107,TeX,markup,NP,2023,3
 11588,JavaScript,programming,NP,2023,3
 4508,Python,programming,NP,2023,3
 2691,PHP,programming,NP,2023,3
@@ -91473,8 +94438,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 193,Rust,programming,NP,2023,3
 125,Objective-C++,programming,NP,2023,3
 124,Solidity,programming,NP,2023,3
-108,XSLT,programming,NP,2023,3
 108,Assembly,programming,NP,2023,3
+108,XSLT,programming,NP,2023,3
+7303,HTML,markup,NZ,2023,3
+6143,CSS,markup,NZ,2023,3
+1518,SCSS,markup,NZ,2023,3
+770,Jupyter Notebook,markup,NZ,2023,3
+362,Vue,markup,NZ,2023,3
+311,TeX,markup,NZ,2023,3
+272,Roff,markup,NZ,2023,3
+240,Svelte,markup,NZ,2023,3
+198,Handlebars,markup,NZ,2023,3
+172,EJS,markup,NZ,2023,3
+168,Less,markup,NZ,2023,3
+164,Jinja,markup,NZ,2023,3
+113,Mustache,markup,NZ,2023,3
+111,Astro,markup,NZ,2023,3
 6676,JavaScript,programming,NZ,2023,3
 4150,Python,programming,NZ,2023,3
 3240,Shell,programming,NZ,2023,3
@@ -91512,8 +94491,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,Objective-C++,programming,NZ,2023,3
 151,MATLAB,programming,NZ,2023,3
 147,Hack,programming,NZ,2023,3
-142,M4,programming,NZ,2023,3
 142,Dart,programming,NZ,2023,3
+142,M4,programming,NZ,2023,3
 140,Scheme,programming,NZ,2023,3
 139,PLpgSQL,programming,NZ,2023,3
 133,Groovy,programming,NZ,2023,3
@@ -91521,11 +94500,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,GDScript,programming,NZ,2023,3
 119,Emacs Lisp,programming,NZ,2023,3
 111,Cython,programming,NZ,2023,3
+676,HTML,markup,OM,2023,3
+514,CSS,markup,OM,2023,3
+124,Jupyter Notebook,markup,OM,2023,3
 471,JavaScript,programming,OM,2023,3
 279,Python,programming,OM,2023,3
 137,TypeScript,programming,OM,2023,3
 117,Java,programming,OM,2023,3
 106,Shell,programming,OM,2023,3
+1058,HTML,markup,PA,2023,3
+867,CSS,markup,PA,2023,3
+161,SCSS,markup,PA,2023,3
 813,JavaScript,programming,PA,2023,3
 410,Python,programming,PA,2023,3
 245,Java,programming,PA,2023,3
@@ -91534,6 +94519,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 189,PHP,programming,PA,2023,3
 133,Dockerfile,programming,PA,2023,3
 105,C++,programming,PA,2023,3
+14778,HTML,markup,PE,2023,3
+12929,CSS,markup,PE,2023,3
+2814,SCSS,markup,PE,2023,3
+1590,Jupyter Notebook,markup,PE,2023,3
+895,Blade,markup,PE,2023,3
+835,Vue,markup,PE,2023,3
+403,Less,markup,PE,2023,3
+237,EJS,markup,PE,2023,3
+233,TeX,markup,PE,2023,3
+207,Astro,markup,PE,2023,3
+193,Handlebars,markup,PE,2023,3
+128,Roff,markup,PE,2023,3
 12909,JavaScript,programming,PE,2023,3
 5178,Java,programming,PE,2023,3
 4569,Python,programming,PE,2023,3
@@ -91574,6 +94571,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 115,HCL,programming,PE,2023,3
 114,PLpgSQL,programming,PE,2023,3
 103,Perl,programming,PE,2023,3
+28239,HTML,markup,PH,2023,3
+24722,CSS,markup,PH,2023,3
+4829,SCSS,markup,PH,2023,3
+2456,Blade,markup,PH,2023,3
+1790,Jupyter Notebook,markup,PH,2023,3
+1749,Vue,markup,PH,2023,3
+580,Less,markup,PH,2023,3
+499,EJS,markup,PH,2023,3
+402,Handlebars,markup,PH,2023,3
+324,Svelte,markup,PH,2023,3
+313,Roff,markup,PH,2023,3
+164,TeX,markup,PH,2023,3
+143,Astro,markup,PH,2023,3
+138,Pug,markup,PH,2023,3
+112,Sass,markup,PH,2023,3
 22875,JavaScript,programming,PH,2023,3
 6361,Python,programming,PH,2023,3
 6336,PHP,programming,PH,2023,3
@@ -91618,6 +94630,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,XSLT,programming,PH,2023,3
 120,Groovy,programming,PH,2023,3
 118,M4,programming,PH,2023,3
+39796,HTML,markup,PK,2023,3
+34242,CSS,markup,PK,2023,3
+6266,SCSS,markup,PK,2023,3
+5070,Jupyter Notebook,markup,PK,2023,3
+2215,Blade,markup,PK,2023,3
+1171,Vue,markup,PK,2023,3
+882,Less,markup,PK,2023,3
+803,EJS,markup,PK,2023,3
+467,Handlebars,markup,PK,2023,3
+366,Pug,markup,PK,2023,3
+341,Roff,markup,PK,2023,3
+254,TeX,markup,PK,2023,3
+200,Jinja,markup,PK,2023,3
+166,Sass,markup,PK,2023,3
+159,Mustache,markup,PK,2023,3
+144,Rich Text Format,markup,PK,2023,3
+128,Svelte,markup,PK,2023,3
+127,Liquid,markup,PK,2023,3
 36311,JavaScript,programming,PK,2023,3
 11444,Python,programming,PK,2023,3
 9548,TypeScript,programming,PK,2023,3
@@ -91648,8 +94678,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 355,ASP.NET,programming,PK,2023,3
 329,Rust,programming,PK,2023,3
 312,HCL,programming,PK,2023,3
-301,Smarty,programming,PK,2023,3
 301,ShaderLab,programming,PK,2023,3
+301,Smarty,programming,PK,2023,3
 282,HLSL,programming,PK,2023,3
 256,Lua,programming,PK,2023,3
 242,Perl,programming,PK,2023,3
@@ -91657,8 +94687,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 230,Gherkin,programming,PK,2023,3
 220,XSLT,programming,PK,2023,3
 182,R,programming,PK,2023,3
-168,PLpgSQL,programming,PK,2023,3
 168,MATLAB,programming,PK,2023,3
+168,PLpgSQL,programming,PK,2023,3
 164,Cython,programming,PK,2023,3
 156,GLSL,programming,PK,2023,3
 143,CoffeeScript,programming,PK,2023,3
@@ -91667,6 +94697,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,Fortran,programming,PK,2023,3
 112,Mako,programming,PK,2023,3
 109,M4,programming,PK,2023,3
+33941,HTML,markup,PL,2023,3
+28053,CSS,markup,PL,2023,3
+8898,SCSS,markup,PL,2023,3
+3301,Jupyter Notebook,markup,PL,2023,3
+1927,Vue,markup,PL,2023,3
+1115,Roff,markup,PL,2023,3
+736,TeX,markup,PL,2023,3
+726,Blade,markup,PL,2023,3
+717,Less,markup,PL,2023,3
+715,Jinja,markup,PL,2023,3
+699,Handlebars,markup,PL,2023,3
+611,EJS,markup,PL,2023,3
+596,Twig,markup,PL,2023,3
+497,Svelte,markup,PL,2023,3
+470,Mustache,markup,PL,2023,3
+391,Sass,markup,PL,2023,3
+332,Astro,markup,PL,2023,3
+269,Rich Text Format,markup,PL,2023,3
+249,Pug,markup,PL,2023,3
 31234,JavaScript,programming,PL,2023,3
 18111,Python,programming,PL,2023,3
 14525,Shell,programming,PL,2023,3
@@ -91701,8 +94750,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 789,Vim Script,programming,PL,2023,3
 734,Procfile,programming,PL,2023,3
 726,Groovy,programming,PL,2023,3
-658,Hack,programming,PL,2023,3
 658,R,programming,PL,2023,3
+658,Hack,programming,PL,2023,3
 649,Gherkin,programming,PL,2023,3
 570,XSLT,programming,PL,2023,3
 551,M4,programming,PL,2023,3
@@ -91716,8 +94765,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 360,Haskell,programming,PL,2023,3
 337,Tcl,programming,PL,2023,3
 330,Yacc,programming,PL,2023,3
-326,MATLAB,programming,PL,2023,3
 326,Mako,programming,PL,2023,3
+326,MATLAB,programming,PL,2023,3
 322,GDB,programming,PL,2023,3
 300,Lex,programming,PL,2023,3
 294,PLSQL,programming,PL,2023,3
@@ -91730,12 +94779,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 243,NSIS,programming,PL,2023,3
 242,SmPL,programming,PL,2023,3
 236,GDScript,programming,PL,2023,3
-230,Elixir,programming,PL,2023,3
 230,Verilog,programming,PL,2023,3
+230,Elixir,programming,PL,2023,3
 226,Pascal,programming,PL,2023,3
 217,Scheme,programming,PL,2023,3
-215,ASP.NET,programming,PL,2023,3
 215,SourcePawn,programming,PL,2023,3
+215,ASP.NET,programming,PL,2023,3
 213,NASL,programming,PL,2023,3
 211,GAP,programming,PL,2023,3
 202,Mathematica,programming,PL,2023,3
@@ -91743,8 +94792,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 188,Raku,programming,PL,2023,3
 183,ANTLR,programming,PL,2023,3
 181,Forth,programming,PL,2023,3
-167,VBScript,programming,PL,2023,3
 167,Fortran,programming,PL,2023,3
+167,VBScript,programming,PL,2023,3
 160,FreeMarker,programming,PL,2023,3
 158,RobotFramework,programming,PL,2023,3
 157,Julia,programming,PL,2023,3
@@ -91756,17 +94805,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,AMPL,programming,PL,2023,3
 132,QML,programming,PL,2023,3
 130,Jsonnet,programming,PL,2023,3
-122,Zig,programming,PL,2023,3
 122,Prolog,programming,PL,2023,3
+122,Zig,programming,PL,2023,3
 121,F#,programming,PL,2023,3
-119,Common Lisp,programming,PL,2023,3
 119,SWIG,programming,PL,2023,3
+119,Common Lisp,programming,PL,2023,3
 113,AutoHotkey,programming,PL,2023,3
 112,CoffeeScript,programming,PL,2023,3
 110,Gnuplot,programming,PL,2023,3
 107,VHDL,programming,PL,2023,3
 105,AppleScript,programming,PL,2023,3
 102,XS,programming,PL,2023,3
+561,HTML,markup,PR,2023,3
+501,CSS,markup,PR,2023,3
 517,JavaScript,programming,PR,2023,3
 346,Python,programming,PR,2023,3
 327,C,programming,PR,2023,3
@@ -91774,6 +94825,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,TypeScript,programming,PR,2023,3
 123,Dockerfile,programming,PR,2023,3
 104,C++,programming,PR,2023,3
+2954,HTML,markup,PS,2023,3
+2455,CSS,markup,PS,2023,3
+570,Blade,markup,PS,2023,3
+547,SCSS,markup,PS,2023,3
+158,Vue,markup,PS,2023,3
+141,Jupyter Notebook,markup,PS,2023,3
+120,Less,markup,PS,2023,3
 2379,JavaScript,programming,PS,2023,3
 770,PHP,programming,PS,2023,3
 666,Java,programming,PS,2023,3
@@ -91792,6 +94850,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 195,C#,programming,PS,2023,3
 137,Hack,programming,PS,2023,3
 123,Makefile,programming,PS,2023,3
+10671,HTML,markup,PT,2023,3
+9129,CSS,markup,PT,2023,3
+2375,SCSS,markup,PT,2023,3
+1505,Jupyter Notebook,markup,PT,2023,3
+590,Vue,markup,PT,2023,3
+499,Roff,markup,PT,2023,3
+439,TeX,markup,PT,2023,3
+309,Handlebars,markup,PT,2023,3
+305,Blade,markup,PT,2023,3
+268,Less,markup,PT,2023,3
+225,Svelte,markup,PT,2023,3
+207,Jinja,markup,PT,2023,3
+193,EJS,markup,PT,2023,3
+166,Mustache,markup,PT,2023,3
+157,Pug,markup,PT,2023,3
+129,Sass,markup,PT,2023,3
+104,Astro,markup,PT,2023,3
 10289,JavaScript,programming,PT,2023,3
 5846,Python,programming,PT,2023,3
 5284,Shell,programming,PT,2023,3
@@ -91817,8 +94892,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 481,Assembly,programming,PT,2023,3
 405,HCL,programming,PT,2023,3
 353,Dart,programming,PT,2023,3
-336,Smarty,programming,PT,2023,3
 336,Solidity,programming,PT,2023,3
+336,Smarty,programming,PT,2023,3
 320,R,programming,PT,2023,3
 307,Procfile,programming,PT,2023,3
 283,Hack,programming,PT,2023,3
@@ -91826,8 +94901,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 276,Vim Script,programming,PT,2023,3
 267,ShaderLab,programming,PT,2023,3
 264,HLSL,programming,PT,2023,3
-254,Objective-C++,programming,PT,2023,3
 254,GLSL,programming,PT,2023,3
+254,Objective-C++,programming,PT,2023,3
 228,PLpgSQL,programming,PT,2023,3
 224,MATLAB,programming,PT,2023,3
 203,XSLT,programming,PT,2023,3
@@ -91846,6 +94921,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,ANTLR,programming,PT,2023,3
 105,Scheme,programming,PT,2023,3
 104,Lex,programming,PT,2023,3
+1401,HTML,markup,PY,2023,3
+1190,CSS,markup,PY,2023,3
+217,SCSS,markup,PY,2023,3
 1239,JavaScript,programming,PY,2023,3
 560,Python,programming,PY,2023,3
 355,TypeScript,programming,PY,2023,3
@@ -91856,14 +94934,37 @@ num_pushers,language,language_type,iso2_code,year,quarter
 151,C,programming,PY,2023,3
 133,C++,programming,PY,2023,3
 104,Makefile,programming,PY,2023,3
+657,HTML,markup,QA,2023,3
+528,CSS,markup,QA,2023,3
+138,SCSS,markup,QA,2023,3
+118,Jupyter Notebook,markup,QA,2023,3
 536,JavaScript,programming,QA,2023,3
 368,Python,programming,QA,2023,3
 234,Shell,programming,QA,2023,3
 161,TypeScript,programming,QA,2023,3
 139,Dockerfile,programming,QA,2023,3
 109,C,programming,QA,2023,3
+286,CSS,markup,RE,2023,3
+267,HTML,markup,RE,2023,3
 271,JavaScript,programming,RE,2023,3
 113,Python,programming,RE,2023,3
+10655,HTML,markup,RO,2023,3
+9143,CSS,markup,RO,2023,3
+2224,SCSS,markup,RO,2023,3
+626,Jupyter Notebook,markup,RO,2023,3
+529,Vue,markup,RO,2023,3
+340,Roff,markup,RO,2023,3
+308,Blade,markup,RO,2023,3
+257,EJS,markup,RO,2023,3
+230,Less,markup,RO,2023,3
+189,Handlebars,markup,RO,2023,3
+169,TeX,markup,RO,2023,3
+160,Jinja,markup,RO,2023,3
+133,Twig,markup,RO,2023,3
+128,Svelte,markup,RO,2023,3
+121,Mustache,markup,RO,2023,3
+114,Pug,markup,RO,2023,3
+103,Rich Text Format,markup,RO,2023,3
 9659,JavaScript,programming,RO,2023,3
 4725,Python,programming,RO,2023,3
 3696,TypeScript,programming,RO,2023,3
@@ -91892,8 +94993,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 275,Gherkin,programming,RO,2023,3
 272,HCL,programming,RO,2023,3
 233,Hack,programming,RO,2023,3
-220,Procfile,programming,RO,2023,3
 220,XSLT,programming,RO,2023,3
+220,Procfile,programming,RO,2023,3
 216,HLSL,programming,RO,2023,3
 202,ShaderLab,programming,RO,2023,3
 200,GLSL,programming,RO,2023,3
@@ -91914,11 +95015,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,sed,programming,RO,2023,3
 111,Scala,programming,RO,2023,3
 108,Starlark,programming,RO,2023,3
-107,Haskell,programming,RO,2023,3
 107,Clojure,programming,RO,2023,3
+107,Haskell,programming,RO,2023,3
 105,ASP.NET,programming,RO,2023,3
 102,Raku,programming,RO,2023,3
 101,Verilog,programming,RO,2023,3
+6335,HTML,markup,RS,2023,3
+5504,CSS,markup,RS,2023,3
+1577,SCSS,markup,RS,2023,3
+596,Jupyter Notebook,markup,RS,2023,3
+427,Vue,markup,RS,2023,3
+384,Blade,markup,RS,2023,3
+142,Less,markup,RS,2023,3
+139,Roff,markup,RS,2023,3
+131,TeX,markup,RS,2023,3
+108,EJS,markup,RS,2023,3
 6130,JavaScript,programming,RS,2023,3
 2586,TypeScript,programming,RS,2023,3
 2454,Python,programming,RS,2023,3
@@ -91954,6 +95065,32 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,Gherkin,programming,RS,2023,3
 105,Vim Script,programming,RS,2023,3
 105,Procfile,programming,RS,2023,3
+79325,HTML,markup,RU,2023,3
+61875,CSS,markup,RU,2023,3
+17941,SCSS,markup,RU,2023,3
+10375,Jupyter Notebook,markup,RU,2023,3
+5846,Vue,markup,RU,2023,3
+2157,Blade,markup,RU,2023,3
+2133,Roff,markup,RU,2023,3
+1944,Less,markup,RU,2023,3
+1656,TeX,markup,RU,2023,3
+1328,Jinja,markup,RU,2023,3
+1294,Sass,markup,RU,2023,3
+955,Handlebars,markup,RU,2023,3
+911,Pug,markup,RU,2023,3
+682,EJS,markup,RU,2023,3
+625,Svelte,markup,RU,2023,3
+592,Rich Text Format,markup,RU,2023,3
+516,Twig,markup,RU,2023,3
+418,Mustache,markup,RU,2023,3
+340,Stylus,markup,RU,2023,3
+173,Astro,markup,RU,2023,3
+170,PostScript,markup,RU,2023,3
+125,Slim,markup,RU,2023,3
+117,Vim Snippet,markup,RU,2023,3
+115,kvlang,markup,RU,2023,3
+114,Liquid,markup,RU,2023,3
+102,Nunjucks,markup,RU,2023,3
 63690,JavaScript,programming,RU,2023,3
 55734,Python,programming,RU,2023,3
 26314,Java,programming,RU,2023,3
@@ -91997,8 +95134,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 831,Pascal,programming,RU,2023,3
 819,Smalltalk,programming,RU,2023,3
 783,Gherkin,programming,RU,2023,3
-727,Solidity,programming,RU,2023,3
 727,MATLAB,programming,RU,2023,3
+727,Solidity,programming,RU,2023,3
 688,Yacc,programming,RU,2023,3
 680,Cython,programming,RU,2023,3
 639,Groovy,programming,RU,2023,3
@@ -92016,8 +95153,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 430,GDB,programming,RU,2023,3
 425,Mathematica,programming,RU,2023,3
 424,Tcl,programming,RU,2023,3
-395,Raku,programming,RU,2023,3
 395,Haskell,programming,RU,2023,3
+395,Raku,programming,RU,2023,3
 386,sed,programming,RU,2023,3
 383,Clojure,programming,RU,2023,3
 382,Fortran,programming,RU,2023,3
@@ -92055,8 +95192,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 168,PureBasic,programming,RU,2023,3
 166,UnrealScript,programming,RU,2023,3
 155,DTrace,programming,RU,2023,3
-153,Jsonnet,programming,RU,2023,3
 153,AutoHotkey,programming,RU,2023,3
+153,Jsonnet,programming,RU,2023,3
 151,Visual Basic .NET,programming,RU,2023,3
 150,LLVM,programming,RU,2023,3
 149,AppleScript,programming,RU,2023,3
@@ -92069,6 +95206,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,VHDL,programming,RU,2023,3
 113,Metal,programming,RU,2023,3
 112,ASL,programming,RU,2023,3
+2433,HTML,markup,RW,2023,3
+2216,CSS,markup,RW,2023,3
+393,SCSS,markup,RW,2023,3
+128,Jupyter Notebook,markup,RW,2023,3
 2058,JavaScript,programming,RW,2023,3
 1049,Shell,programming,RW,2023,3
 813,Python,programming,RW,2023,3
@@ -92084,6 +95225,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,Puppet,programming,RW,2023,3
 110,Objective-C,programming,RW,2023,3
 103,Procfile,programming,RW,2023,3
+4941,HTML,markup,SA,2023,3
+3831,CSS,markup,SA,2023,3
+958,Jupyter Notebook,markup,SA,2023,3
+732,SCSS,markup,SA,2023,3
+231,Blade,markup,SA,2023,3
+151,Vue,markup,SA,2023,3
 3607,JavaScript,programming,SA,2023,3
 2280,Python,programming,SA,2023,3
 1356,Shell,programming,SA,2023,3
@@ -92097,8 +95244,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 652,Swift,programming,SA,2023,3
 594,Objective-C,programming,SA,2023,3
 559,Dart,programming,SA,2023,3
-509,Ruby,programming,SA,2023,3
 509,CMake,programming,SA,2023,3
+509,Ruby,programming,SA,2023,3
 448,C#,programming,SA,2023,3
 389,Makefile,programming,SA,2023,3
 268,Batchfile,programming,SA,2023,3
@@ -92108,11 +95255,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,Go,programming,SA,2023,3
 139,Hack,programming,SA,2023,3
 129,Lua,programming,SA,2023,3
+133,HTML,markup,SC,2023,3
+107,CSS,markup,SC,2023,3
 132,JavaScript,programming,SC,2023,3
+313,HTML,markup,SD,2023,3
+249,CSS,markup,SD,2023,3
 447,Shell,programming,SD,2023,3
 353,C,programming,SD,2023,3
 246,JavaScript,programming,SD,2023,3
 111,Python,programming,SD,2023,3
+15631,HTML,markup,SE,2023,3
+13361,CSS,markup,SE,2023,3
+3185,SCSS,markup,SE,2023,3
+1883,Jupyter Notebook,markup,SE,2023,3
+896,TeX,markup,SE,2023,3
+857,Roff,markup,SE,2023,3
+834,Vue,markup,SE,2023,3
+445,Svelte,markup,SE,2023,3
+399,Jinja,markup,SE,2023,3
+355,Handlebars,markup,SE,2023,3
+300,Less,markup,SE,2023,3
+268,Mustache,markup,SE,2023,3
+230,EJS,markup,SE,2023,3
+170,Blade,markup,SE,2023,3
+157,Astro,markup,SE,2023,3
+153,Rich Text Format,markup,SE,2023,3
+125,Sass,markup,SE,2023,3
+121,Pug,markup,SE,2023,3
 14158,JavaScript,programming,SE,2023,3
 9783,Python,programming,SE,2023,3
 8735,Shell,programming,SE,2023,3
@@ -92181,9 +95350,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 145,Common Lisp,programming,SE,2023,3
 144,Cython,programming,SE,2023,3
 143,Pascal,programming,SE,2023,3
-139,SmPL,programming,SE,2023,3
 139,PLSQL,programming,SE,2023,3
 139,Raku,programming,SE,2023,3
+139,SmPL,programming,SE,2023,3
 130,ASP.NET,programming,SE,2023,3
 125,GDScript,programming,SE,2023,3
 123,AutoHotkey,programming,SE,2023,3
@@ -92191,11 +95360,32 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Prolog,programming,SE,2023,3
 117,Mako,programming,SE,2023,3
 116,D,programming,SE,2023,3
-108,Inno Setup,programming,SE,2023,3
 108,ANTLR,programming,SE,2023,3
+108,Inno Setup,programming,SE,2023,3
 105,Gnuplot,programming,SE,2023,3
 103,Zig,programming,SE,2023,3
 102,Verilog,programming,SE,2023,3
+26268,HTML,markup,SG,2023,3
+20409,CSS,markup,SG,2023,3
+7146,SCSS,markup,SG,2023,3
+4839,Jupyter Notebook,markup,SG,2023,3
+3072,Vue,markup,SG,2023,3
+1571,Less,markup,SG,2023,3
+1125,Roff,markup,SG,2023,3
+999,TeX,markup,SG,2023,3
+810,EJS,markup,SG,2023,3
+532,Handlebars,markup,SG,2023,3
+480,Jinja,markup,SG,2023,3
+458,Mustache,markup,SG,2023,3
+353,Pug,markup,SG,2023,3
+310,Stylus,markup,SG,2023,3
+302,Svelte,markup,SG,2023,3
+253,Rich Text Format,markup,SG,2023,3
+225,Blade,markup,SG,2023,3
+186,Astro,markup,SG,2023,3
+160,Sass,markup,SG,2023,3
+137,Vim Snippet,markup,SG,2023,3
+101,Nunjucks,markup,SG,2023,3
 24528,JavaScript,programming,SG,2023,3
 18478,Python,programming,SG,2023,3
 16006,Shell,programming,SG,2023,3
@@ -92277,9 +95467,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,Haskell,programming,SG,2023,3
 147,PLSQL,programming,SG,2023,3
 136,Scheme,programming,SG,2023,3
+133,CoffeeScript,programming,SG,2023,3
 133,Pawn,programming,SG,2023,3
 133,Jsonnet,programming,SG,2023,3
-133,CoffeeScript,programming,SG,2023,3
 131,AppleScript,programming,SG,2023,3
 128,AIDL,programming,SG,2023,3
 127,VBScript,programming,SG,2023,3
@@ -92293,6 +95483,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,Julia,programming,SG,2023,3
 101,F#,programming,SG,2023,3
 101,Inno Setup,programming,SG,2023,3
+1705,HTML,markup,SI,2023,3
+1379,CSS,markup,SI,2023,3
+384,SCSS,markup,SI,2023,3
+279,Jupyter Notebook,markup,SI,2023,3
+156,Vue,markup,SI,2023,3
+126,TeX,markup,SI,2023,3
 1599,JavaScript,programming,SI,2023,3
 1286,Python,programming,SI,2023,3
 997,Shell,programming,SI,2023,3
@@ -92315,6 +95511,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,Assembly,programming,SI,2023,3
 111,Swift,programming,SI,2023,3
 104,Lua,programming,SI,2023,3
+2817,HTML,markup,SK,2023,3
+2341,CSS,markup,SK,2023,3
+671,SCSS,markup,SK,2023,3
+270,Vue,markup,SK,2023,3
+213,Jupyter Notebook,markup,SK,2023,3
+141,Roff,markup,SK,2023,3
+102,Blade,markup,SK,2023,3
 2655,JavaScript,programming,SK,2023,3
 1595,Python,programming,SK,2023,3
 1465,Shell,programming,SK,2023,3
@@ -92340,7 +95543,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,Swift,programming,SK,2023,3
 116,Smarty,programming,SK,2023,3
 101,Emacs Lisp,programming,SK,2023,3
+138,HTML,markup,SL,2023,3
+123,CSS,markup,SL,2023,3
 115,JavaScript,programming,SL,2023,3
+1580,HTML,markup,SN,2023,3
+1388,CSS,markup,SN,2023,3
+345,SCSS,markup,SN,2023,3
+218,Blade,markup,SN,2023,3
+154,Jupyter Notebook,markup,SN,2023,3
 1248,JavaScript,programming,SN,2023,3
 550,PHP,programming,SN,2023,3
 538,Python,programming,SN,2023,3
@@ -92353,10 +95563,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 129,C++,programming,SN,2023,3
 118,Kotlin,programming,SN,2023,3
 116,Objective-C,programming,SN,2023,3
-115,Swift,programming,SN,2023,3
 115,CMake,programming,SN,2023,3
+115,Swift,programming,SN,2023,3
 114,Dart,programming,SN,2023,3
+627,HTML,markup,SO,2023,3
+521,CSS,markup,SO,2023,3
 466,JavaScript,programming,SO,2023,3
+2766,HTML,markup,SV,2023,3
+2319,CSS,markup,SV,2023,3
+438,SCSS,markup,SV,2023,3
+265,Blade,markup,SV,2023,3
+150,Vue,markup,SV,2023,3
 2313,JavaScript,programming,SV,2023,3
 785,Java,programming,SV,2023,3
 654,C#,programming,SV,2023,3
@@ -92375,6 +95592,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,Dart,programming,SV,2023,3
 150,TSQL,programming,SV,2023,3
 104,Ruby,programming,SV,2023,3
+1122,HTML,markup,SY,2023,3
+962,CSS,markup,SY,2023,3
+287,Blade,markup,SY,2023,3
+246,SCSS,markup,SY,2023,3
 980,JavaScript,programming,SY,2023,3
 352,PHP,programming,SY,2023,3
 239,Python,programming,SY,2023,3
@@ -92387,6 +95608,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,TypeScript,programming,SY,2023,3
 141,CMake,programming,SY,2023,3
 109,C#,programming,SY,2023,3
+554,HTML,markup,TG,2023,3
+482,CSS,markup,TG,2023,3
+169,SCSS,markup,TG,2023,3
+107,Blade,markup,TG,2023,3
 494,JavaScript,programming,TG,2023,3
 223,Python,programming,TG,2023,3
 184,PHP,programming,TG,2023,3
@@ -92394,6 +95619,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,Shell,programming,TG,2023,3
 111,C,programming,TG,2023,3
 101,Kotlin,programming,TG,2023,3
+15524,HTML,markup,TH,2023,3
+12589,CSS,markup,TH,2023,3
+2721,SCSS,markup,TH,2023,3
+1859,Jupyter Notebook,markup,TH,2023,3
+1442,Vue,markup,TH,2023,3
+676,Blade,markup,TH,2023,3
+383,EJS,markup,TH,2023,3
+359,Less,markup,TH,2023,3
+291,Roff,markup,TH,2023,3
+277,Svelte,markup,TH,2023,3
+223,Handlebars,markup,TH,2023,3
+202,TeX,markup,TH,2023,3
+189,Pug,markup,TH,2023,3
+146,Astro,markup,TH,2023,3
+104,Jinja,markup,TH,2023,3
 14045,JavaScript,programming,TH,2023,3
 6548,Python,programming,TH,2023,3
 5332,TypeScript,programming,TH,2023,3
@@ -92438,11 +95678,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,Starlark,programming,TH,2023,3
 106,Groovy,programming,TH,2023,3
 104,ASP.NET,programming,TH,2023,3
+481,HTML,markup,TJ,2023,3
+412,CSS,markup,TJ,2023,3
+104,SCSS,markup,TJ,2023,3
 394,JavaScript,programming,TJ,2023,3
 165,Python,programming,TJ,2023,3
 114,C#,programming,TJ,2023,3
 107,TypeScript,programming,TJ,2023,3
+177,HTML,markup,TM,2023,3
+164,CSS,markup,TM,2023,3
 174,JavaScript,programming,TM,2023,3
+7274,HTML,markup,TN,2023,3
+6471,CSS,markup,TN,2023,3
+1691,SCSS,markup,TN,2023,3
+710,Jupyter Notebook,markup,TN,2023,3
+346,Twig,markup,TN,2023,3
+239,Blade,markup,TN,2023,3
+232,Vue,markup,TN,2023,3
+188,Less,markup,TN,2023,3
+110,EJS,markup,TN,2023,3
 6401,JavaScript,programming,TN,2023,3
 2481,TypeScript,programming,TN,2023,3
 2145,Python,programming,TN,2023,3
@@ -92466,6 +95720,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Assembly,programming,TN,2023,3
 134,Go,programming,TN,2023,3
 113,Procfile,programming,TN,2023,3
+30538,HTML,markup,TR,2023,3
+25444,CSS,markup,TR,2023,3
+6226,SCSS,markup,TR,2023,3
+4039,Jupyter Notebook,markup,TR,2023,3
+1462,Vue,markup,TR,2023,3
+1010,Less,markup,TR,2023,3
+926,Blade,markup,TR,2023,3
+745,EJS,markup,TR,2023,3
+532,Roff,markup,TR,2023,3
+436,TeX,markup,TR,2023,3
+369,Handlebars,markup,TR,2023,3
+280,Pug,markup,TR,2023,3
+246,Svelte,markup,TR,2023,3
+203,Sass,markup,TR,2023,3
+194,Jinja,markup,TR,2023,3
+192,Rich Text Format,markup,TR,2023,3
+161,Mustache,markup,TR,2023,3
+134,Astro,markup,TR,2023,3
+117,Twig,markup,TR,2023,3
 27295,JavaScript,programming,TR,2023,3
 13546,Python,programming,TR,2023,3
 10989,C#,programming,TR,2023,3
@@ -92516,8 +95789,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 183,QMake,programming,TR,2023,3
 182,Cuda,programming,TR,2023,3
 172,Yacc,programming,TR,2023,3
-163,Groovy,programming,TR,2023,3
 163,Tcl,programming,TR,2023,3
+163,Groovy,programming,TR,2023,3
 151,Emacs Lisp,programming,TR,2023,3
 143,Lex,programming,TR,2023,3
 142,Cython,programming,TR,2023,3
@@ -92527,13 +95800,34 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Mako,programming,TR,2023,3
 110,sed,programming,TR,2023,3
 108,Fortran,programming,TR,2023,3
-106,Pascal,programming,TR,2023,3
 106,GDB,programming,TR,2023,3
+106,Pascal,programming,TR,2023,3
 102,Clojure,programming,TR,2023,3
 101,Meson,programming,TR,2023,3
 101,CoffeeScript,programming,TR,2023,3
+281,HTML,markup,TT,2023,3
+241,CSS,markup,TT,2023,3
 281,JavaScript,programming,TT,2023,3
 132,Python,programming,TT,2023,3
+24361,HTML,markup,TW,2023,3
+18394,CSS,markup,TW,2023,3
+6296,SCSS,markup,TW,2023,3
+4336,Jupyter Notebook,markup,TW,2023,3
+3556,Vue,markup,TW,2023,3
+1031,Less,markup,TW,2023,3
+956,EJS,markup,TW,2023,3
+869,Roff,markup,TW,2023,3
+868,TeX,markup,TW,2023,3
+570,Handlebars,markup,TW,2023,3
+529,Blade,markup,TW,2023,3
+362,Pug,markup,TW,2023,3
+311,Jinja,markup,TW,2023,3
+310,Sass,markup,TW,2023,3
+236,Mustache,markup,TW,2023,3
+235,Stylus,markup,TW,2023,3
+230,Svelte,markup,TW,2023,3
+181,Rich Text Format,markup,TW,2023,3
+141,Astro,markup,TW,2023,3
 21621,JavaScript,programming,TW,2023,3
 16225,Python,programming,TW,2023,3
 10752,Shell,programming,TW,2023,3
@@ -92600,8 +95894,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 174,Mako,programming,TW,2023,3
 170,SmPL,programming,TW,2023,3
 161,NSIS,programming,TW,2023,3
-157,ANTLR,programming,TW,2023,3
 157,Forth,programming,TW,2023,3
+157,ANTLR,programming,TW,2023,3
 151,SourcePawn,programming,TW,2023,3
 147,XS,programming,TW,2023,3
 139,FreeMarker,programming,TW,2023,3
@@ -92611,18 +95905,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,Pawn,programming,TW,2023,3
 125,Haskell,programming,TW,2023,3
 122,Processing,programming,TW,2023,3
-121,PLSQL,programming,TW,2023,3
 121,GAP,programming,TW,2023,3
+121,PLSQL,programming,TW,2023,3
 120,SystemVerilog,programming,TW,2023,3
 117,SWIG,programming,TW,2023,3
 115,CoffeeScript,programming,TW,2023,3
 109,LLVM,programming,TW,2023,3
 104,QML,programming,TW,2023,3
-102,Thrift,programming,TW,2023,3
 102,AIDL,programming,TW,2023,3
 102,Gnuplot,programming,TW,2023,3
-101,Scheme,programming,TW,2023,3
+102,Thrift,programming,TW,2023,3
 101,PureBasic,programming,TW,2023,3
+101,Scheme,programming,TW,2023,3
+1416,HTML,markup,TZ,2023,3
+1229,CSS,markup,TZ,2023,3
+335,SCSS,markup,TZ,2023,3
+230,Blade,markup,TZ,2023,3
 1241,JavaScript,programming,TZ,2023,3
 508,PHP,programming,TZ,2023,3
 471,Python,programming,TZ,2023,3
@@ -92636,9 +95934,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 191,Dockerfile,programming,TZ,2023,3
 187,Dart,programming,TZ,2023,3
 180,Swift,programming,TZ,2023,3
-158,Hack,programming,TZ,2023,3
 158,CMake,programming,TZ,2023,3
+158,Hack,programming,TZ,2023,3
 131,Ruby,programming,TZ,2023,3
+36695,HTML,markup,UA,2023,3
+30261,CSS,markup,UA,2023,3
+11867,SCSS,markup,UA,2023,3
+1873,Vue,markup,UA,2023,3
+1305,Jupyter Notebook,markup,UA,2023,3
+982,Blade,markup,UA,2023,3
+820,Handlebars,markup,UA,2023,3
+760,Less,markup,UA,2023,3
+593,Sass,markup,UA,2023,3
+590,Roff,markup,UA,2023,3
+396,Pug,markup,UA,2023,3
+391,EJS,markup,UA,2023,3
+303,Jinja,markup,UA,2023,3
+298,Twig,markup,UA,2023,3
+225,TeX,markup,UA,2023,3
+211,Svelte,markup,UA,2023,3
+195,Mustache,markup,UA,2023,3
+160,Rich Text Format,markup,UA,2023,3
+143,Liquid,markup,UA,2023,3
+105,Astro,markup,UA,2023,3
 33057,JavaScript,programming,UA,2023,3
 11957,Python,programming,UA,2023,3
 11222,TypeScript,programming,UA,2023,3
@@ -92666,8 +95984,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 666,Hack,programming,UA,2023,3
 621,Objective-C++,programming,UA,2023,3
 611,Procfile,programming,UA,2023,3
-561,Assembly,programming,UA,2023,3
 561,HCL,programming,UA,2023,3
+561,Assembly,programming,UA,2023,3
 561,Smarty,programming,UA,2023,3
 527,Perl,programming,UA,2023,3
 501,GLSL,programming,UA,2023,3
@@ -92685,12 +96003,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 223,Starlark,programming,UA,2023,3
 196,Emacs Lisp,programming,UA,2023,3
 186,QMake,programming,UA,2023,3
-177,Scala,programming,UA,2023,3
 177,Smalltalk,programming,UA,2023,3
+177,Scala,programming,UA,2023,3
 160,R,programming,UA,2023,3
 157,Yacc,programming,UA,2023,3
-144,FreeMarker,programming,UA,2023,3
 144,ASP.NET,programming,UA,2023,3
+144,FreeMarker,programming,UA,2023,3
 142,Mathematica,programming,UA,2023,3
 142,MATLAB,programming,UA,2023,3
 124,NSIS,programming,UA,2023,3
@@ -92702,6 +96020,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Cython,programming,UA,2023,3
 109,GDB,programming,UA,2023,3
 105,PLSQL,programming,UA,2023,3
+2751,HTML,markup,UG,2023,3
+2326,CSS,markup,UG,2023,3
+584,SCSS,markup,UG,2023,3
+476,Jupyter Notebook,markup,UG,2023,3
+203,Blade,markup,UG,2023,3
+142,Vue,markup,UG,2023,3
 2193,JavaScript,programming,UG,2023,3
 1204,Python,programming,UG,2023,3
 857,Shell,programming,UG,2023,3
@@ -92723,6 +96047,42 @@ num_pushers,language,language_type,iso2_code,year,quarter
 150,Hack,programming,UG,2023,3
 124,PowerShell,programming,UG,2023,3
 109,Procfile,programming,UG,2023,3
+699,YAML,data,US,2023,3
+573,JSON,data,US,2023,3
+397340,HTML,markup,US,2023,3
+323654,CSS,markup,US,2023,3
+86271,SCSS,markup,US,2023,3
+85640,Jupyter Notebook,markup,US,2023,3
+23221,TeX,markup,US,2023,3
+19759,Roff,markup,US,2023,3
+17392,Vue,markup,US,2023,3
+10867,Less,markup,US,2023,3
+10648,Jinja,markup,US,2023,3
+10396,Handlebars,markup,US,2023,3
+8926,EJS,markup,US,2023,3
+7191,Svelte,markup,US,2023,3
+6850,Mustache,markup,US,2023,3
+5437,Rich Text Format,markup,US,2023,3
+4288,Pug,markup,US,2023,3
+3265,Astro,markup,US,2023,3
+3025,Sass,markup,US,2023,3
+2472,Blade,markup,US,2023,3
+2000,PostScript,markup,US,2023,3
+1966,Liquid,markup,US,2023,3
+1926,Stylus,markup,US,2023,3
+1909,Nunjucks,markup,US,2023,3
+1532,Vim Snippet,markup,US,2023,3
+1457,Twig,markup,US,2023,3
+911,Haml,markup,US,2023,3
+557,YASnippet,markup,US,2023,3
+549,Mermaid,markup,US,2023,3
+444,Slim,markup,US,2023,3
+418,kvlang,markup,US,2023,3
+253,Velocity Template Language,markup,US,2023,3
+243,StringTemplate,markup,US,2023,3
+227,Bikeshed,markup,US,2023,3
+192,RAML,markup,US,2023,3
+109,Closure Templates,markup,US,2023,3
 350612,JavaScript,programming,US,2023,3
 280529,Python,programming,US,2023,3
 212768,Shell,programming,US,2023,3
@@ -92811,8 +96171,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 2130,Bicep,programming,US,2023,3
 2121,LLVM,programming,US,2023,3
 2028,AppleScript,programming,US,2023,3
-2021,M,programming,US,2023,3
 2021,SmPL,programming,US,2023,3
+2021,M,programming,US,2023,3
 1934,VBScript,programming,US,2023,3
 1932,Inno Setup,programming,US,2023,3
 1920,Jsonnet,programming,US,2023,3
@@ -92868,8 +96228,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 683,Module Management System,programming,US,2023,3
 662,Rebol,programming,US,2023,3
 658,PureScript,programming,US,2023,3
-588,Jasmin,programming,US,2023,3
 588,Brainfuck,programming,US,2023,3
+588,Jasmin,programming,US,2023,3
 576,Cap'n Proto,programming,US,2023,3
 574,NewLisp,programming,US,2023,3
 554,IDL,programming,US,2023,3
@@ -92883,8 +96243,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 511,q,programming,US,2023,3
 486,AGS Script,programming,US,2023,3
 474,Ragel,programming,US,2023,3
-470,Stan,programming,US,2023,3
 470,Game Maker Language,programming,US,2023,3
+470,Stan,programming,US,2023,3
 464,BitBake,programming,US,2023,3
 461,Max,programming,US,2023,3
 454,COBOL,programming,US,2023,3
@@ -92900,8 +96260,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 361,JetBrains MPS,programming,US,2023,3
 360,SMT,programming,US,2023,3
 354,MAXScript,programming,US,2023,3
-353,Lean,programming,US,2023,3
 353,Io,programming,US,2023,3
+353,Lean,programming,US,2023,3
 349,Terra,programming,US,2023,3
 346,TLA,programming,US,2023,3
 341,Q#,programming,US,2023,3
@@ -92920,8 +96280,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 288,VCL,programming,US,2023,3
 287,ImageJ Macro,programming,US,2023,3
 270,LookML,programming,US,2023,3
-268,SaltStack,programming,US,2023,3
 268,YARA,programming,US,2023,3
+268,SaltStack,programming,US,2023,3
 261,Dhall,programming,US,2023,3
 256,Eiffel,programming,US,2023,3
 254,nesC,programming,US,2023,3
@@ -92939,13 +96299,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 199,Witcher Script,programming,US,2023,3
 197,Common Workflow Language,programming,US,2023,3
 194,PigLatin,programming,US,2023,3
-189,eC,programming,US,2023,3
 189,KRL,programming,US,2023,3
+189,eC,programming,US,2023,3
 188,Xonsh,programming,US,2023,3
 187,Cypher,programming,US,2023,3
 183,E,programming,US,2023,3
-181,ZenScript,programming,US,2023,3
 181,Monkey C,programming,US,2023,3
+181,ZenScript,programming,US,2023,3
 180,Modula-3,programming,US,2023,3
 180,CWeb,programming,US,2023,3
 178,GSC,programming,US,2023,3
@@ -92953,8 +96313,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,OpenQASM,programming,US,2023,3
 168,Clarion,programming,US,2023,3
 166,CLIPS,programming,US,2023,3
-166,REXX,programming,US,2023,3
 166,LiveScript,programming,US,2023,3
+166,REXX,programming,US,2023,3
 160,AutoIt,programming,US,2023,3
 157,LabVIEW,programming,US,2023,3
 156,SQF,programming,US,2023,3
@@ -92964,9 +96324,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 151,Nu,programming,US,2023,3
 147,Vyper,programming,US,2023,3
 146,Singularity,programming,US,2023,3
-146,Odin,programming,US,2023,3
 146,Squirrel,programming,US,2023,3
 146,Ink,programming,US,2023,3
+146,Odin,programming,US,2023,3
 144,Nearley,programming,US,2023,3
 143,BlitzBasic,programming,US,2023,3
 143,Alloy,programming,US,2023,3
@@ -92974,18 +96334,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Hy,programming,US,2023,3
 137,Cool,programming,US,2023,3
 136,Smithy,programming,US,2023,3
-136,P4,programming,US,2023,3
 136,Agda,programming,US,2023,3
+136,P4,programming,US,2023,3
 135,Sieve,programming,US,2023,3
 135,Fennel,programming,US,2023,3
-134,Promela,programming,US,2023,3
 134,Berry,programming,US,2023,3
+134,Promela,programming,US,2023,3
 133,J,programming,US,2023,3
 133,Nasal,programming,US,2023,3
 132,Cairo,programming,US,2023,3
 131,Modelica,programming,US,2023,3
-131,Objective-J,programming,US,2023,3
 131,Slash,programming,US,2023,3
+131,Objective-J,programming,US,2023,3
 129,Harbour,programming,US,2023,3
 129,mIRC Script,programming,US,2023,3
 126,Isabelle,programming,US,2023,3
@@ -92999,12 +96359,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,LSL,programming,US,2023,3
 113,F*,programming,US,2023,3
 112,Xtend,programming,US,2023,3
-111,Faust,programming,US,2023,3
 111,Filebench WML,programming,US,2023,3
+111,Faust,programming,US,2023,3
 108,Augeas,programming,US,2023,3
 107,Chapel,programming,US,2023,3
 105,IGOR Pro,programming,US,2023,3
 102,ZAP,programming,US,2023,3
+1202,Markdown,prose,US,2023,3
+4491,HTML,markup,UY,2023,3
+4089,CSS,markup,UY,2023,3
+892,SCSS,markup,UY,2023,3
+285,Jupyter Notebook,markup,UY,2023,3
+142,Handlebars,markup,UY,2023,3
+101,Blade,markup,UY,2023,3
 4238,JavaScript,programming,UY,2023,3
 1118,Python,programming,UY,2023,3
 955,Shell,programming,UY,2023,3
@@ -93025,6 +96392,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Procfile,programming,UY,2023,3
 109,Go,programming,UY,2023,3
 104,CMake,programming,UY,2023,3
+9772,HTML,markup,UZ,2023,3
+8294,CSS,markup,UZ,2023,3
+2850,SCSS,markup,UZ,2023,3
+749,Vue,markup,UZ,2023,3
+376,Blade,markup,UZ,2023,3
+224,Jupyter Notebook,markup,UZ,2023,3
+212,Less,markup,UZ,2023,3
+151,Handlebars,markup,UZ,2023,3
+104,EJS,markup,UZ,2023,3
 7532,JavaScript,programming,UZ,2023,3
 3157,Python,programming,UZ,2023,3
 1695,TypeScript,programming,UZ,2023,3
@@ -93048,6 +96424,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 267,Procfile,programming,UZ,2023,3
 173,Hack,programming,UZ,2023,3
 103,PLpgSQL,programming,UZ,2023,3
+5013,HTML,markup,VE,2023,3
+4542,CSS,markup,VE,2023,3
+1001,SCSS,markup,VE,2023,3
+392,Blade,markup,VE,2023,3
+307,Vue,markup,VE,2023,3
+193,Jupyter Notebook,markup,VE,2023,3
+119,Less,markup,VE,2023,3
+115,Astro,markup,VE,2023,3
 4841,JavaScript,programming,VE,2023,3
 1538,Python,programming,VE,2023,3
 1504,TypeScript,programming,VE,2023,3
@@ -93064,13 +96448,34 @@ num_pushers,language,language_type,iso2_code,year,quarter
 225,Kotlin,programming,VE,2023,3
 216,Batchfile,programming,VE,2023,3
 216,Objective-C,programming,VE,2023,3
-187,CMake,programming,VE,2023,3
 187,Swift,programming,VE,2023,3
+187,CMake,programming,VE,2023,3
 175,Dart,programming,VE,2023,3
 155,Procfile,programming,VE,2023,3
 125,Lua,programming,VE,2023,3
 122,PowerShell,programming,VE,2023,3
 111,Go,programming,VE,2023,3
+54751,HTML,markup,VN,2023,3
+48647,CSS,markup,VN,2023,3
+17429,SCSS,markup,VN,2023,3
+4738,Jupyter Notebook,markup,VN,2023,3
+3865,Less,markup,VN,2023,3
+3614,Blade,markup,VN,2023,3
+3050,Vue,markup,VN,2023,3
+2139,EJS,markup,VN,2023,3
+1847,Handlebars,markup,VN,2023,3
+733,Pug,markup,VN,2023,3
+712,Roff,markup,VN,2023,3
+519,TeX,markup,VN,2023,3
+348,Jinja,markup,VN,2023,3
+310,Sass,markup,VN,2023,3
+304,Svelte,markup,VN,2023,3
+261,Mustache,markup,VN,2023,3
+197,Rich Text Format,markup,VN,2023,3
+187,Twig,markup,VN,2023,3
+169,Astro,markup,VN,2023,3
+124,Liquid,markup,VN,2023,3
+107,Stylus,markup,VN,2023,3
 54377,JavaScript,programming,VN,2023,3
 18443,Java,programming,VN,2023,3
 17466,TypeScript,programming,VN,2023,3
@@ -93127,24 +96532,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 181,Visual Basic .NET,programming,VN,2023,3
 169,Yacc,programming,VN,2023,3
 168,Mathematica,programming,VN,2023,3
-166,QMake,programming,VN,2023,3
 166,GAP,programming,VN,2023,3
+166,QMake,programming,VN,2023,3
 152,Emacs Lisp,programming,VN,2023,3
 136,Sage,programming,VN,2023,3
-133,Lex,programming,VN,2023,3
 133,Tcl,programming,VN,2023,3
+133,Lex,programming,VN,2023,3
 131,PureBasic,programming,VN,2023,3
 128,Pascal,programming,VN,2023,3
 119,FreeMarker,programming,VN,2023,3
 111,Raku,programming,VN,2023,3
 110,Fortran,programming,VN,2023,3
-110,Clojure,programming,VN,2023,3
 110,sed,programming,VN,2023,3
+110,Clojure,programming,VN,2023,3
 108,PLSQL,programming,VN,2023,3
+716,HTML,markup,XK,2023,3
+600,CSS,markup,XK,2023,3
+129,SCSS,markup,XK,2023,3
 632,JavaScript,programming,XK,2023,3
 186,TypeScript,programming,XK,2023,3
 116,C#,programming,XK,2023,3
 111,PHP,programming,XK,2023,3
+850,HTML,markup,YE,2023,3
+645,CSS,markup,YE,2023,3
+150,SCSS,markup,YE,2023,3
 642,JavaScript,programming,YE,2023,3
 336,Python,programming,YE,2023,3
 264,Dart,programming,YE,2023,3
@@ -93158,6 +96569,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,CMake,programming,YE,2023,3
 131,Dockerfile,programming,YE,2023,3
 108,Java,programming,YE,2023,3
+12081,HTML,markup,ZA,2023,3
+10209,CSS,markup,ZA,2023,3
+2196,SCSS,markup,ZA,2023,3
+1192,Jupyter Notebook,markup,ZA,2023,3
+469,Vue,markup,ZA,2023,3
+255,Less,markup,ZA,2023,3
+253,Roff,markup,ZA,2023,3
+249,EJS,markup,ZA,2023,3
+213,Blade,markup,ZA,2023,3
+191,TeX,markup,ZA,2023,3
+170,Handlebars,markup,ZA,2023,3
+164,Svelte,markup,ZA,2023,3
+107,Jinja,markup,ZA,2023,3
 10343,JavaScript,programming,ZA,2023,3
 6182,Shell,programming,ZA,2023,3
 4980,Python,programming,ZA,2023,3
@@ -93205,12 +96629,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,Forth,programming,ZA,2023,3
 104,Cython,programming,ZA,2023,3
 101,Solidity,programming,ZA,2023,3
+638,HTML,markup,ZM,2023,3
+583,CSS,markup,ZM,2023,3
 558,JavaScript,programming,ZM,2023,3
 213,Python,programming,ZM,2023,3
 209,Shell,programming,ZM,2023,3
 149,C,programming,ZM,2023,3
 131,TypeScript,programming,ZM,2023,3
 115,PHP,programming,ZM,2023,3
+833,HTML,markup,ZW,2023,3
+758,CSS,markup,ZW,2023,3
+199,SCSS,markup,ZW,2023,3
 783,JavaScript,programming,ZW,2023,3
 370,Python,programming,ZW,2023,3
 317,Shell,programming,ZW,2023,3
@@ -93221,6 +96650,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 141,Dockerfile,programming,ZW,2023,3
 102,Ruby,programming,ZW,2023,3
 108,JavaScript,programming,AD,2023,4
+5680,HTML,markup,AE,2023,4
+4814,CSS,markup,AE,2023,4
+1245,SCSS,markup,AE,2023,4
+1031,Jupyter Notebook,markup,AE,2023,4
+277,Vue,markup,AE,2023,4
+216,Blade,markup,AE,2023,4
+161,Handlebars,markup,AE,2023,4
+147,Roff,markup,AE,2023,4
+142,Less,markup,AE,2023,4
+123,TeX,markup,AE,2023,4
+115,EJS,markup,AE,2023,4
+104,Jinja,markup,AE,2023,4
 5150,JavaScript,programming,AE,2023,4
 3317,Python,programming,AE,2023,4
 2103,Shell,programming,AE,2023,4
@@ -93253,9 +96694,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,Lua,programming,AE,2023,4
 126,Nix,programming,AE,2023,4
 101,MATLAB,programming,AE,2023,4
+622,HTML,markup,AF,2023,4
+562,CSS,markup,AF,2023,4
 504,JavaScript,programming,AF,2023,4
 212,Python,programming,AF,2023,4
 126,PHP,programming,AF,2023,4
+1275,HTML,markup,AL,2023,4
+1133,CSS,markup,AL,2023,4
+208,SCSS,markup,AL,2023,4
 1111,JavaScript,programming,AL,2023,4
 388,Java,programming,AL,2023,4
 359,TypeScript,programming,AL,2023,4
@@ -93264,6 +96710,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 211,Dockerfile,programming,AL,2023,4
 199,C#,programming,AL,2023,4
 164,PHP,programming,AL,2023,4
+3662,HTML,markup,AM,2023,4
+3131,CSS,markup,AM,2023,4
+995,SCSS,markup,AM,2023,4
+279,Jupyter Notebook,markup,AM,2023,4
+266,Vue,markup,AM,2023,4
+236,Blade,markup,AM,2023,4
+120,Roff,markup,AM,2023,4
 3650,JavaScript,programming,AM,2023,4
 1615,Python,programming,AM,2023,4
 1408,TypeScript,programming,AM,2023,4
@@ -93286,6 +96739,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,Perl,programming,AM,2023,4
 114,Rust,programming,AM,2023,4
 113,Lua,programming,AM,2023,4
+976,HTML,markup,AO,2023,4
+914,CSS,markup,AO,2023,4
+180,SCSS,markup,AO,2023,4
+106,Blade,markup,AO,2023,4
 901,JavaScript,programming,AO,2023,4
 325,TypeScript,programming,AO,2023,4
 284,PHP,programming,AO,2023,4
@@ -93293,6 +96750,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 157,Java,programming,AO,2023,4
 111,Shell,programming,AO,2023,4
 105,C,programming,AO,2023,4
+51357,HTML,markup,AR,2023,4
+47992,CSS,markup,AR,2023,4
+8532,SCSS,markup,AR,2023,4
+3564,Jupyter Notebook,markup,AR,2023,4
+2201,Handlebars,markup,AR,2023,4
+2144,EJS,markup,AR,2023,4
+1124,Vue,markup,AR,2023,4
+874,Blade,markup,AR,2023,4
+593,TeX,markup,AR,2023,4
+581,Less,markup,AR,2023,4
+579,Astro,markup,AR,2023,4
+466,Roff,markup,AR,2023,4
+292,Pug,markup,AR,2023,4
+261,Svelte,markup,AR,2023,4
+201,Jinja,markup,AR,2023,4
+186,Nunjucks,markup,AR,2023,4
+184,Mustache,markup,AR,2023,4
+182,Rich Text Format,markup,AR,2023,4
+162,Sass,markup,AR,2023,4
+117,Twig,markup,AR,2023,4
 48364,JavaScript,programming,AR,2023,4
 14764,Python,programming,AR,2023,4
 11622,TypeScript,programming,AR,2023,4
@@ -93369,6 +96846,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 103,Emacs Lisp,programming,AR,2023,4
 102,GAP,programming,AR,2023,4
 101,Common Lisp,programming,AR,2023,4
+106,Markdown,prose,AR,2023,4
+9301,HTML,markup,AT,2023,4
+7571,CSS,markup,AT,2023,4
+2455,SCSS,markup,AT,2023,4
+1697,Jupyter Notebook,markup,AT,2023,4
+758,Vue,markup,AT,2023,4
+684,TeX,markup,AT,2023,4
+581,Roff,markup,AT,2023,4
+331,Jinja,markup,AT,2023,4
+282,Svelte,markup,AT,2023,4
+278,Less,markup,AT,2023,4
+260,Handlebars,markup,AT,2023,4
+212,EJS,markup,AT,2023,4
+179,Mustache,markup,AT,2023,4
+167,Twig,markup,AT,2023,4
+142,Astro,markup,AT,2023,4
+136,Rich Text Format,markup,AT,2023,4
+122,Blade,markup,AT,2023,4
+110,Sass,markup,AT,2023,4
 8403,JavaScript,programming,AT,2023,4
 6833,Python,programming,AT,2023,4
 5987,Shell,programming,AT,2023,4
@@ -93421,11 +96917,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 164,Yacc,programming,AT,2023,4
 154,sed,programming,AT,2023,4
 151,Lex,programming,AT,2023,4
-146,Scheme,programming,AT,2023,4
 146,Smalltalk,programming,AT,2023,4
+146,Scheme,programming,AT,2023,4
 143,QMake,programming,AT,2023,4
-141,Verilog,programming,AT,2023,4
 141,Julia,programming,AT,2023,4
+141,Verilog,programming,AT,2023,4
 131,Cython,programming,AT,2023,4
 131,Jsonnet,programming,AT,2023,4
 128,Solidity,programming,AT,2023,4
@@ -93438,6 +96934,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Prolog,programming,AT,2023,4
 106,Mathematica,programming,AT,2023,4
 103,Erlang,programming,AT,2023,4
+28921,HTML,markup,AU,2023,4
+24651,CSS,markup,AU,2023,4
+5957,SCSS,markup,AU,2023,4
+5343,Jupyter Notebook,markup,AU,2023,4
+1475,Vue,markup,AU,2023,4
+1452,TeX,markup,AU,2023,4
+1313,Roff,markup,AU,2023,4
+760,EJS,markup,AU,2023,4
+735,Less,markup,AU,2023,4
+733,Handlebars,markup,AU,2023,4
+716,Jinja,markup,AU,2023,4
+563,Svelte,markup,AU,2023,4
+501,Mustache,markup,AU,2023,4
+408,Rich Text Format,markup,AU,2023,4
+406,Pug,markup,AU,2023,4
+393,Blade,markup,AU,2023,4
+341,Astro,markup,AU,2023,4
+208,Sass,markup,AU,2023,4
+155,Twig,markup,AU,2023,4
+130,Liquid,markup,AU,2023,4
+129,Nunjucks,markup,AU,2023,4
+126,PostScript,markup,AU,2023,4
+102,Vim Snippet,markup,AU,2023,4
 27186,JavaScript,programming,AU,2023,4
 20477,Python,programming,AU,2023,4
 15852,Shell,programming,AU,2023,4
@@ -93496,8 +97015,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 306,sed,programming,AU,2023,4
 297,GDScript,programming,AU,2023,4
 297,Lex,programming,AU,2023,4
-292,Tcl,programming,AU,2023,4
 292,Julia,programming,AU,2023,4
+292,Tcl,programming,AU,2023,4
 290,ASP.NET,programming,AU,2023,4
 281,Pascal,programming,AU,2023,4
 272,Meson,programming,AU,2023,4
@@ -93517,8 +97036,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 191,ANTLR,programming,AU,2023,4
 185,CoffeeScript,programming,AU,2023,4
 178,AppleScript,programming,AU,2023,4
-172,Gnuplot,programming,AU,2023,4
 172,PLSQL,programming,AU,2023,4
+172,Gnuplot,programming,AU,2023,4
 170,Elixir,programming,AU,2023,4
 168,VBScript,programming,AU,2023,4
 163,Prolog,programming,AU,2023,4
@@ -93533,8 +97052,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,PureBasic,programming,AU,2023,4
 130,M,programming,AU,2023,4
 128,Erlang,programming,AU,2023,4
-124,VHDL,programming,AU,2023,4
 124,Pawn,programming,AU,2023,4
+124,VHDL,programming,AU,2023,4
 121,OpenEdge ABL,programming,AU,2023,4
 119,Nim,programming,AU,2023,4
 118,QML,programming,AU,2023,4
@@ -93543,6 +97062,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,OCaml,programming,AU,2023,4
 109,Visual Basic .NET,programming,AU,2023,4
 103,AMPL,programming,AU,2023,4
+105,Markdown,prose,AU,2023,4
+4296,HTML,markup,AZ,2023,4
+3756,CSS,markup,AZ,2023,4
+1380,SCSS,markup,AZ,2023,4
+239,Jupyter Notebook,markup,AZ,2023,4
+134,Blade,markup,AZ,2023,4
 3608,JavaScript,programming,AZ,2023,4
 1073,C#,programming,AZ,2023,4
 994,Python,programming,AZ,2023,4
@@ -93562,6 +97087,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 132,Batchfile,programming,AZ,2023,4
 130,Dart,programming,AZ,2023,4
 108,PowerShell,programming,AZ,2023,4
+1783,HTML,markup,BA,2023,4
+1549,CSS,markup,BA,2023,4
+311,SCSS,markup,BA,2023,4
 1604,JavaScript,programming,BA,2023,4
 641,TypeScript,programming,BA,2023,4
 486,Java,programming,BA,2023,4
@@ -93578,6 +97106,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 128,Swift,programming,BA,2023,4
 125,Makefile,programming,BA,2023,4
 121,Objective-C,programming,BA,2023,4
+33066,HTML,markup,BD,2023,4
+30483,CSS,markup,BD,2023,4
+5603,SCSS,markup,BD,2023,4
+3448,Blade,markup,BD,2023,4
+3147,Jupyter Notebook,markup,BD,2023,4
+1309,Vue,markup,BD,2023,4
+847,Less,markup,BD,2023,4
+644,EJS,markup,BD,2023,4
+343,Handlebars,markup,BD,2023,4
+319,Roff,markup,BD,2023,4
+318,TeX,markup,BD,2023,4
+155,Svelte,markup,BD,2023,4
+128,Astro,markup,BD,2023,4
+124,Pug,markup,BD,2023,4
+119,Sass,markup,BD,2023,4
 29003,JavaScript,programming,BD,2023,4
 9206,Python,programming,BD,2023,4
 7470,PHP,programming,BD,2023,4
@@ -93622,6 +97165,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Cython,programming,BD,2023,4
 117,Vim Script,programming,BD,2023,4
 102,CoffeeScript,programming,BD,2023,4
+11330,HTML,markup,BE,2023,4
+9620,CSS,markup,BE,2023,4
+3139,SCSS,markup,BE,2023,4
+1744,Jupyter Notebook,markup,BE,2023,4
+840,TeX,markup,BE,2023,4
+827,Vue,markup,BE,2023,4
+491,Roff,markup,BE,2023,4
+366,Blade,markup,BE,2023,4
+353,Jinja,markup,BE,2023,4
+316,Less,markup,BE,2023,4
+299,Twig,markup,BE,2023,4
+270,Handlebars,markup,BE,2023,4
+262,Svelte,markup,BE,2023,4
+251,EJS,markup,BE,2023,4
+157,Mustache,markup,BE,2023,4
+154,Liquid,markup,BE,2023,4
+152,Rich Text Format,markup,BE,2023,4
+148,Sass,markup,BE,2023,4
+140,Astro,markup,BE,2023,4
+128,Pug,markup,BE,2023,4
 10399,JavaScript,programming,BE,2023,4
 7524,Python,programming,BE,2023,4
 5866,Shell,programming,BE,2023,4
@@ -93652,10 +97215,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 352,HCL,programming,BE,2023,4
 346,Vim Script,programming,BE,2023,4
 307,MATLAB,programming,BE,2023,4
-289,Nix,programming,BE,2023,4
 289,GLSL,programming,BE,2023,4
-271,HLSL,programming,BE,2023,4
+289,Nix,programming,BE,2023,4
 271,Dart,programming,BE,2023,4
+271,HLSL,programming,BE,2023,4
 246,ShaderLab,programming,BE,2023,4
 237,PLpgSQL,programming,BE,2023,4
 232,M4,programming,BE,2023,4
@@ -93681,8 +97244,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,Elixir,programming,BE,2023,4
 119,Solidity,programming,BE,2023,4
 117,NSIS,programming,BE,2023,4
-116,QMake,programming,BE,2023,4
 116,Yacc,programming,BE,2023,4
+116,QMake,programming,BE,2023,4
 116,Starlark,programming,BE,2023,4
 115,Mathematica,programming,BE,2023,4
 111,Lex,programming,BE,2023,4
@@ -93691,8 +97254,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,Verilog,programming,BE,2023,4
 105,VHDL,programming,BE,2023,4
 102,Clojure,programming,BE,2023,4
+293,HTML,markup,BF,2023,4
+274,CSS,markup,BF,2023,4
+140,SCSS,markup,BF,2023,4
+126,Blade,markup,BF,2023,4
 291,JavaScript,programming,BF,2023,4
 158,PHP,programming,BF,2023,4
+7333,HTML,markup,BG,2023,4
+6465,CSS,markup,BG,2023,4
+1583,SCSS,markup,BG,2023,4
+371,Jupyter Notebook,markup,BG,2023,4
+326,Handlebars,markup,BG,2023,4
+324,Vue,markup,BG,2023,4
+195,Roff,markup,BG,2023,4
+188,Pug,markup,BG,2023,4
+177,Blade,markup,BG,2023,4
+173,Less,markup,BG,2023,4
+154,Mustache,markup,BG,2023,4
+118,EJS,markup,BG,2023,4
+102,TeX,markup,BG,2023,4
 7150,JavaScript,programming,BG,2023,4
 2951,Python,programming,BG,2023,4
 2490,TypeScript,programming,BG,2023,4
@@ -93729,10 +97309,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,Dart,programming,BG,2023,4
 114,GLSL,programming,BG,2023,4
 105,Procfile,programming,BG,2023,4
+707,HTML,markup,BH,2023,4
+466,CSS,markup,BH,2023,4
 466,JavaScript,programming,BH,2023,4
 242,Python,programming,BH,2023,4
 139,TypeScript,programming,BH,2023,4
 133,Shell,programming,BH,2023,4
+112,HTML,markup,BI,2023,4
+105,CSS,markup,BI,2023,4
+917,HTML,markup,BJ,2023,4
+801,CSS,markup,BJ,2023,4
+207,Blade,markup,BJ,2023,4
+178,SCSS,markup,BJ,2023,4
+128,Vue,markup,BJ,2023,4
 810,JavaScript,programming,BJ,2023,4
 355,PHP,programming,BJ,2023,4
 287,Python,programming,BJ,2023,4
@@ -93745,6 +97334,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 115,Kotlin,programming,BJ,2023,4
 114,Objective-C,programming,BJ,2023,4
 104,CMake,programming,BJ,2023,4
+4477,HTML,markup,BO,2023,4
+3999,CSS,markup,BO,2023,4
+853,SCSS,markup,BO,2023,4
+631,Blade,markup,BO,2023,4
+356,Vue,markup,BO,2023,4
+295,Jupyter Notebook,markup,BO,2023,4
+124,Less,markup,BO,2023,4
 4087,JavaScript,programming,BO,2023,4
 1213,TypeScript,programming,BO,2023,4
 1168,PHP,programming,BO,2023,4
@@ -93765,6 +97361,31 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,Batchfile,programming,BO,2023,4
 134,Makefile,programming,BO,2023,4
 116,PowerShell,programming,BO,2023,4
+194761,HTML,markup,BR,2023,4
+171548,CSS,markup,BR,2023,4
+23197,SCSS,markup,BR,2023,4
+20522,Jupyter Notebook,markup,BR,2023,4
+6585,Vue,markup,BR,2023,4
+5757,Blade,markup,BR,2023,4
+3058,EJS,markup,BR,2023,4
+2586,Handlebars,markup,BR,2023,4
+2338,Less,markup,BR,2023,4
+2233,Roff,markup,BR,2023,4
+2225,TeX,markup,BR,2023,4
+1190,Sass,markup,BR,2023,4
+909,Svelte,markup,BR,2023,4
+800,Jinja,markup,BR,2023,4
+729,Pug,markup,BR,2023,4
+612,Mustache,markup,BR,2023,4
+527,Astro,markup,BR,2023,4
+460,Rich Text Format,markup,BR,2023,4
+282,Twig,markup,BR,2023,4
+244,kvlang,markup,BR,2023,4
+175,Stylus,markup,BR,2023,4
+168,Liquid,markup,BR,2023,4
+165,PostScript,markup,BR,2023,4
+162,Vim Snippet,markup,BR,2023,4
+104,Nunjucks,markup,BR,2023,4
 165949,JavaScript,programming,BR,2023,4
 63663,Python,programming,BR,2023,4
 55853,TypeScript,programming,BR,2023,4
@@ -93868,10 +97489,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 178,xBase,programming,BR,2023,4
 177,SourcePawn,programming,BR,2023,4
 171,XS,programming,BR,2023,4
-164,Processing,programming,BR,2023,4
 164,OCaml,programming,BR,2023,4
-153,UnrealScript,programming,BR,2023,4
+164,Processing,programming,BR,2023,4
 153,D,programming,BR,2023,4
+153,UnrealScript,programming,BR,2023,4
 151,Pawn,programming,BR,2023,4
 149,AppleScript,programming,BR,2023,4
 146,SWIG,programming,BR,2023,4
@@ -93888,9 +97509,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,V,programming,BR,2023,4
 110,Scilab,programming,BR,2023,4
 101,COBOL,programming,BR,2023,4
+126,Markdown,prose,BR,2023,4
+327,HTML,markup,BT,2023,4
+288,CSS,markup,BT,2023,4
 259,JavaScript,programming,BT,2023,4
 187,Python,programming,BT,2023,4
+187,HTML,markup,BW,2023,4
+160,CSS,markup,BW,2023,4
 145,JavaScript,programming,BW,2023,4
+9488,HTML,markup,BY,2023,4
+7564,CSS,markup,BY,2023,4
+2518,SCSS,markup,BY,2023,4
+378,Vue,markup,BY,2023,4
+374,Jupyter Notebook,markup,BY,2023,4
+242,Less,markup,BY,2023,4
+184,Roff,markup,BY,2023,4
+181,Blade,markup,BY,2023,4
+140,Sass,markup,BY,2023,4
+119,TeX,markup,BY,2023,4
 8184,JavaScript,programming,BY,2023,4
 3735,Python,programming,BY,2023,4
 3451,Java,programming,BY,2023,4
@@ -93929,6 +97565,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 116,Procfile,programming,BY,2023,4
 110,XSLT,programming,BY,2023,4
 102,Gherkin,programming,BY,2023,4
+142,HTML,markup,BZ,2023,4
+104,CSS,markup,BZ,2023,4
+115,YAML,data,CA,2023,4
+73073,HTML,markup,CA,2023,4
+63435,CSS,markup,CA,2023,4
+15183,Jupyter Notebook,markup,CA,2023,4
+14575,SCSS,markup,CA,2023,4
+3529,TeX,markup,CA,2023,4
+2896,Vue,markup,CA,2023,4
+2657,EJS,markup,CA,2023,4
+2583,Roff,markup,CA,2023,4
+1693,Handlebars,markup,CA,2023,4
+1564,Jinja,markup,CA,2023,4
+1413,Less,markup,CA,2023,4
+1199,Svelte,markup,CA,2023,4
+913,Mustache,markup,CA,2023,4
+838,Pug,markup,CA,2023,4
+756,Rich Text Format,markup,CA,2023,4
+753,Blade,markup,CA,2023,4
+643,Astro,markup,CA,2023,4
+475,Sass,markup,CA,2023,4
+290,PostScript,markup,CA,2023,4
+282,Liquid,markup,CA,2023,4
+281,Twig,markup,CA,2023,4
+217,Nunjucks,markup,CA,2023,4
+214,Vim Snippet,markup,CA,2023,4
+201,Stylus,markup,CA,2023,4
 67352,JavaScript,programming,CA,2023,4
 46754,Python,programming,CA,2023,4
 30997,Shell,programming,CA,2023,4
@@ -94020,8 +97683,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 276,AppleScript,programming,CA,2023,4
 269,SWIG,programming,CA,2023,4
 263,Erlang,programming,CA,2023,4
-256,AutoHotkey,programming,CA,2023,4
 256,D,programming,CA,2023,4
+256,AutoHotkey,programming,CA,2023,4
 241,Visual Basic .NET,programming,CA,2023,4
 241,DIGITAL Command Language,programming,CA,2023,4
 240,Zig,programming,CA,2023,4
@@ -94050,11 +97713,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,Racket,programming,CA,2023,4
 129,PureScript,programming,CA,2023,4
 120,Open Policy Agent,programming,CA,2023,4
+118,Scilab,programming,CA,2023,4
 118,Ada,programming,CA,2023,4
+118,Thrift,programming,CA,2023,4
 118,WebAssembly,programming,CA,2023,4
 118,Apex,programming,CA,2023,4
-118,Scilab,programming,CA,2023,4
-118,Thrift,programming,CA,2023,4
 117,SAS,programming,CA,2023,4
 116,G-code,programming,CA,2023,4
 115,ActionScript,programming,CA,2023,4
@@ -94063,17 +97726,43 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,DM,programming,CA,2023,4
 111,Fluent,programming,CA,2023,4
 110,Elvish,programming,CA,2023,4
-108,Sage,programming,CA,2023,4
-108,Visual Basic 6.0,programming,CA,2023,4
 108,jq,programming,CA,2023,4
+108,Visual Basic 6.0,programming,CA,2023,4
+108,Sage,programming,CA,2023,4
 105,UnrealScript,programming,CA,2023,4
 101,Nextflow,programming,CA,2023,4
+173,Markdown,prose,CA,2023,4
+747,HTML,markup,CD,2023,4
+738,CSS,markup,CD,2023,4
+172,SCSS,markup,CD,2023,4
 732,JavaScript,programming,CD,2023,4
 265,PHP,programming,CD,2023,4
 187,Python,programming,CD,2023,4
 172,TypeScript,programming,CD,2023,4
 119,Shell,programming,CD,2023,4
+132,HTML,markup,CG,2023,4
+119,CSS,markup,CG,2023,4
 120,JavaScript,programming,CG,2023,4
+15881,HTML,markup,CH,2023,4
+12510,CSS,markup,CH,2023,4
+5283,Jupyter Notebook,markup,CH,2023,4
+4101,SCSS,markup,CH,2023,4
+1932,TeX,markup,CH,2023,4
+1059,Roff,markup,CH,2023,4
+1038,Vue,markup,CH,2023,4
+603,Jinja,markup,CH,2023,4
+470,Less,markup,CH,2023,4
+414,Handlebars,markup,CH,2023,4
+408,Svelte,markup,CH,2023,4
+321,Mustache,markup,CH,2023,4
+270,EJS,markup,CH,2023,4
+263,Rich Text Format,markup,CH,2023,4
+257,Blade,markup,CH,2023,4
+236,Sass,markup,CH,2023,4
+216,Twig,markup,CH,2023,4
+154,Astro,markup,CH,2023,4
+126,Pug,markup,CH,2023,4
+123,PostScript,markup,CH,2023,4
 14466,Python,programming,CH,2023,4
 13845,JavaScript,programming,CH,2023,4
 11488,Shell,programming,CH,2023,4
@@ -94150,9 +97839,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 157,Forth,programming,CH,2023,4
 156,Common Lisp,programming,CH,2023,4
 142,SystemVerilog,programming,CH,2023,4
+136,POV-Ray SDL,programming,CH,2023,4
 136,Clojure,programming,CH,2023,4
 136,Elixir,programming,CH,2023,4
-136,POV-Ray SDL,programming,CH,2023,4
 134,Mathematica,programming,CH,2023,4
 130,ANTLR,programming,CH,2023,4
 129,Smalltalk,programming,CH,2023,4
@@ -94169,6 +97858,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,AppleScript,programming,CH,2023,4
 106,Bicep,programming,CH,2023,4
 104,GDScript,programming,CH,2023,4
+1147,HTML,markup,CI,2023,4
+1024,CSS,markup,CI,2023,4
+303,SCSS,markup,CI,2023,4
+157,Blade,markup,CI,2023,4
 975,JavaScript,programming,CI,2023,4
 352,Python,programming,CI,2023,4
 345,PHP,programming,CI,2023,4
@@ -94183,6 +97876,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 129,Swift,programming,CI,2023,4
 127,C++,programming,CI,2023,4
 107,CMake,programming,CI,2023,4
+13522,HTML,markup,CL,2023,4
+11158,CSS,markup,CL,2023,4
+3416,SCSS,markup,CL,2023,4
+1879,Jupyter Notebook,markup,CL,2023,4
+546,Vue,markup,CL,2023,4
+481,Blade,markup,CL,2023,4
+299,TeX,markup,CL,2023,4
+228,Handlebars,markup,CL,2023,4
+225,Less,markup,CL,2023,4
+225,Astro,markup,CL,2023,4
+195,Roff,markup,CL,2023,4
+153,EJS,markup,CL,2023,4
+125,Svelte,markup,CL,2023,4
 12258,JavaScript,programming,CL,2023,4
 6772,Python,programming,CL,2023,4
 4328,TypeScript,programming,CL,2023,4
@@ -94216,14 +97922,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 161,GLSL,programming,CL,2023,4
 159,Perl,programming,CL,2023,4
 156,Smarty,programming,CL,2023,4
-149,GDScript,programming,CL,2023,4
 149,HCL,programming,CL,2023,4
+149,GDScript,programming,CL,2023,4
 137,Cython,programming,CL,2023,4
 136,Objective-C++,programming,CL,2023,4
 135,MATLAB,programming,CL,2023,4
 116,Mako,programming,CL,2023,4
 112,Fortran,programming,CL,2023,4
 103,Vim Script,programming,CL,2023,4
+2431,HTML,markup,CM,2023,4
+2207,CSS,markup,CM,2023,4
+577,SCSS,markup,CM,2023,4
+246,Blade,markup,CM,2023,4
+194,Jupyter Notebook,markup,CM,2023,4
 2202,JavaScript,programming,CM,2023,4
 842,Python,programming,CM,2023,4
 697,TypeScript,programming,CM,2023,4
@@ -94243,6 +97954,28 @@ num_pushers,language,language_type,iso2_code,year,quarter
 146,C#,programming,CM,2023,4
 139,Makefile,programming,CM,2023,4
 128,Procfile,programming,CM,2023,4
+44728,HTML,markup,CN,2023,4
+31118,CSS,markup,CN,2023,4
+10770,Vue,markup,CN,2023,4
+10199,SCSS,markup,CN,2023,4
+4479,Less,markup,CN,2023,4
+4416,Jupyter Notebook,markup,CN,2023,4
+2445,Roff,markup,CN,2023,4
+1524,TeX,markup,CN,2023,4
+1142,EJS,markup,CN,2023,4
+897,Stylus,markup,CN,2023,4
+649,Handlebars,markup,CN,2023,4
+634,Jinja,markup,CN,2023,4
+569,Mustache,markup,CN,2023,4
+469,Pug,markup,CN,2023,4
+414,Rich Text Format,markup,CN,2023,4
+315,Astro,markup,CN,2023,4
+229,Vim Snippet,markup,CN,2023,4
+229,Svelte,markup,CN,2023,4
+209,Sass,markup,CN,2023,4
+200,PostScript,markup,CN,2023,4
+189,Blade,markup,CN,2023,4
+137,Nunjucks,markup,CN,2023,4
 39485,JavaScript,programming,CN,2023,4
 27594,Python,programming,CN,2023,4
 24560,Shell,programming,CN,2023,4
@@ -94332,10 +98065,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 200,LLVM,programming,CN,2023,4
 198,Gnuplot,programming,CN,2023,4
 194,Forth,programming,CN,2023,4
-193,Scheme,programming,CN,2023,4
 193,Visual Basic .NET,programming,CN,2023,4
-192,AMPL,programming,CN,2023,4
+193,Scheme,programming,CN,2023,4
 192,SystemVerilog,programming,CN,2023,4
+192,AMPL,programming,CN,2023,4
 190,CoffeeScript,programming,CN,2023,4
 189,QML,programming,CN,2023,4
 181,Julia,programming,CN,2023,4
@@ -94350,16 +98083,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 159,AspectJ,programming,CN,2023,4
 158,Jsonnet,programming,CN,2023,4
 146,VHDL,programming,CN,2023,4
-145,HiveQL,programming,CN,2023,4
 145,Logos,programming,CN,2023,4
+145,HiveQL,programming,CN,2023,4
 143,Common Lisp,programming,CN,2023,4
 141,AutoHotkey,programming,CN,2023,4
 141,Module Management System,programming,CN,2023,4
 137,GDScript,programming,CN,2023,4
-130,V,programming,CN,2023,4
 130,Scilab,programming,CN,2023,4
-129,Erlang,programming,CN,2023,4
+130,V,programming,CN,2023,4
 129,Visual Basic 6.0,programming,CN,2023,4
+129,Erlang,programming,CN,2023,4
 128,Terra,programming,CN,2023,4
 126,Stata,programming,CN,2023,4
 113,Prolog,programming,CN,2023,4
@@ -94367,6 +98100,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,Ada,programming,CN,2023,4
 108,Elixir,programming,CN,2023,4
 105,q,programming,CN,2023,4
+141,Markdown,prose,CN,2023,4
+37241,HTML,markup,CO,2023,4
+33133,CSS,markup,CO,2023,4
+6514,SCSS,markup,CO,2023,4
+4525,Jupyter Notebook,markup,CO,2023,4
+1928,Blade,markup,CO,2023,4
+1563,Vue,markup,CO,2023,4
+743,Less,markup,CO,2023,4
+646,Handlebars,markup,CO,2023,4
+635,EJS,markup,CO,2023,4
+585,Astro,markup,CO,2023,4
+482,TeX,markup,CO,2023,4
+385,Roff,markup,CO,2023,4
+254,Sass,markup,CO,2023,4
+210,Pug,markup,CO,2023,4
+197,Svelte,markup,CO,2023,4
+122,Mustache,markup,CO,2023,4
+114,Jinja,markup,CO,2023,4
 33219,JavaScript,programming,CO,2023,4
 14185,Python,programming,CO,2023,4
 10594,Java,programming,CO,2023,4
@@ -94427,8 +98178,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,Verilog,programming,CO,2023,4
 109,Elixir,programming,CO,2023,4
 108,VBScript,programming,CO,2023,4
-103,Visual Basic .NET,programming,CO,2023,4
 103,Racket,programming,CO,2023,4
+103,Visual Basic .NET,programming,CO,2023,4
+3877,HTML,markup,CR,2023,4
+3625,CSS,markup,CR,2023,4
+802,SCSS,markup,CR,2023,4
+315,Jupyter Notebook,markup,CR,2023,4
+123,Vue,markup,CR,2023,4
+119,Less,markup,CR,2023,4
+103,Blade,markup,CR,2023,4
 3698,JavaScript,programming,CR,2023,4
 1546,Python,programming,CR,2023,4
 1471,Java,programming,CR,2023,4
@@ -94453,6 +98211,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,Assembly,programming,CR,2023,4
 119,Objective-C,programming,CR,2023,4
 115,Swift,programming,CR,2023,4
+902,HTML,markup,CU,2023,4
+798,CSS,markup,CU,2023,4
+142,SCSS,markup,CU,2023,4
 825,JavaScript,programming,CU,2023,4
 555,Python,programming,CU,2023,4
 333,TypeScript,programming,CU,2023,4
@@ -94463,6 +98224,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 158,C,programming,CU,2023,4
 147,PHP,programming,CU,2023,4
 135,Makefile,programming,CU,2023,4
+1472,HTML,markup,CY,2023,4
+1207,CSS,markup,CY,2023,4
+358,SCSS,markup,CY,2023,4
+184,Jupyter Notebook,markup,CY,2023,4
 1382,JavaScript,programming,CY,2023,4
 915,Python,programming,CY,2023,4
 823,Shell,programming,CY,2023,4
@@ -94482,6 +98247,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 138,Swift,programming,CY,2023,4
 124,Objective-C,programming,CY,2023,4
 119,Rust,programming,CY,2023,4
+11406,HTML,markup,CZ,2023,4
+9582,CSS,markup,CZ,2023,4
+2439,SCSS,markup,CZ,2023,4
+1319,Jupyter Notebook,markup,CZ,2023,4
+756,Roff,markup,CZ,2023,4
+612,Vue,markup,CZ,2023,4
+569,TeX,markup,CZ,2023,4
+451,Jinja,markup,CZ,2023,4
+356,Less,markup,CZ,2023,4
+318,Svelte,markup,CZ,2023,4
+271,Mustache,markup,CZ,2023,4
+261,Handlebars,markup,CZ,2023,4
+218,Latte,markup,CZ,2023,4
+212,EJS,markup,CZ,2023,4
+194,Twig,markup,CZ,2023,4
+186,Blade,markup,CZ,2023,4
+140,Rich Text Format,markup,CZ,2023,4
+139,Sass,markup,CZ,2023,4
+119,Astro,markup,CZ,2023,4
+104,Pug,markup,CZ,2023,4
 10216,JavaScript,programming,CZ,2023,4
 7786,Python,programming,CZ,2023,4
 6562,Shell,programming,CZ,2023,4
@@ -94522,8 +98307,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 275,Dart,programming,CZ,2023,4
 269,ShaderLab,programming,CZ,2023,4
 250,Emacs Lisp,programming,CZ,2023,4
-247,MATLAB,programming,CZ,2023,4
 247,Procfile,programming,CZ,2023,4
+247,MATLAB,programming,CZ,2023,4
 223,Gherkin,programming,CZ,2023,4
 208,Yacc,programming,CZ,2023,4
 205,Meson,programming,CZ,2023,4
@@ -94547,17 +98332,48 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,ANTLR,programming,CZ,2023,4
 120,Clojure,programming,CZ,2023,4
 117,Cython,programming,CZ,2023,4
-116,Solidity,programming,CZ,2023,4
 116,Julia,programming,CZ,2023,4
+116,Solidity,programming,CZ,2023,4
 115,Jsonnet,programming,CZ,2023,4
-114,F#,programming,CZ,2023,4
 114,Pascal,programming,CZ,2023,4
+114,F#,programming,CZ,2023,4
 106,Prolog,programming,CZ,2023,4
 104,SourcePawn,programming,CZ,2023,4
 103,Fortran,programming,CZ,2023,4
 102,NSIS,programming,CZ,2023,4
 102,OpenSCAD,programming,CZ,2023,4
 101,Mathematica,programming,CZ,2023,4
+307,YAML,data,DE,2023,4
+259,JSON,data,DE,2023,4
+74384,HTML,markup,DE,2023,4
+60084,CSS,markup,DE,2023,4
+18949,SCSS,markup,DE,2023,4
+15728,Jupyter Notebook,markup,DE,2023,4
+6311,Vue,markup,DE,2023,4
+6198,TeX,markup,DE,2023,4
+5286,Roff,markup,DE,2023,4
+3155,Jinja,markup,DE,2023,4
+2316,Less,markup,DE,2023,4
+2201,Handlebars,markup,DE,2023,4
+1991,Svelte,markup,DE,2023,4
+1953,Mustache,markup,DE,2023,4
+1471,EJS,markup,DE,2023,4
+1230,Twig,markup,DE,2023,4
+1192,Rich Text Format,markup,DE,2023,4
+1191,Blade,markup,DE,2023,4
+987,Sass,markup,DE,2023,4
+855,Astro,markup,DE,2023,4
+775,Pug,markup,DE,2023,4
+499,PostScript,markup,DE,2023,4
+473,Vim Snippet,markup,DE,2023,4
+403,Liquid,markup,DE,2023,4
+367,Nunjucks,markup,DE,2023,4
+300,Stylus,markup,DE,2023,4
+219,Haml,markup,DE,2023,4
+179,Mermaid,markup,DE,2023,4
+133,Slim,markup,DE,2023,4
+115,YASnippet,markup,DE,2023,4
+104,kvlang,markup,DE,2023,4
 69303,JavaScript,programming,DE,2023,4
 64123,Python,programming,DE,2023,4
 56563,Shell,programming,DE,2023,4
@@ -94580,8 +98396,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 6297,Perl,programming,DE,2023,4
 5626,Objective-C,programming,DE,2023,4
 4982,Swift,programming,DE,2023,4
-4875,Assembly,programming,DE,2023,4
 4875,R,programming,DE,2023,4
+4875,Assembly,programming,DE,2023,4
 4583,Smarty,programming,DE,2023,4
 3631,Vim Script,programming,DE,2023,4
 3616,XSLT,programming,DE,2023,4
@@ -94670,8 +98486,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 372,M,programming,DE,2023,4
 368,AMPL,programming,DE,2023,4
 367,Visual Basic .NET,programming,DE,2023,4
-366,ASP.NET,programming,DE,2023,4
 366,Boogie,programming,DE,2023,4
+366,ASP.NET,programming,DE,2023,4
 332,AIDL,programming,DE,2023,4
 326,OpenSCAD,programming,DE,2023,4
 323,DTrace,programming,DE,2023,4
@@ -94708,16 +98524,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 168,Logos,programming,DE,2023,4
 165,ActionScript,programming,DE,2023,4
 162,Module Management System,programming,DE,2023,4
+160,AGS Script,programming,DE,2023,4
 160,Xtend,programming,DE,2023,4
 160,Brainfuck,programming,DE,2023,4
-160,AGS Script,programming,DE,2023,4
 156,EmberScript,programming,DE,2023,4
 150,Max,programming,DE,2023,4
 150,SAS,programming,DE,2023,4
 148,Apex,programming,DE,2023,4
 147,Vala,programming,DE,2023,4
-147,COBOL,programming,DE,2023,4
 147,Cairo,programming,DE,2023,4
+147,COBOL,programming,DE,2023,4
 136,NewLisp,programming,DE,2023,4
 135,XQuery,programming,DE,2023,4
 131,Racket,programming,DE,2023,4
@@ -94737,6 +98553,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,VBA,programming,DE,2023,4
 102,Qt Script,programming,DE,2023,4
 101,Terra,programming,DE,2023,4
+417,Markdown,prose,DE,2023,4
+10084,HTML,markup,DK,2023,4
+8762,CSS,markup,DK,2023,4
+2356,Jupyter Notebook,markup,DK,2023,4
+1939,SCSS,markup,DK,2023,4
+774,TeX,markup,DK,2023,4
+585,Vue,markup,DK,2023,4
+407,Roff,markup,DK,2023,4
+271,Svelte,markup,DK,2023,4
+245,Astro,markup,DK,2023,4
+208,Jinja,markup,DK,2023,4
+199,Less,markup,DK,2023,4
+197,Blade,markup,DK,2023,4
+169,EJS,markup,DK,2023,4
+169,Handlebars,markup,DK,2023,4
+120,Mustache,markup,DK,2023,4
+104,Pug,markup,DK,2023,4
 9297,JavaScript,programming,DK,2023,4
 7041,Python,programming,DK,2023,4
 5153,Shell,programming,DK,2023,4
@@ -94790,16 +98623,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,Fortran,programming,DK,2023,4
 129,Groovy,programming,DK,2023,4
 129,Yacc,programming,DK,2023,4
-123,Verilog,programming,DK,2023,4
 123,GDScript,programming,DK,2023,4
+123,Verilog,programming,DK,2023,4
 121,Starlark,programming,DK,2023,4
 118,Meson,programming,DK,2023,4
-116,Cuda,programming,DK,2023,4
 116,Cython,programming,DK,2023,4
+116,Cuda,programming,DK,2023,4
 112,Julia,programming,DK,2023,4
 106,Lex,programming,DK,2023,4
 105,Scheme,programming,DK,2023,4
 104,GAP,programming,DK,2023,4
+2976,HTML,markup,DO,2023,4
+2544,CSS,markup,DO,2023,4
+464,SCSS,markup,DO,2023,4
+116,Vue,markup,DO,2023,4
+105,Jupyter Notebook,markup,DO,2023,4
 2659,JavaScript,programming,DO,2023,4
 928,TypeScript,programming,DO,2023,4
 803,C#,programming,DO,2023,4
@@ -94819,6 +98657,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Batchfile,programming,DO,2023,4
 134,Makefile,programming,DO,2023,4
 115,Hack,programming,DO,2023,4
+3976,HTML,markup,DZ,2023,4
+3617,CSS,markup,DZ,2023,4
+550,SCSS,markup,DZ,2023,4
+486,Jupyter Notebook,markup,DZ,2023,4
+229,Blade,markup,DZ,2023,4
+168,Vue,markup,DZ,2023,4
 3484,JavaScript,programming,DZ,2023,4
 1604,Python,programming,DZ,2023,4
 941,TypeScript,programming,DZ,2023,4
@@ -94840,6 +98684,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,Assembly,programming,DZ,2023,4
 141,C#,programming,DZ,2023,4
 115,PowerShell,programming,DZ,2023,4
+6559,HTML,markup,EC,2023,4
+5405,CSS,markup,EC,2023,4
+1316,SCSS,markup,EC,2023,4
+612,Jupyter Notebook,markup,EC,2023,4
+355,Blade,markup,EC,2023,4
+261,Vue,markup,EC,2023,4
+147,Less,markup,EC,2023,4
+139,TeX,markup,EC,2023,4
+115,Handlebars,markup,EC,2023,4
+107,EJS,markup,EC,2023,4
 5494,JavaScript,programming,EC,2023,4
 2401,Java,programming,EC,2023,4
 2258,Python,programming,EC,2023,4
@@ -94851,9 +98705,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 687,C++,programming,EC,2023,4
 632,C,programming,EC,2023,4
 587,Kotlin,programming,EC,2023,4
-386,Swift,programming,EC,2023,4
-386,Objective-C,programming,EC,2023,4
 386,Hack,programming,EC,2023,4
+386,Objective-C,programming,EC,2023,4
+386,Swift,programming,EC,2023,4
 366,Makefile,programming,EC,2023,4
 365,CMake,programming,EC,2023,4
 348,Dart,programming,EC,2023,4
@@ -94864,6 +98718,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Papyrus,programming,EC,2023,4
 115,Procfile,programming,EC,2023,4
 105,R,programming,EC,2023,4
+3562,HTML,markup,EE,2023,4
+2862,CSS,markup,EE,2023,4
+619,SCSS,markup,EE,2023,4
+425,Vue,markup,EE,2023,4
+404,Jupyter Notebook,markup,EE,2023,4
+150,EJS,markup,EE,2023,4
 3167,JavaScript,programming,EE,2023,4
 1724,Python,programming,EE,2023,4
 1462,Shell,programming,EE,2023,4
@@ -94888,6 +98748,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,Perl,programming,EE,2023,4
 123,Hack,programming,EE,2023,4
 101,PLpgSQL,programming,EE,2023,4
+26374,HTML,markup,EG,2023,4
+21629,CSS,markup,EG,2023,4
+4747,SCSS,markup,EG,2023,4
+3661,Jupyter Notebook,markup,EG,2023,4
+1840,Blade,markup,EG,2023,4
+992,Vue,markup,EG,2023,4
+616,Less,markup,EG,2023,4
+531,EJS,markup,EG,2023,4
+369,Roff,markup,EG,2023,4
+356,Handlebars,markup,EG,2023,4
+308,TeX,markup,EG,2023,4
+273,Pug,markup,EG,2023,4
+157,Rich Text Format,markup,EG,2023,4
+116,Sass,markup,EG,2023,4
+102,Svelte,markup,EG,2023,4
 20983,JavaScript,programming,EG,2023,4
 9368,C,programming,EG,2023,4
 9067,Python,programming,EG,2023,4
@@ -94937,6 +98812,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,Vim Script,programming,EG,2023,4
 103,PLpgSQL,programming,EG,2023,4
 102,CoffeeScript,programming,EG,2023,4
+108,YAML,data,ES,2023,4
+47213,HTML,markup,ES,2023,4
+38708,CSS,markup,ES,2023,4
+9652,SCSS,markup,ES,2023,4
+7419,Jupyter Notebook,markup,ES,2023,4
+2319,Vue,markup,ES,2023,4
+1552,TeX,markup,ES,2023,4
+1443,Blade,markup,ES,2023,4
+1412,Roff,markup,ES,2023,4
+1016,Less,markup,ES,2023,4
+905,Astro,markup,ES,2023,4
+898,Handlebars,markup,ES,2023,4
+855,Jinja,markup,ES,2023,4
+837,EJS,markup,ES,2023,4
+636,Mustache,markup,ES,2023,4
+624,Svelte,markup,ES,2023,4
+523,Twig,markup,ES,2023,4
+425,Rich Text Format,markup,ES,2023,4
+406,Sass,markup,ES,2023,4
+381,Pug,markup,ES,2023,4
+130,PostScript,markup,ES,2023,4
+124,Nunjucks,markup,ES,2023,4
+104,Liquid,markup,ES,2023,4
 39789,JavaScript,programming,ES,2023,4
 25971,Python,programming,ES,2023,4
 18501,Shell,programming,ES,2023,4
@@ -94994,8 +98892,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 427,Emacs Lisp,programming,ES,2023,4
 419,Julia,programming,ES,2023,4
 418,Cython,programming,ES,2023,4
-411,Clojure,programming,ES,2023,4
 411,Mako,programming,ES,2023,4
+411,Clojure,programming,ES,2023,4
 402,GDScript,programming,ES,2023,4
 395,Smalltalk,programming,ES,2023,4
 390,Yacc,programming,ES,2023,4
@@ -95015,9 +98913,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 305,F#,programming,ES,2023,4
 300,NSIS,programming,ES,2023,4
 299,Ada,programming,ES,2023,4
+294,GAP,programming,ES,2023,4
 294,AppleScript,programming,ES,2023,4
 294,Pawn,programming,ES,2023,4
-294,GAP,programming,ES,2023,4
 287,Standard ML,programming,ES,2023,4
 279,Zig,programming,ES,2023,4
 275,Nim,programming,ES,2023,4
@@ -95030,67 +98928,76 @@ num_pushers,language,language_type,iso2_code,year,quarter
 239,Elm,programming,ES,2023,4
 236,sed,programming,ES,2023,4
 233,ActionScript,programming,ES,2023,4
-231,Jasmin,programming,ES,2023,4
 231,Racket,programming,ES,2023,4
+231,Jasmin,programming,ES,2023,4
 227,Rebol,programming,ES,2023,4
 225,Haxe,programming,ES,2023,4
-222,xBase,programming,ES,2023,4
 222,ABAP,programming,ES,2023,4
+222,xBase,programming,ES,2023,4
 221,Crystal,programming,ES,2023,4
-220,NewLisp,programming,ES,2023,4
 220,V,programming,ES,2023,4
+220,NewLisp,programming,ES,2023,4
 220,AL,programming,ES,2023,4
 219,Limbo,programming,ES,2023,4
 218,Brainfuck,programming,ES,2023,4
 216,Vala,programming,ES,2023,4
 210,Lasso,programming,ES,2023,4
-208,Arc,programming,ES,2023,4
 208,Mercury,programming,ES,2023,4
+208,Arc,programming,ES,2023,4
 204,CWeb,programming,ES,2023,4
 201,Red,programming,ES,2023,4
 201,Eiffel,programming,ES,2023,4
-200,VHDL,programming,ES,2023,4
 200,Turing,programming,ES,2023,4
+200,VHDL,programming,ES,2023,4
 199,Hy,programming,ES,2023,4
-197,LiveScript,programming,ES,2023,4
 197,LOLCODE,programming,ES,2023,4
 197,Alloy,programming,ES,2023,4
+197,LiveScript,programming,ES,2023,4
 196,Boo,programming,ES,2023,4
 196,Agda,programming,ES,2023,4
-195,NASL,programming,ES,2023,4
-195,HolyC,programming,ES,2023,4
-195,Idris,programming,ES,2023,4
-195,Cool,programming,ES,2023,4
-195,Dylan,programming,ES,2023,4
 195,Witcher Script,programming,ES,2023,4
+195,NASL,programming,ES,2023,4
+195,Dylan,programming,ES,2023,4
+195,Cool,programming,ES,2023,4
+195,Idris,programming,ES,2023,4
+195,HolyC,programming,ES,2023,4
+194,Fantom,programming,ES,2023,4
 194,Pony,programming,ES,2023,4
 194,Genie,programming,ES,2023,4
 194,Grace,programming,ES,2023,4
 194,Modula-2,programming,ES,2023,4
-194,Fantom,programming,ES,2023,4
-193,Befunge,programming,ES,2023,4
-193,Ioke,programming,ES,2023,4
 193,Self,programming,ES,2023,4
+193,Ioke,programming,ES,2023,4
+193,Befunge,programming,ES,2023,4
+192,Chapel,programming,ES,2023,4
 192,Ceylon,programming,ES,2023,4
 192,Ballerina,programming,ES,2023,4
 192,Nit,programming,ES,2023,4
-192,Chapel,programming,ES,2023,4
 186,FreeMarker,programming,ES,2023,4
 185,ANTLR,programming,ES,2023,4
 180,SWIG,programming,ES,2023,4
 180,Verilog,programming,ES,2023,4
 171,Jsonnet,programming,ES,2023,4
-167,PureBasic,programming,ES,2023,4
 167,Gnuplot,programming,ES,2023,4
-148,Papyrus,programming,ES,2023,4
+167,PureBasic,programming,ES,2023,4
 148,DIGITAL Command Language,programming,ES,2023,4
-138,SourcePawn,programming,ES,2023,4
+148,Papyrus,programming,ES,2023,4
 138,Processing,programming,ES,2023,4
+138,SourcePawn,programming,ES,2023,4
 138,QML,programming,ES,2023,4
 137,Inno Setup,programming,ES,2023,4
 136,M,programming,ES,2023,4
 129,SmPL,programming,ES,2023,4
 123,Bicep,programming,ES,2023,4
+124,Markdown,prose,ES,2023,4
+4883,HTML,markup,ET,2023,4
+4223,CSS,markup,ET,2023,4
+655,SCSS,markup,ET,2023,4
+467,Jupyter Notebook,markup,ET,2023,4
+188,Blade,markup,ET,2023,4
+147,EJS,markup,ET,2023,4
+136,Vue,markup,ET,2023,4
+103,Roff,markup,ET,2023,4
 4329,JavaScript,programming,ET,2023,4
 2559,Python,programming,ET,2023,4
 1611,Shell,programming,ET,2023,4
@@ -95109,14 +99016,46 @@ num_pushers,language,language_type,iso2_code,year,quarter
 455,CMake,programming,ET,2023,4
 284,Makefile,programming,ET,2023,4
 222,C#,programming,ET,2023,4
-199,Batchfile,programming,ET,2023,4
 199,Puppet,programming,ET,2023,4
+199,Batchfile,programming,ET,2023,4
 178,Hack,programming,ET,2023,4
 165,PowerShell,programming,ET,2023,4
 125,Brainfuck,programming,ET,2023,4
 116,Go,programming,ET,2023,4
 110,Procfile,programming,ET,2023,4
 109,MATLAB,programming,ET,2023,4
+601,YAML,data,EU,2023,4
+422,JSON,data,EU,2023,4
+443508,HTML,markup,EU,2023,4
+372717,CSS,markup,EU,2023,4
+103259,SCSS,markup,EU,2023,4
+73021,Jupyter Notebook,markup,EU,2023,4
+29440,Vue,markup,EU,2023,4
+22695,TeX,markup,EU,2023,4
+20001,Roff,markup,EU,2023,4
+11592,Jinja,markup,EU,2023,4
+10999,Blade,markup,EU,2023,4
+10302,Less,markup,EU,2023,4
+9632,Handlebars,markup,EU,2023,4
+9031,Twig,markup,EU,2023,4
+8413,Svelte,markup,EU,2023,4
+8154,EJS,markup,EU,2023,4
+7161,Mustache,markup,EU,2023,4
+4652,Rich Text Format,markup,EU,2023,4
+4366,Astro,markup,EU,2023,4
+3798,Sass,markup,EU,2023,4
+3769,Pug,markup,EU,2023,4
+1243,Liquid,markup,EU,2023,4
+1167,PostScript,markup,EU,2023,4
+906,Vim Snippet,markup,EU,2023,4
+896,Nunjucks,markup,EU,2023,4
+617,Stylus,markup,EU,2023,4
+344,Haml,markup,EU,2023,4
+302,Mermaid,markup,EU,2023,4
+218,Latte,markup,EU,2023,4
+133,Slim,markup,EU,2023,4
+115,YASnippet,markup,EU,2023,4
+104,kvlang,markup,EU,2023,4
 401502,JavaScript,programming,EU,2023,4
 293265,Python,programming,EU,2023,4
 233267,Shell,programming,EU,2023,4
@@ -95256,8 +99195,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 379,WebAssembly,programming,EU,2023,4
 378,Brainfuck,programming,EU,2023,4
 372,Puppet,programming,EU,2023,4
-363,Vala,programming,EU,2023,4
 363,G-code,programming,EU,2023,4
+363,Vala,programming,EU,2023,4
 362,Racket,programming,EU,2023,4
 356,NewLisp,programming,EU,2023,4
 354,Thrift,programming,EU,2023,4
@@ -95274,45 +99213,45 @@ num_pushers,language,language_type,iso2_code,year,quarter
 242,BitBake,programming,EU,2023,4
 222,xBase,programming,EU,2023,4
 221,CAP CDS,programming,EU,2023,4
-220,V,programming,EU,2023,4
 220,AL,programming,EU,2023,4
+220,V,programming,EU,2023,4
 210,Lasso,programming,EU,2023,4
 208,Mercury,programming,EU,2023,4
 208,Arc,programming,EU,2023,4
 204,CWeb,programming,EU,2023,4
 203,Coq,programming,EU,2023,4
-201,Eiffel,programming,EU,2023,4
 201,Red,programming,EU,2023,4
+201,Eiffel,programming,EU,2023,4
 200,Turing,programming,EU,2023,4
 199,Hy,programming,EU,2023,4
 199,RenderScript,programming,EU,2023,4
 198,Nextflow,programming,EU,2023,4
+197,LiveScript,programming,EU,2023,4
 197,Alloy,programming,EU,2023,4
 197,LOLCODE,programming,EU,2023,4
-197,LiveScript,programming,EU,2023,4
-196,Boo,programming,EU,2023,4
 196,Agda,programming,EU,2023,4
+196,Boo,programming,EU,2023,4
+195,HolyC,programming,EU,2023,4
+195,Cool,programming,EU,2023,4
 195,Idris,programming,EU,2023,4
 195,Witcher Script,programming,EU,2023,4
-195,Cool,programming,EU,2023,4
-195,HolyC,programming,EU,2023,4
 195,Dylan,programming,EU,2023,4
-194,Pony,programming,EU,2023,4
+194,Fantom,programming,EU,2023,4
+194,Genie,programming,EU,2023,4
 194,Modula-2,programming,EU,2023,4
 194,Grace,programming,EU,2023,4
-194,Genie,programming,EU,2023,4
-194,Fantom,programming,EU,2023,4
-193,Self,programming,EU,2023,4
+194,Pony,programming,EU,2023,4
 193,Ioke,programming,EU,2023,4
 193,Befunge,programming,EU,2023,4
-192,Chapel,programming,EU,2023,4
-192,Nit,programming,EU,2023,4
+193,Self,programming,EU,2023,4
 192,Ceylon,programming,EU,2023,4
 192,Ballerina,programming,EU,2023,4
+192,Chapel,programming,EU,2023,4
+192,Nit,programming,EU,2023,4
 173,Cap'n Proto,programming,EU,2023,4
 162,Module Management System,programming,EU,2023,4
-160,Xtend,programming,EU,2023,4
 160,AGS Script,programming,EU,2023,4
+160,Xtend,programming,EU,2023,4
 156,EmberScript,programming,EU,2023,4
 150,Max,programming,EU,2023,4
 150,SAS,programming,EU,2023,4
@@ -95332,6 +99271,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,VBA,programming,EU,2023,4
 102,Qt Script,programming,EU,2023,4
 101,Terra,programming,EU,2023,4
+997,Markdown,prose,EU,2023,4
+11464,HTML,markup,FI,2023,4
+9596,CSS,markup,FI,2023,4
+1952,SCSS,markup,FI,2023,4
+1529,Jupyter Notebook,markup,FI,2023,4
+506,Roff,markup,FI,2023,4
+458,TeX,markup,FI,2023,4
+424,Vue,markup,FI,2023,4
+299,Jinja,markup,FI,2023,4
+244,Svelte,markup,FI,2023,4
+243,Less,markup,FI,2023,4
+186,Handlebars,markup,FI,2023,4
+169,EJS,markup,FI,2023,4
+157,Pug,markup,FI,2023,4
+138,Mustache,markup,FI,2023,4
+113,Rich Text Format,markup,FI,2023,4
+104,Blade,markup,FI,2023,4
 10667,JavaScript,programming,FI,2023,4
 7741,Python,programming,FI,2023,4
 5764,Shell,programming,FI,2023,4
@@ -95391,6 +99347,34 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,Cuda,programming,FI,2023,4
 114,Fortran,programming,FI,2023,4
 108,Gherkin,programming,FI,2023,4
+186,YAML,data,FR,2023,4
+163,JSON,data,FR,2023,4
+75392,HTML,markup,FR,2023,4
+66811,CSS,markup,FR,2023,4
+20014,SCSS,markup,FR,2023,4
+12119,Jupyter Notebook,markup,FR,2023,4
+5872,Vue,markup,FR,2023,4
+4909,Twig,markup,FR,2023,4
+3700,TeX,markup,FR,2023,4
+3261,Roff,markup,FR,2023,4
+1909,Less,markup,FR,2023,4
+1885,Jinja,markup,FR,2023,4
+1614,Handlebars,markup,FR,2023,4
+1610,Blade,markup,FR,2023,4
+1425,EJS,markup,FR,2023,4
+1314,Svelte,markup,FR,2023,4
+1154,Mustache,markup,FR,2023,4
+828,Sass,markup,FR,2023,4
+736,Pug,markup,FR,2023,4
+736,Rich Text Format,markup,FR,2023,4
+714,Astro,markup,FR,2023,4
+279,PostScript,markup,FR,2023,4
+254,Nunjucks,markup,FR,2023,4
+213,Stylus,markup,FR,2023,4
+204,Liquid,markup,FR,2023,4
+197,Vim Snippet,markup,FR,2023,4
+125,Haml,markup,FR,2023,4
+123,Mermaid,markup,FR,2023,4
 68844,JavaScript,programming,FR,2023,4
 45349,Python,programming,FR,2023,4
 37367,Shell,programming,FR,2023,4
@@ -95456,8 +99440,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 595,Scheme,programming,FR,2023,4
 570,NASL,programming,FR,2023,4
 566,Julia,programming,FR,2023,4
-545,Pascal,programming,FR,2023,4
 545,Raku,programming,FR,2023,4
+545,Pascal,programming,FR,2023,4
 510,TSQL,programming,FR,2023,4
 504,PLSQL,programming,FR,2023,4
 497,Inno Setup,programming,FR,2023,4
@@ -95475,10 +99459,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 400,Clojure,programming,FR,2023,4
 395,SourcePawn,programming,FR,2023,4
 379,VHDL,programming,FR,2023,4
-375,ASP.NET,programming,FR,2023,4
 375,SWIG,programming,FR,2023,4
-361,SmPL,programming,FR,2023,4
+375,ASP.NET,programming,FR,2023,4
 361,D,programming,FR,2023,4
+361,SmPL,programming,FR,2023,4
 353,QML,programming,FR,2023,4
 310,VBScript,programming,FR,2023,4
 309,CoffeeScript,programming,FR,2023,4
@@ -95498,31 +99482,31 @@ num_pushers,language,language_type,iso2_code,year,quarter
 196,Ada,programming,FR,2023,4
 192,Visual Basic .NET,programming,FR,2023,4
 183,CUE,programming,FR,2023,4
-182,LLVM,programming,FR,2023,4
 182,POV-Ray SDL,programming,FR,2023,4
+182,LLVM,programming,FR,2023,4
 178,DTrace,programming,FR,2023,4
 176,Visual Basic 6.0,programming,FR,2023,4
 174,Reason,programming,FR,2023,4
 168,XS,programming,FR,2023,4
 167,AutoHotkey,programming,FR,2023,4
-162,RobotFramework,programming,FR,2023,4
 162,Bicep,programming,FR,2023,4
+162,RobotFramework,programming,FR,2023,4
 155,Sage,programming,FR,2023,4
 153,Scilab,programming,FR,2023,4
 150,AIDL,programming,FR,2023,4
 148,PureScript,programming,FR,2023,4
-146,UnrealScript,programming,FR,2023,4
 146,Fluent,programming,FR,2023,4
+146,UnrealScript,programming,FR,2023,4
 142,SystemVerilog,programming,FR,2023,4
 140,Elm,programming,FR,2023,4
 139,Metal,programming,FR,2023,4
 139,OpenEdge ABL,programming,FR,2023,4
-136,Stata,programming,FR,2023,4
 136,Elvish,programming,FR,2023,4
-135,Jasmin,programming,FR,2023,4
+136,Stata,programming,FR,2023,4
 135,jq,programming,FR,2023,4
-131,Puppet,programming,FR,2023,4
+135,Jasmin,programming,FR,2023,4
 131,Thrift,programming,FR,2023,4
+131,Puppet,programming,FR,2023,4
 129,OpenSCAD,programming,FR,2023,4
 124,Cairo,programming,FR,2023,4
 121,JetBrains MPS,programming,FR,2023,4
@@ -95531,11 +99515,45 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,G-code,programming,FR,2023,4
 112,Haxe,programming,FR,2023,4
 111,ASL,programming,FR,2023,4
-110,WebAssembly,programming,FR,2023,4
 110,COBOL,programming,FR,2023,4
+110,WebAssembly,programming,FR,2023,4
 108,ActionScript,programming,FR,2023,4
 107,Logos,programming,FR,2023,4
+233,Markdown,prose,FR,2023,4
+156,HTML,markup,GA,2023,4
+133,CSS,markup,GA,2023,4
 131,JavaScript,programming,GA,2023,4
+212,YAML,data,GB,2023,4
+185,JSON,data,GB,2023,4
+77011,HTML,markup,GB,2023,4
+63210,CSS,markup,GB,2023,4
+18852,SCSS,markup,GB,2023,4
+16901,Jupyter Notebook,markup,GB,2023,4
+4393,TeX,markup,GB,2023,4
+3471,Vue,markup,GB,2023,4
+3401,Roff,markup,GB,2023,4
+2172,Jinja,markup,GB,2023,4
+1886,Handlebars,markup,GB,2023,4
+1849,EJS,markup,GB,2023,4
+1636,Less,markup,GB,2023,4
+1501,Nunjucks,markup,GB,2023,4
+1447,Blade,markup,GB,2023,4
+1388,Mustache,markup,GB,2023,4
+1373,Svelte,markup,GB,2023,4
+1070,Rich Text Format,markup,GB,2023,4
+868,Astro,markup,GB,2023,4
+800,Pug,markup,GB,2023,4
+654,Sass,markup,GB,2023,4
+512,Twig,markup,GB,2023,4
+374,Liquid,markup,GB,2023,4
+348,PostScript,markup,GB,2023,4
+270,Vim Snippet,markup,GB,2023,4
+217,Stylus,markup,GB,2023,4
+190,Mermaid,markup,GB,2023,4
+153,Haml,markup,GB,2023,4
+126,RAML,markup,GB,2023,4
+123,Slim,markup,GB,2023,4
+114,YASnippet,markup,GB,2023,4
 70316,JavaScript,programming,GB,2023,4
 58588,Python,programming,GB,2023,4
 43575,Shell,programming,GB,2023,4
@@ -95624,8 +99642,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 401,OCaml,programming,GB,2023,4
 399,Inno Setup,programming,GB,2023,4
 395,SmPL,programming,GB,2023,4
-389,Pawn,programming,GB,2023,4
 389,Gnuplot,programming,GB,2023,4
+389,Pawn,programming,GB,2023,4
 380,D,programming,GB,2023,4
 379,Open Policy Agent,programming,GB,2023,4
 373,DIGITAL Command Language,programming,GB,2023,4
@@ -95650,16 +99668,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 244,XS,programming,GB,2023,4
 239,Stata,programming,GB,2023,4
 222,QML,programming,GB,2023,4
+211,CUE,programming,GB,2023,4
 211,POV-Ray SDL,programming,GB,2023,4
 211,WebAssembly,programming,GB,2023,4
-211,CUE,programming,GB,2023,4
 210,Puppet,programming,GB,2023,4
 210,ASL,programming,GB,2023,4
 206,Processing,programming,GB,2023,4
 198,Reason,programming,GB,2023,4
 196,Scilab,programming,GB,2023,4
-188,Thrift,programming,GB,2023,4
 188,Ada,programming,GB,2023,4
+188,Thrift,programming,GB,2023,4
 181,PureScript,programming,GB,2023,4
 176,AIDL,programming,GB,2023,4
 175,Visual Basic 6.0,programming,GB,2023,4
@@ -95673,8 +99691,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,Module Management System,programming,GB,2023,4
 149,OpenEdge ABL,programming,GB,2023,4
 148,Logos,programming,GB,2023,4
-141,SAS,programming,GB,2023,4
 141,G-code,programming,GB,2023,4
+141,SAS,programming,GB,2023,4
 138,RPC,programming,GB,2023,4
 137,RobotFramework,programming,GB,2023,4
 136,RenderScript,programming,GB,2023,4
@@ -95687,16 +99705,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,SuperCollider,programming,GB,2023,4
 119,Rebol,programming,GB,2023,4
 117,Apex,programming,GB,2023,4
-112,Racket,programming,GB,2023,4
 112,Cap'n Proto,programming,GB,2023,4
+112,Racket,programming,GB,2023,4
 109,ActionScript,programming,GB,2023,4
 108,VCL,programming,GB,2023,4
 106,q,programming,GB,2023,4
 105,Brainfuck,programming,GB,2023,4
 104,Lean,programming,GB,2023,4
-103,Haxe,programming,GB,2023,4
 103,JetBrains MPS,programming,GB,2023,4
+103,Haxe,programming,GB,2023,4
 101,Max,programming,GB,2023,4
+288,Markdown,prose,GB,2023,4
+5890,HTML,markup,GE,2023,4
+5042,CSS,markup,GE,2023,4
+1251,SCSS,markup,GE,2023,4
+332,Vue,markup,GE,2023,4
+284,Jupyter Notebook,markup,GE,2023,4
+203,Blade,markup,GE,2023,4
 5060,JavaScript,programming,GE,2023,4
 2165,TypeScript,programming,GE,2023,4
 2052,Python,programming,GE,2023,4
@@ -95724,6 +99749,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,ShaderLab,programming,GE,2023,4
 105,Dart,programming,GE,2023,4
 101,Assembly,programming,GE,2023,4
+5873,HTML,markup,GH,2023,4
+5382,CSS,markup,GH,2023,4
+914,SCSS,markup,GH,2023,4
+709,Jupyter Notebook,markup,GH,2023,4
+270,Blade,markup,GH,2023,4
+211,Vue,markup,GH,2023,4
+141,EJS,markup,GH,2023,4
 5158,JavaScript,programming,GH,2023,4
 2578,Python,programming,GH,2023,4
 2063,Shell,programming,GH,2023,4
@@ -95752,8 +99784,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,MATLAB,programming,GH,2023,4
 119,Solidity,programming,GH,2023,4
 108,M,programming,GH,2023,4
+107,HTML,markup,GM,2023,4
 104,JavaScript,programming,GM,2023,4
+131,HTML,markup,GN,2023,4
+121,CSS,markup,GN,2023,4
 102,JavaScript,programming,GN,2023,4
+5569,HTML,markup,GR,2023,4
+4600,CSS,markup,GR,2023,4
+1114,SCSS,markup,GR,2023,4
+1094,Jupyter Notebook,markup,GR,2023,4
+281,TeX,markup,GR,2023,4
+259,Roff,markup,GR,2023,4
+257,Vue,markup,GR,2023,4
+152,Blade,markup,GR,2023,4
+134,EJS,markup,GR,2023,4
+131,Less,markup,GR,2023,4
+129,Handlebars,markup,GR,2023,4
+126,Jinja,markup,GR,2023,4
 4937,JavaScript,programming,GR,2023,4
 3854,Python,programming,GR,2023,4
 2802,Shell,programming,GR,2023,4
@@ -95773,8 +99820,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 332,PowerShell,programming,GR,2023,4
 325,Lua,programming,GR,2023,4
 287,Objective-C,programming,GR,2023,4
-279,Perl,programming,GR,2023,4
 279,Assembly,programming,GR,2023,4
+279,Perl,programming,GR,2023,4
 265,Swift,programming,GR,2023,4
 262,Rust,programming,GR,2023,4
 223,MATLAB,programming,GR,2023,4
@@ -95784,16 +99831,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 163,HCL,programming,GR,2023,4
 147,Vim Script,programming,GR,2023,4
 143,GLSL,programming,GR,2023,4
-139,HLSL,programming,GR,2023,4
 139,Procfile,programming,GR,2023,4
+139,HLSL,programming,GR,2023,4
 138,Dart,programming,GR,2023,4
 138,XSLT,programming,GR,2023,4
 129,M4,programming,GR,2023,4
-116,ShaderLab,programming,GR,2023,4
 116,Nix,programming,GR,2023,4
+116,ShaderLab,programming,GR,2023,4
 111,Solidity,programming,GR,2023,4
 103,PLpgSQL,programming,GR,2023,4
 101,Yacc,programming,GR,2023,4
+3363,HTML,markup,GT,2023,4
+2926,CSS,markup,GT,2023,4
+636,SCSS,markup,GT,2023,4
+283,Blade,markup,GT,2023,4
+242,Jupyter Notebook,markup,GT,2023,4
+150,Vue,markup,GT,2023,4
 2996,JavaScript,programming,GT,2023,4
 1416,Python,programming,GT,2023,4
 1136,Java,programming,GT,2023,4
@@ -95815,6 +99868,28 @@ num_pushers,language,language_type,iso2_code,year,quarter
 112,Ruby,programming,GT,2023,4
 108,PowerShell,programming,GT,2023,4
 103,Assembly,programming,GT,2023,4
+43888,HTML,markup,HK,2023,4
+32842,CSS,markup,HK,2023,4
+12595,SCSS,markup,HK,2023,4
+9291,Vue,markup,HK,2023,4
+7180,Jupyter Notebook,markup,HK,2023,4
+4802,Less,markup,HK,2023,4
+2993,Roff,markup,HK,2023,4
+2323,TeX,markup,HK,2023,4
+1654,EJS,markup,HK,2023,4
+1141,Mustache,markup,HK,2023,4
+1064,Jinja,markup,HK,2023,4
+1019,Handlebars,markup,HK,2023,4
+981,Stylus,markup,HK,2023,4
+549,Pug,markup,HK,2023,4
+498,Rich Text Format,markup,HK,2023,4
+464,Astro,markup,HK,2023,4
+462,Svelte,markup,HK,2023,4
+438,Vim Snippet,markup,HK,2023,4
+326,Blade,markup,HK,2023,4
+324,Sass,markup,HK,2023,4
+199,PostScript,markup,HK,2023,4
+199,Nunjucks,markup,HK,2023,4
 43180,JavaScript,programming,HK,2023,4
 34939,Python,programming,HK,2023,4
 34344,Shell,programming,HK,2023,4
@@ -95882,8 +99957,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 481,XS,programming,HK,2023,4
 470,Hack,programming,HK,2023,4
 444,Meson,programming,HK,2023,4
-439,Fortran,programming,HK,2023,4
 439,SWIG,programming,HK,2023,4
+439,Fortran,programming,HK,2023,4
 439,TSQL,programming,HK,2023,4
 414,GAP,programming,HK,2023,4
 394,PLSQL,programming,HK,2023,4
@@ -95924,8 +99999,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 179,Prolog,programming,HK,2023,4
 177,AMPL,programming,HK,2023,4
 172,Erlang,programming,HK,2023,4
-164,WebAssembly,programming,HK,2023,4
 164,GDScript,programming,HK,2023,4
+164,WebAssembly,programming,HK,2023,4
 163,AutoHotkey,programming,HK,2023,4
 162,Zig,programming,HK,2023,4
 159,OCaml,programming,HK,2023,4
@@ -95935,8 +100010,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Nim,programming,HK,2023,4
 136,Fluent,programming,HK,2023,4
 132,Ada,programming,HK,2023,4
-130,Ragel,programming,HK,2023,4
 130,Stata,programming,HK,2023,4
+130,Ragel,programming,HK,2023,4
 129,AspectJ,programming,HK,2023,4
 129,ReScript,programming,HK,2023,4
 128,Standard ML,programming,HK,2023,4
@@ -95947,12 +100022,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Scilab,programming,HK,2023,4
 115,Visual Basic 6.0,programming,HK,2023,4
 112,Module Management System,programming,HK,2023,4
-111,Brainfuck,programming,HK,2023,4
 111,Logos,programming,HK,2023,4
+111,Brainfuck,programming,HK,2023,4
 106,Vala,programming,HK,2023,4
 105,CUE,programming,HK,2023,4
 104,Open Policy Agent,programming,HK,2023,4
 103,MLIR,programming,HK,2023,4
+234,Markdown,prose,HK,2023,4
+1345,HTML,markup,HN,2023,4
+1248,CSS,markup,HN,2023,4
+215,SCSS,markup,HN,2023,4
+165,Blade,markup,HN,2023,4
+102,Less,markup,HN,2023,4
 1306,JavaScript,programming,HN,2023,4
 375,Java,programming,HN,2023,4
 368,TypeScript,programming,HN,2023,4
@@ -95966,6 +100047,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Dockerfile,programming,HN,2023,4
 109,Kotlin,programming,HN,2023,4
 106,CMake,programming,HN,2023,4
+3804,HTML,markup,HR,2023,4
+3364,CSS,markup,HR,2023,4
+807,SCSS,markup,HR,2023,4
+338,Jupyter Notebook,markup,HR,2023,4
+236,Vue,markup,HR,2023,4
+132,TeX,markup,HR,2023,4
+128,EJS,markup,HR,2023,4
+110,Blade,markup,HR,2023,4
+104,Roff,markup,HR,2023,4
 3664,JavaScript,programming,HR,2023,4
 1709,Python,programming,HR,2023,4
 1524,TypeScript,programming,HR,2023,4
@@ -95991,8 +100081,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,Assembly,programming,HR,2023,4
 122,Hack,programming,HR,2023,4
 114,Perl,programming,HR,2023,4
+260,HTML,markup,HT,2023,4
+239,CSS,markup,HT,2023,4
 220,JavaScript,programming,HT,2023,4
 131,Python,programming,HT,2023,4
+9230,HTML,markup,HU,2023,4
+7789,CSS,markup,HU,2023,4
+1537,SCSS,markup,HU,2023,4
+931,Jupyter Notebook,markup,HU,2023,4
+449,Vue,markup,HU,2023,4
+428,Blade,markup,HU,2023,4
+300,Roff,markup,HU,2023,4
+266,TeX,markup,HU,2023,4
+214,Svelte,markup,HU,2023,4
+189,EJS,markup,HU,2023,4
+161,Handlebars,markup,HU,2023,4
+155,Less,markup,HU,2023,4
+152,Mustache,markup,HU,2023,4
+128,Jinja,markup,HU,2023,4
 7767,JavaScript,programming,HU,2023,4
 4759,Python,programming,HU,2023,4
 3239,Shell,programming,HU,2023,4
@@ -96025,18 +100131,38 @@ num_pushers,language,language_type,iso2_code,year,quarter
 211,HCL,programming,HU,2023,4
 200,ShaderLab,programming,HU,2023,4
 179,Vim Script,programming,HU,2023,4
-174,Nix,programming,HU,2023,4
 174,Gherkin,programming,HU,2023,4
+174,Nix,programming,HU,2023,4
 164,Objective-C++,programming,HU,2023,4
 156,M4,programming,HU,2023,4
-147,Groovy,programming,HU,2023,4
 147,R,programming,HU,2023,4
+147,Groovy,programming,HU,2023,4
 141,MATLAB,programming,HU,2023,4
 117,Procfile,programming,HU,2023,4
 116,PLpgSQL,programming,HU,2023,4
 110,Awk,programming,HU,2023,4
-109,Haskell,programming,HU,2023,4
 109,Yacc,programming,HU,2023,4
+109,Haskell,programming,HU,2023,4
+88048,HTML,markup,ID,2023,4
+81215,CSS,markup,ID,2023,4
+19301,SCSS,markup,ID,2023,4
+19106,Blade,markup,ID,2023,4
+11905,Jupyter Notebook,markup,ID,2023,4
+5148,Vue,markup,ID,2023,4
+4144,Less,markup,ID,2023,4
+1884,EJS,markup,ID,2023,4
+1172,Handlebars,markup,ID,2023,4
+1045,Roff,markup,ID,2023,4
+642,Pug,markup,ID,2023,4
+615,Svelte,markup,ID,2023,4
+568,TeX,markup,ID,2023,4
+519,Astro,markup,ID,2023,4
+471,Stylus,markup,ID,2023,4
+324,Sass,markup,ID,2023,4
+268,Rich Text Format,markup,ID,2023,4
+266,Jinja,markup,ID,2023,4
+166,Mustache,markup,ID,2023,4
+123,Twig,markup,ID,2023,4
 83540,JavaScript,programming,ID,2023,4
 38952,PHP,programming,ID,2023,4
 26447,Python,programming,ID,2023,4
@@ -96086,8 +100212,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 347,HCL,programming,ID,2023,4
 345,Yacc,programming,ID,2023,4
 327,Vim Script,programming,ID,2023,4
-324,Clojure,programming,ID,2023,4
 324,Mako,programming,ID,2023,4
+324,Clojure,programming,ID,2023,4
 312,Forth,programming,ID,2023,4
 297,Lex,programming,ID,2023,4
 295,Raku,programming,ID,2023,4
@@ -96121,6 +100247,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 109,Haskell,programming,ID,2023,4
 105,Julia,programming,ID,2023,4
 104,Inno Setup,programming,ID,2023,4
+121,Markdown,prose,ID,2023,4
+8713,HTML,markup,IE,2023,4
+7266,CSS,markup,IE,2023,4
+1670,Jupyter Notebook,markup,IE,2023,4
+1533,SCSS,markup,IE,2023,4
+341,Roff,markup,IE,2023,4
+297,Vue,markup,IE,2023,4
+291,TeX,markup,IE,2023,4
+204,Jinja,markup,IE,2023,4
+196,Handlebars,markup,IE,2023,4
+192,EJS,markup,IE,2023,4
+185,Less,markup,IE,2023,4
+156,Mustache,markup,IE,2023,4
+128,Blade,markup,IE,2023,4
+106,Svelte,markup,IE,2023,4
 7599,JavaScript,programming,IE,2023,4
 5838,Python,programming,IE,2023,4
 3981,Shell,programming,IE,2023,4
@@ -96170,6 +100311,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,MATLAB,programming,IE,2023,4
 108,Cython,programming,IE,2023,4
 103,Yacc,programming,IE,2023,4
+13582,HTML,markup,IL,2023,4
+10927,CSS,markup,IL,2023,4
+2702,SCSS,markup,IL,2023,4
+1911,Jupyter Notebook,markup,IL,2023,4
+529,Roff,markup,IL,2023,4
+502,Vue,markup,IL,2023,4
+485,EJS,markup,IL,2023,4
+397,Jinja,markup,IL,2023,4
+352,Handlebars,markup,IL,2023,4
+350,Mustache,markup,IL,2023,4
+302,TeX,markup,IL,2023,4
+236,Less,markup,IL,2023,4
+186,Pug,markup,IL,2023,4
+172,Rich Text Format,markup,IL,2023,4
+141,Svelte,markup,IL,2023,4
 12813,JavaScript,programming,IL,2023,4
 10022,Python,programming,IL,2023,4
 6714,Shell,programming,IL,2023,4
@@ -96227,6 +100383,38 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,ASP.NET,programming,IL,2023,4
 105,Meson,programming,IL,2023,4
 104,Jsonnet,programming,IL,2023,4
+186,YAML,data,IN,2023,4
+168,JSON,data,IN,2023,4
+519219,HTML,markup,IN,2023,4
+427824,CSS,markup,IN,2023,4
+101843,Jupyter Notebook,markup,IN,2023,4
+57304,SCSS,markup,IN,2023,4
+19118,EJS,markup,IN,2023,4
+9262,Roff,markup,IN,2023,4
+7779,Vue,markup,IN,2023,4
+7413,Less,markup,IN,2023,4
+6236,Handlebars,markup,IN,2023,4
+5714,Blade,markup,IN,2023,4
+4932,TeX,markup,IN,2023,4
+4130,Pug,markup,IN,2023,4
+3839,Jinja,markup,IN,2023,4
+2711,Mustache,markup,IN,2023,4
+2683,Svelte,markup,IN,2023,4
+2201,Rich Text Format,markup,IN,2023,4
+1659,Astro,markup,IN,2023,4
+1388,PostScript,markup,IN,2023,4
+1367,Sass,markup,IN,2023,4
+631,Liquid,markup,IN,2023,4
+579,Twig,markup,IN,2023,4
+454,Stylus,markup,IN,2023,4
+280,kvlang,markup,IN,2023,4
+258,Tea,markup,IN,2023,4
+253,Vim Snippet,markup,IN,2023,4
+233,Nunjucks,markup,IN,2023,4
+193,RAML,markup,IN,2023,4
+177,Mermaid,markup,IN,2023,4
+153,Haml,markup,IN,2023,4
+118,Slim,markup,IN,2023,4
 414185,JavaScript,programming,IN,2023,4
 225618,Python,programming,IN,2023,4
 132735,Java,programming,IN,2023,4
@@ -96320,8 +100508,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1220,BASIC,programming,IN,2023,4
 1183,Standard ML,programming,IN,2023,4
 1168,AppleScript,programming,IN,2023,4
-1114,FreeMarker,programming,IN,2023,4
 1114,Squirrel,programming,IN,2023,4
+1114,FreeMarker,programming,IN,2023,4
 1105,Factor,programming,IN,2023,4
 1054,M,programming,IN,2023,4
 1019,Haxe,programming,IN,2023,4
@@ -96344,8 +100532,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 669,Classic ASP,programming,IN,2023,4
 667,DTrace,programming,IN,2023,4
 657,Mercury,programming,IN,2023,4
-656,SmPL,programming,IN,2023,4
 656,XS,programming,IN,2023,4
+656,SmPL,programming,IN,2023,4
 648,Jsonnet,programming,IN,2023,4
 642,FreeBasic,programming,IN,2023,4
 592,HiveQL,programming,IN,2023,4
@@ -96374,25 +100562,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 351,OpenEdge ABL,programming,IN,2023,4
 338,Limbo,programming,IN,2023,4
 334,Logos,programming,IN,2023,4
-332,Ballerina,programming,IN,2023,4
 332,VHDL,programming,IN,2023,4
+332,Ballerina,programming,IN,2023,4
 324,GDScript,programming,IN,2023,4
 322,Gnuplot,programming,IN,2023,4
 300,LiveScript,programming,IN,2023,4
 296,QML,programming,IN,2023,4
-290,E,programming,IN,2023,4
 290,SourcePawn,programming,IN,2023,4
+290,E,programming,IN,2023,4
 289,Puppet,programming,IN,2023,4
 279,Modula-3,programming,IN,2023,4
 276,Chapel,programming,IN,2023,4
 274,APL,programming,IN,2023,4
 273,Ring,programming,IN,2023,4
-269,ActionScript,programming,IN,2023,4
 269,Pony,programming,IN,2023,4
+269,ActionScript,programming,IN,2023,4
 265,TLA,programming,IN,2023,4
 247,Pawn,programming,IN,2023,4
-241,GSC,programming,IN,2023,4
 241,CAP CDS,programming,IN,2023,4
+241,GSC,programming,IN,2023,4
 235,Vyper,programming,IN,2023,4
 229,jq,programming,IN,2023,4
 222,Metal,programming,IN,2023,4
@@ -96409,13 +100597,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 153,Objective-J,programming,IN,2023,4
 151,POV-Ray SDL,programming,IN,2023,4
 143,ASL,programming,IN,2023,4
-141,LookML,programming,IN,2023,4
 141,CUE,programming,IN,2023,4
+141,LookML,programming,IN,2023,4
 133,Cadence,programming,IN,2023,4
 130,RenderScript,programming,IN,2023,4
 128,RPC,programming,IN,2023,4
-125,VCL,programming,IN,2023,4
 125,Reason,programming,IN,2023,4
+125,VCL,programming,IN,2023,4
 120,AutoIt,programming,IN,2023,4
 119,Xonsh,programming,IN,2023,4
 118,Io,programming,IN,2023,4
@@ -96423,6 +100611,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,AspectJ,programming,IN,2023,4
 114,BitBake,programming,IN,2023,4
 104,Coq,programming,IN,2023,4
+419,Markdown,prose,IN,2023,4
+1528,HTML,markup,IQ,2023,4
+1253,CSS,markup,IQ,2023,4
+171,SCSS,markup,IQ,2023,4
+122,Blade,markup,IQ,2023,4
+101,Vue,markup,IQ,2023,4
 1253,JavaScript,programming,IQ,2023,4
 688,Python,programming,IQ,2023,4
 329,Shell,programming,IQ,2023,4
@@ -96440,6 +100634,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,Java,programming,IQ,2023,4
 132,Ruby,programming,IQ,2023,4
 113,C#,programming,IQ,2023,4
+11872,HTML,markup,IR,2023,4
+10160,CSS,markup,IR,2023,4
+2660,SCSS,markup,IR,2023,4
+2108,Jupyter Notebook,markup,IR,2023,4
+754,Blade,markup,IR,2023,4
+680,Vue,markup,IR,2023,4
+490,Less,markup,IR,2023,4
+234,TeX,markup,IR,2023,4
+177,Roff,markup,IR,2023,4
+157,EJS,markup,IR,2023,4
+115,Handlebars,markup,IR,2023,4
 10360,JavaScript,programming,IR,2023,4
 6716,Python,programming,IR,2023,4
 3143,TypeScript,programming,IR,2023,4
@@ -96473,6 +100678,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,R,programming,IR,2023,4
 106,Smalltalk,programming,IR,2023,4
 106,Gherkin,programming,IR,2023,4
+786,HTML,markup,IS,2023,4
+666,CSS,markup,IS,2023,4
+255,SCSS,markup,IS,2023,4
+110,Jupyter Notebook,markup,IS,2023,4
 731,JavaScript,programming,IS,2023,4
 529,Python,programming,IS,2023,4
 410,Shell,programming,IS,2023,4
@@ -96485,6 +100694,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Ruby,programming,IS,2023,4
 110,C#,programming,IS,2023,4
 107,Objective-C,programming,IS,2023,4
+25917,HTML,markup,IT,2023,4
+21174,CSS,markup,IT,2023,4
+6290,SCSS,markup,IT,2023,4
+6109,Jupyter Notebook,markup,IT,2023,4
+1973,Vue,markup,IT,2023,4
+1948,TeX,markup,IT,2023,4
+1334,Roff,markup,IT,2023,4
+1071,Blade,markup,IT,2023,4
+619,Jinja,markup,IT,2023,4
+589,Less,markup,IT,2023,4
+552,Rich Text Format,markup,IT,2023,4
+510,Handlebars,markup,IT,2023,4
+475,Svelte,markup,IT,2023,4
+422,EJS,markup,IT,2023,4
+401,Mustache,markup,IT,2023,4
+296,Astro,markup,IT,2023,4
+240,Sass,markup,IT,2023,4
+229,Pug,markup,IT,2023,4
+186,Twig,markup,IT,2023,4
+120,PostScript,markup,IT,2023,4
+104,Liquid,markup,IT,2023,4
 22564,JavaScript,programming,IT,2023,4
 18938,Python,programming,IT,2023,4
 13738,Shell,programming,IT,2023,4
@@ -96523,8 +100753,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 539,HLSL,programming,IT,2023,4
 484,ShaderLab,programming,IT,2023,4
 455,PLpgSQL,programming,IT,2023,4
-437,Fortran,programming,IT,2023,4
 437,Awk,programming,IT,2023,4
+437,Fortran,programming,IT,2023,4
 436,Solidity,programming,IT,2023,4
 435,Procfile,programming,IT,2023,4
 433,Emacs Lisp,programming,IT,2023,4
@@ -96545,12 +100775,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 249,Julia,programming,IT,2023,4
 242,NSIS,programming,IT,2023,4
 237,Pascal,programming,IT,2023,4
-233,Mathematica,programming,IT,2023,4
 233,NASL,programming,IT,2023,4
+233,Mathematica,programming,IT,2023,4
 231,GDB,programming,IT,2023,4
 228,Haskell,programming,IT,2023,4
-217,ANTLR,programming,IT,2023,4
 217,PLSQL,programming,IT,2023,4
+217,ANTLR,programming,IT,2023,4
 210,Raku,programming,IT,2023,4
 209,Scheme,programming,IT,2023,4
 203,FreeMarker,programming,IT,2023,4
@@ -96564,8 +100794,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 168,GDScript,programming,IT,2023,4
 166,Forth,programming,IT,2023,4
 164,OCaml,programming,IT,2023,4
-163,Common Lisp,programming,IT,2023,4
 163,GAP,programming,IT,2023,4
+163,Common Lisp,programming,IT,2023,4
 161,Smalltalk,programming,IT,2023,4
 158,PureBasic,programming,IT,2023,4
 158,Inno Setup,programming,IT,2023,4
@@ -96589,11 +100819,18 @@ num_pushers,language,language_type,iso2_code,year,quarter
 102,DIGITAL Command Language,programming,IT,2023,4
 102,POV-Ray SDL,programming,IT,2023,4
 101,AppleScript,programming,IT,2023,4
+601,HTML,markup,JM,2023,4
+569,CSS,markup,JM,2023,4
 543,JavaScript,programming,JM,2023,4
 208,PHP,programming,JM,2023,4
 185,Python,programming,JM,2023,4
 146,Java,programming,JM,2023,4
 132,TypeScript,programming,JM,2023,4
+2515,HTML,markup,JO,2023,4
+2045,CSS,markup,JO,2023,4
+552,SCSS,markup,JO,2023,4
+240,Jupyter Notebook,markup,JO,2023,4
+190,Blade,markup,JO,2023,4
 2109,JavaScript,programming,JO,2023,4
 669,Python,programming,JO,2023,4
 597,Java,programming,JO,2023,4
@@ -96612,6 +100849,35 @@ num_pushers,language,language_type,iso2_code,year,quarter
 205,Ruby,programming,JO,2023,4
 143,Makefile,programming,JO,2023,4
 117,Batchfile,programming,JO,2023,4
+122,YAML,data,JP,2023,4
+116,JSON,data,JP,2023,4
+62090,HTML,markup,JP,2023,4
+51831,CSS,markup,JP,2023,4
+15102,SCSS,markup,JP,2023,4
+7974,Jupyter Notebook,markup,JP,2023,4
+7772,Vue,markup,JP,2023,4
+3205,Blade,markup,JP,2023,4
+2701,Roff,markup,JP,2023,4
+2473,Less,markup,JP,2023,4
+2332,TeX,markup,JP,2023,4
+1557,EJS,markup,JP,2023,4
+1206,Astro,markup,JP,2023,4
+1066,Pug,markup,JP,2023,4
+1043,Jinja,markup,JP,2023,4
+1035,Handlebars,markup,JP,2023,4
+888,Svelte,markup,JP,2023,4
+716,Mustache,markup,JP,2023,4
+668,Stylus,markup,JP,2023,4
+512,Rich Text Format,markup,JP,2023,4
+466,Sass,markup,JP,2023,4
+419,Vim Snippet,markup,JP,2023,4
+288,Haml,markup,JP,2023,4
+237,Nunjucks,markup,JP,2023,4
+210,PostScript,markup,JP,2023,4
+204,Slim,markup,JP,2023,4
+193,Liquid,markup,JP,2023,4
+180,Twig,markup,JP,2023,4
+150,YASnippet,markup,JP,2023,4
 59091,JavaScript,programming,JP,2023,4
 38502,Python,programming,JP,2023,4
 35431,Shell,programming,JP,2023,4
@@ -96736,16 +101002,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,ASL,programming,JP,2023,4
 124,Ragel,programming,JP,2023,4
 124,RPC,programming,JP,2023,4
-119,RenderScript,programming,JP,2023,4
 119,Logos,programming,JP,2023,4
+119,RenderScript,programming,JP,2023,4
 117,Module Management System,programming,JP,2023,4
 114,Fluent,programming,JP,2023,4
 111,Elm,programming,JP,2023,4
-110,Brainfuck,programming,JP,2023,4
 110,VBA,programming,JP,2023,4
+110,Brainfuck,programming,JP,2023,4
 110,Reason,programming,JP,2023,4
 109,OpenEdge ABL,programming,JP,2023,4
 104,Classic ASP,programming,JP,2023,4
+248,Markdown,prose,JP,2023,4
+16054,HTML,markup,KE,2023,4
+14437,CSS,markup,KE,2023,4
+2589,SCSS,markup,KE,2023,4
+2457,Jupyter Notebook,markup,KE,2023,4
+816,Blade,markup,KE,2023,4
+623,Vue,markup,KE,2023,4
+329,Less,markup,KE,2023,4
+323,EJS,markup,KE,2023,4
+277,Roff,markup,KE,2023,4
+199,TeX,markup,KE,2023,4
+194,Handlebars,markup,KE,2023,4
+140,Pug,markup,KE,2023,4
 14261,JavaScript,programming,KE,2023,4
 9506,Python,programming,KE,2023,4
 6857,Shell,programming,KE,2023,4
@@ -96789,6 +101068,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 119,CoffeeScript,programming,KE,2023,4
 118,PLpgSQL,programming,KE,2023,4
 107,TSQL,programming,KE,2023,4
+4122,HTML,markup,KG,2023,4
+3336,CSS,markup,KG,2023,4
+895,SCSS,markup,KG,2023,4
+162,Jupyter Notebook,markup,KG,2023,4
+148,Vue,markup,KG,2023,4
 3113,JavaScript,programming,KG,2023,4
 1667,Python,programming,KG,2023,4
 875,Java,programming,KG,2023,4
@@ -96808,6 +101092,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 214,Ruby,programming,KG,2023,4
 181,Batchfile,programming,KG,2023,4
 180,Makefile,programming,KG,2023,4
+2925,HTML,markup,KH,2023,4
+2377,CSS,markup,KH,2023,4
+534,SCSS,markup,KH,2023,4
+340,Vue,markup,KH,2023,4
+313,Blade,markup,KH,2023,4
+150,Jupyter Notebook,markup,KH,2023,4
 2369,JavaScript,programming,KH,2023,4
 643,Python,programming,KH,2023,4
 614,TypeScript,programming,KH,2023,4
@@ -96827,6 +101117,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 135,Hack,programming,KH,2023,4
 125,Makefile,programming,KH,2023,4
 105,Batchfile,programming,KH,2023,4
+104,YAML,data,KR,2023,4
+73473,HTML,markup,KR,2023,4
+56571,CSS,markup,KR,2023,4
+15112,Jupyter Notebook,markup,KR,2023,4
+14911,SCSS,markup,KR,2023,4
+4310,Vue,markup,KR,2023,4
+2026,EJS,markup,KR,2023,4
+1801,Roff,markup,KR,2023,4
+1450,TeX,markup,KR,2023,4
+1373,Less,markup,KR,2023,4
+997,Pug,markup,KR,2023,4
+940,Mustache,markup,KR,2023,4
+721,Svelte,markup,KR,2023,4
+679,Handlebars,markup,KR,2023,4
+516,Jinja,markup,KR,2023,4
+422,Rich Text Format,markup,KR,2023,4
+389,Vim Snippet,markup,KR,2023,4
+254,Blade,markup,KR,2023,4
+249,Sass,markup,KR,2023,4
+192,Astro,markup,KR,2023,4
+149,Liquid,markup,KR,2023,4
+135,Stylus,markup,KR,2023,4
+115,PostScript,markup,KR,2023,4
 65399,JavaScript,programming,KR,2023,4
 43728,Python,programming,KR,2023,4
 41256,Java,programming,KR,2023,4
@@ -96856,8 +101169,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1519,GLSL,programming,KR,2023,4
 1349,Perl,programming,KR,2023,4
 1346,Lua,programming,KR,2023,4
-1078,R,programming,KR,2023,4
 1078,Smarty,programming,KR,2023,4
+1078,R,programming,KR,2023,4
 956,Procfile,programming,KR,2023,4
 942,HCL,programming,KR,2023,4
 884,Cuda,programming,KR,2023,4
@@ -96898,13 +101211,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 211,XS,programming,KR,2023,4
 208,Ada,programming,KR,2023,4
 207,SmPL,programming,KR,2023,4
-200,Visual Basic .NET,programming,KR,2023,4
 200,NASL,programming,KR,2023,4
+200,Visual Basic .NET,programming,KR,2023,4
 196,Pascal,programming,KR,2023,4
 195,FreeMarker,programming,KR,2023,4
 193,TSQL,programming,KR,2023,4
-188,SWIG,programming,KR,2023,4
 188,QML,programming,KR,2023,4
+188,SWIG,programming,KR,2023,4
 171,UnrealScript,programming,KR,2023,4
 169,ANTLR,programming,KR,2023,4
 162,AIDL,programming,KR,2023,4
@@ -96914,12 +101227,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 140,Pawn,programming,KR,2023,4
 139,SourcePawn,programming,KR,2023,4
 137,Elixir,programming,KR,2023,4
-136,DIGITAL Command Language,programming,KR,2023,4
 136,Common Lisp,programming,KR,2023,4
+136,DIGITAL Command Language,programming,KR,2023,4
 133,Jsonnet,programming,KR,2023,4
 128,CoffeeScript,programming,KR,2023,4
-124,Julia,programming,KR,2023,4
 124,VBScript,programming,KR,2023,4
+124,Julia,programming,KR,2023,4
 123,GDScript,programming,KR,2023,4
 118,Inno Setup,programming,KR,2023,4
 116,Gnuplot,programming,KR,2023,4
@@ -96931,9 +101244,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 105,OCaml,programming,KR,2023,4
 103,BASIC,programming,KR,2023,4
 102,Thrift,programming,KR,2023,4
+177,Markdown,prose,KR,2023,4
+512,HTML,markup,KW,2023,4
+380,CSS,markup,KW,2023,4
 414,JavaScript,programming,KW,2023,4
 229,Python,programming,KW,2023,4
 124,Shell,programming,KW,2023,4
+8222,HTML,markup,KZ,2023,4
+6619,CSS,markup,KZ,2023,4
+1416,SCSS,markup,KZ,2023,4
+800,Jupyter Notebook,markup,KZ,2023,4
+575,Vue,markup,KZ,2023,4
+281,Blade,markup,KZ,2023,4
+170,Less,markup,KZ,2023,4
+166,EJS,markup,KZ,2023,4
+146,Roff,markup,KZ,2023,4
+140,TeX,markup,KZ,2023,4
 6513,JavaScript,programming,KZ,2023,4
 4142,Python,programming,KZ,2023,4
 2349,Java,programming,KZ,2023,4
@@ -96962,8 +101288,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 165,Hack,programming,KZ,2023,4
 138,Rust,programming,KZ,2023,4
 102,Mako,programming,KZ,2023,4
+378,HTML,markup,LA,2023,4
+288,CSS,markup,LA,2023,4
 332,JavaScript,programming,LA,2023,4
 108,TypeScript,programming,LA,2023,4
+2705,HTML,markup,LB,2023,4
+2221,CSS,markup,LB,2023,4
+377,SCSS,markup,LB,2023,4
+217,Blade,markup,LB,2023,4
+199,Jupyter Notebook,markup,LB,2023,4
 2184,JavaScript,programming,LB,2023,4
 892,Python,programming,LB,2023,4
 575,TypeScript,programming,LB,2023,4
@@ -96982,6 +101315,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 145,Ruby,programming,LB,2023,4
 122,Makefile,programming,LB,2023,4
 121,Hack,programming,LB,2023,4
+14714,HTML,markup,LK,2023,4
+12881,CSS,markup,LK,2023,4
+2462,SCSS,markup,LK,2023,4
+1892,Jupyter Notebook,markup,LK,2023,4
+747,Blade,markup,LK,2023,4
+483,Less,markup,LK,2023,4
+437,Vue,markup,LK,2023,4
+262,EJS,markup,LK,2023,4
+237,Handlebars,markup,LK,2023,4
+199,Jinja,markup,LK,2023,4
+135,Roff,markup,LK,2023,4
+126,TeX,markup,LK,2023,4
+110,Mustache,markup,LK,2023,4
 13913,JavaScript,programming,LK,2023,4
 5283,Python,programming,LK,2023,4
 4994,Java,programming,LK,2023,4
@@ -96997,8 +101343,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1380,Nix,programming,LK,2023,4
 1371,Objective-C,programming,LK,2023,4
 1331,Hack,programming,LK,2023,4
-1241,Swift,programming,LK,2023,4
 1241,Dart,programming,LK,2023,4
+1241,Swift,programming,LK,2023,4
 1068,CMake,programming,LK,2023,4
 788,Ruby,programming,LK,2023,4
 728,Batchfile,programming,LK,2023,4
@@ -97021,14 +101367,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 128,HCL,programming,LK,2023,4
 126,PLSQL,programming,LK,2023,4
 121,Scala,programming,LK,2023,4
-111,Pascal,programming,LK,2023,4
 111,Smarty,programming,LK,2023,4
+111,Pascal,programming,LK,2023,4
 108,Tcl,programming,LK,2023,4
 107,Gherkin,programming,LK,2023,4
 106,Fortran,programming,LK,2023,4
 105,ASP.NET,programming,LK,2023,4
 104,SQLPL,programming,LK,2023,4
+126,HTML,markup,LR,2023,4
+115,CSS,markup,LR,2023,4
+160,HTML,markup,LS,2023,4
+135,CSS,markup,LS,2023,4
 110,JavaScript,programming,LS,2023,4
+3868,HTML,markup,LT,2023,4
+3354,CSS,markup,LT,2023,4
+815,SCSS,markup,LT,2023,4
+391,Jupyter Notebook,markup,LT,2023,4
+228,Vue,markup,LT,2023,4
+181,Blade,markup,LT,2023,4
+115,Roff,markup,LT,2023,4
 3580,JavaScript,programming,LT,2023,4
 1745,Python,programming,LT,2023,4
 1443,Shell,programming,LT,2023,4
@@ -97057,6 +101414,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 113,Smarty,programming,LT,2023,4
 104,Hack,programming,LT,2023,4
 101,Objective-C++,programming,LT,2023,4
+832,HTML,markup,LU,2023,4
+660,CSS,markup,LU,2023,4
+249,SCSS,markup,LU,2023,4
+185,Jupyter Notebook,markup,LU,2023,4
 782,JavaScript,programming,LU,2023,4
 656,Python,programming,LU,2023,4
 546,Shell,programming,LU,2023,4
@@ -97069,6 +101430,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 159,PHP,programming,LU,2023,4
 158,Ruby,programming,LU,2023,4
 131,Batchfile,programming,LU,2023,4
+2803,HTML,markup,LV,2023,4
+2217,CSS,markup,LV,2023,4
+532,SCSS,markup,LV,2023,4
+222,Vue,markup,LV,2023,4
+180,Blade,markup,LV,2023,4
+151,Jupyter Notebook,markup,LV,2023,4
 2304,JavaScript,programming,LV,2023,4
 1651,Python,programming,LV,2023,4
 877,Shell,programming,LV,2023,4
@@ -97085,12 +101452,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 185,Ruby,programming,LV,2023,4
 174,CMake,programming,LV,2023,4
 133,Kotlin,programming,LV,2023,4
-119,Lua,programming,LV,2023,4
 119,Rust,programming,LV,2023,4
+119,Lua,programming,LV,2023,4
 107,PowerShell,programming,LV,2023,4
 103,Hack,programming,LV,2023,4
 101,Objective-C,programming,LV,2023,4
+285,HTML,markup,LY,2023,4
+228,CSS,markup,LY,2023,4
 235,JavaScript,programming,LY,2023,4
+12205,HTML,markup,MA,2023,4
+11155,CSS,markup,MA,2023,4
+2174,SCSS,markup,MA,2023,4
+1419,Jupyter Notebook,markup,MA,2023,4
+901,Blade,markup,MA,2023,4
+482,Vue,markup,MA,2023,4
+233,Less,markup,MA,2023,4
+226,EJS,markup,MA,2023,4
+203,Roff,markup,MA,2023,4
+165,Pug,markup,MA,2023,4
+128,Handlebars,markup,MA,2023,4
+114,Twig,markup,MA,2023,4
 10647,JavaScript,programming,MA,2023,4
 5487,Python,programming,MA,2023,4
 4862,Shell,programming,MA,2023,4
@@ -97126,6 +101507,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,Perl,programming,MA,2023,4
 107,R,programming,MA,2023,4
 101,CoffeeScript,programming,MA,2023,4
+2304,HTML,markup,MD,2023,4
+1948,CSS,markup,MD,2023,4
+546,SCSS,markup,MD,2023,4
+145,Vue,markup,MD,2023,4
 2004,JavaScript,programming,MD,2023,4
 829,Python,programming,MD,2023,4
 753,TypeScript,programming,MD,2023,4
@@ -97144,6 +101529,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 115,CMake,programming,MD,2023,4
 104,Swift,programming,MD,2023,4
 103,Objective-C,programming,MD,2023,4
+801,HTML,markup,ME,2023,4
+667,CSS,markup,ME,2023,4
+219,SCSS,markup,ME,2023,4
 804,JavaScript,programming,ME,2023,4
 433,Python,programming,ME,2023,4
 376,Shell,programming,ME,2023,4
@@ -97155,6 +101543,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,C,programming,ME,2023,4
 109,C++,programming,ME,2023,4
 105,PHP,programming,ME,2023,4
+1479,HTML,markup,MG,2023,4
+1429,CSS,markup,MG,2023,4
+449,SCSS,markup,MG,2023,4
+136,Blade,markup,MG,2023,4
+118,Vue,markup,MG,2023,4
 1534,JavaScript,programming,MG,2023,4
 547,Java,programming,MG,2023,4
 478,TypeScript,programming,MG,2023,4
@@ -97166,6 +101559,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 147,Hack,programming,MG,2023,4
 133,C,programming,MG,2023,4
 116,C#,programming,MG,2023,4
+1901,HTML,markup,MK,2023,4
+1611,CSS,markup,MK,2023,4
+327,SCSS,markup,MK,2023,4
+132,Jupyter Notebook,markup,MK,2023,4
 1600,JavaScript,programming,MK,2023,4
 688,Java,programming,MK,2023,4
 614,TypeScript,programming,MK,2023,4
@@ -97179,7 +101576,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,Kotlin,programming,MK,2023,4
 110,Swift,programming,MK,2023,4
 107,CMake,programming,MK,2023,4
+260,HTML,markup,ML,2023,4
+208,CSS,markup,ML,2023,4
 187,JavaScript,programming,ML,2023,4
+3395,HTML,markup,MM,2023,4
+3029,CSS,markup,MM,2023,4
+712,SCSS,markup,MM,2023,4
+632,Blade,markup,MM,2023,4
+297,Vue,markup,MM,2023,4
+117,Jupyter Notebook,markup,MM,2023,4
 2947,JavaScript,programming,MM,2023,4
 936,PHP,programming,MM,2023,4
 822,TypeScript,programming,MM,2023,4
@@ -97190,8 +101595,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 298,Objective-C,programming,MM,2023,4
 294,C++,programming,MM,2023,4
 286,C,programming,MM,2023,4
-282,Swift,programming,MM,2023,4
 282,Dockerfile,programming,MM,2023,4
+282,Swift,programming,MM,2023,4
 257,Dart,programming,MM,2023,4
 243,Ruby,programming,MM,2023,4
 230,CMake,programming,MM,2023,4
@@ -97199,6 +101604,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 155,C#,programming,MM,2023,4
 117,Makefile,programming,MM,2023,4
 115,Batchfile,programming,MM,2023,4
+1367,CSS,markup,MN,2023,4
+1271,HTML,markup,MN,2023,4
+207,SCSS,markup,MN,2023,4
 1315,JavaScript,programming,MN,2023,4
 417,TypeScript,programming,MN,2023,4
 283,Python,programming,MN,2023,4
@@ -97210,10 +101618,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 142,PHP,programming,MN,2023,4
 119,Objective-C,programming,MN,2023,4
 101,Kotlin,programming,MN,2023,4
+290,HTML,markup,MO,2023,4
+221,CSS,markup,MO,2023,4
 255,JavaScript,programming,MO,2023,4
 244,Python,programming,MO,2023,4
 134,Shell,programming,MO,2023,4
+151,HTML,markup,MR,2023,4
+112,CSS,markup,MR,2023,4
 117,JavaScript,programming,MR,2023,4
+544,HTML,markup,MT,2023,4
+476,CSS,markup,MT,2023,4
+120,SCSS,markup,MT,2023,4
 526,JavaScript,programming,MT,2023,4
 252,Python,programming,MT,2023,4
 234,Shell,programming,MT,2023,4
@@ -97222,16 +101637,41 @@ num_pushers,language,language_type,iso2_code,year,quarter
 130,C#,programming,MT,2023,4
 118,Java,programming,MT,2023,4
 107,PHP,programming,MT,2023,4
+529,HTML,markup,MU,2023,4
+448,CSS,markup,MU,2023,4
+127,SCSS,markup,MU,2023,4
 486,JavaScript,programming,MU,2023,4
 190,Python,programming,MU,2023,4
 158,Shell,programming,MU,2023,4
 121,TypeScript,programming,MU,2023,4
 105,Dockerfile,programming,MU,2023,4
+147,HTML,markup,MV,2023,4
+146,CSS,markup,MV,2023,4
 166,JavaScript,programming,MV,2023,4
+422,HTML,markup,MW,2023,4
+362,CSS,markup,MW,2023,4
 381,JavaScript,programming,MW,2023,4
 202,Python,programming,MW,2023,4
 144,Shell,programming,MW,2023,4
 121,C,programming,MW,2023,4
+37226,HTML,markup,MX,2023,4
+32425,CSS,markup,MX,2023,4
+6489,SCSS,markup,MX,2023,4
+4681,Jupyter Notebook,markup,MX,2023,4
+2354,Blade,markup,MX,2023,4
+1764,Vue,markup,MX,2023,4
+780,Less,markup,MX,2023,4
+714,TeX,markup,MX,2023,4
+649,EJS,markup,MX,2023,4
+536,Astro,markup,MX,2023,4
+525,Handlebars,markup,MX,2023,4
+511,Roff,markup,MX,2023,4
+349,Pug,markup,MX,2023,4
+327,Svelte,markup,MX,2023,4
+187,Sass,markup,MX,2023,4
+167,Jinja,markup,MX,2023,4
+165,Rich Text Format,markup,MX,2023,4
+103,Mustache,markup,MX,2023,4
 33350,JavaScript,programming,MX,2023,4
 14929,Python,programming,MX,2023,4
 9106,TypeScript,programming,MX,2023,4
@@ -97270,8 +101710,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 337,Smarty,programming,MX,2023,4
 315,HCL,programming,MX,2023,4
 314,XSLT,programming,MX,2023,4
-300,Nix,programming,MX,2023,4
 300,PLpgSQL,programming,MX,2023,4
+300,Nix,programming,MX,2023,4
 247,Mathematica,programming,MX,2023,4
 244,Solidity,programming,MX,2023,4
 241,Cython,programming,MX,2023,4
@@ -97290,22 +101730,34 @@ num_pushers,language,language_type,iso2_code,year,quarter
 164,Julia,programming,MX,2023,4
 163,CoffeeScript,programming,MX,2023,4
 154,GDScript,programming,MX,2023,4
-145,Elixir,programming,MX,2023,4
 145,Smalltalk,programming,MX,2023,4
+145,Elixir,programming,MX,2023,4
 143,Scheme,programming,MX,2023,4
 142,GAP,programming,MX,2023,4
 135,Yacc,programming,MX,2023,4
 132,Pascal,programming,MX,2023,4
-130,Emacs Lisp,programming,MX,2023,4
 130,Mako,programming,MX,2023,4
-129,M4,programming,MX,2023,4
+130,Emacs Lisp,programming,MX,2023,4
 129,Starlark,programming,MX,2023,4
+129,M4,programming,MX,2023,4
 125,Common Lisp,programming,MX,2023,4
 124,PureBasic,programming,MX,2023,4
 122,Clojure,programming,MX,2023,4
 113,Meson,programming,MX,2023,4
 107,Processing,programming,MX,2023,4
 103,VBScript,programming,MX,2023,4
+10802,HTML,markup,MY,2023,4
+9089,CSS,markup,MY,2023,4
+1995,SCSS,markup,MY,2023,4
+1647,Jupyter Notebook,markup,MY,2023,4
+918,Blade,markup,MY,2023,4
+694,Vue,markup,MY,2023,4
+326,Roff,markup,MY,2023,4
+252,Less,markup,MY,2023,4
+182,EJS,markup,MY,2023,4
+163,Svelte,markup,MY,2023,4
+146,Handlebars,markup,MY,2023,4
+128,TeX,markup,MY,2023,4
 9205,JavaScript,programming,MY,2023,4
 4759,Python,programming,MY,2023,4
 2702,Java,programming,MY,2023,4
@@ -97336,8 +101788,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 203,R,programming,MY,2023,4
 195,Nix,programming,MY,2023,4
 190,HLSL,programming,MY,2023,4
-183,ShaderLab,programming,MY,2023,4
 183,Smarty,programming,MY,2023,4
+183,ShaderLab,programming,MY,2023,4
 168,Objective-C++,programming,MY,2023,4
 150,HCL,programming,MY,2023,4
 140,ASP.NET,programming,MY,2023,4
@@ -97345,14 +101797,35 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Vim Script,programming,MY,2023,4
 104,XSLT,programming,MY,2023,4
 101,Cython,programming,MY,2023,4
+627,HTML,markup,MZ,2023,4
+567,CSS,markup,MZ,2023,4
+127,SCSS,markup,MZ,2023,4
 583,JavaScript,programming,MZ,2023,4
 198,Java,programming,MZ,2023,4
 167,Python,programming,MZ,2023,4
 163,TypeScript,programming,MZ,2023,4
 162,PHP,programming,MZ,2023,4
 135,Shell,programming,MZ,2023,4
+198,HTML,markup,NA,2023,4
+168,CSS,markup,NA,2023,4
 166,JavaScript,programming,NA,2023,4
 136,Ballerina,programming,NA,2023,4
+37598,HTML,markup,NG,2023,4
+34228,CSS,markup,NG,2023,4
+6006,SCSS,markup,NG,2023,4
+3553,Jupyter Notebook,markup,NG,2023,4
+1326,Vue,markup,NG,2023,4
+1207,Blade,markup,NG,2023,4
+1159,EJS,markup,NG,2023,4
+821,Less,markup,NG,2023,4
+496,Handlebars,markup,NG,2023,4
+386,Pug,markup,NG,2023,4
+326,Roff,markup,NG,2023,4
+213,Svelte,markup,NG,2023,4
+176,Astro,markup,NG,2023,4
+175,Jinja,markup,NG,2023,4
+150,TeX,markup,NG,2023,4
+118,Sass,markup,NG,2023,4
 32620,JavaScript,programming,NG,2023,4
 12569,Python,programming,NG,2023,4
 11291,Shell,programming,NG,2023,4
@@ -97399,8 +101872,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,Fortran,programming,NG,2023,4
 117,Groovy,programming,NG,2023,4
 116,Tcl,programming,NG,2023,4
-114,M4,programming,NG,2023,4
 114,Starlark,programming,NG,2023,4
+114,M4,programming,NG,2023,4
+1146,HTML,markup,NI,2023,4
+1057,CSS,markup,NI,2023,4
+228,SCSS,markup,NI,2023,4
 1065,JavaScript,programming,NI,2023,4
 349,C#,programming,NI,2023,4
 306,TypeScript,programming,NI,2023,4
@@ -97411,6 +101887,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,C++,programming,NI,2023,4
 102,Dockerfile,programming,NI,2023,4
 101,Kotlin,programming,NI,2023,4
+30853,HTML,markup,NL,2023,4
+25863,CSS,markup,NL,2023,4
+7482,SCSS,markup,NL,2023,4
+6197,Jupyter Notebook,markup,NL,2023,4
+2308,Vue,markup,NL,2023,4
+1794,TeX,markup,NL,2023,4
+1473,Blade,markup,NL,2023,4
+1454,Roff,markup,NL,2023,4
+1070,Jinja,markup,NL,2023,4
+876,Svelte,markup,NL,2023,4
+794,Less,markup,NL,2023,4
+750,Handlebars,markup,NL,2023,4
+588,Mustache,markup,NL,2023,4
+573,EJS,markup,NL,2023,4
+458,Rich Text Format,markup,NL,2023,4
+450,Twig,markup,NL,2023,4
+307,Astro,markup,NL,2023,4
+277,Sass,markup,NL,2023,4
+261,Pug,markup,NL,2023,4
+166,Liquid,markup,NL,2023,4
+151,Nunjucks,markup,NL,2023,4
+139,PostScript,markup,NL,2023,4
+129,Vim Snippet,markup,NL,2023,4
+104,Stylus,markup,NL,2023,4
 28299,JavaScript,programming,NL,2023,4
 22873,Python,programming,NL,2023,4
 18096,Shell,programming,NL,2023,4
@@ -97499,20 +101999,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 176,Gnuplot,programming,NL,2023,4
 167,Erlang,programming,NL,2023,4
 166,AppleScript,programming,NL,2023,4
-163,SmPL,programming,NL,2023,4
 163,D,programming,NL,2023,4
+163,SmPL,programming,NL,2023,4
 161,Forth,programming,NL,2023,4
 160,DIGITAL Command Language,programming,NL,2023,4
 147,VHDL,programming,NL,2023,4
-138,DTrace,programming,NL,2023,4
 138,Pawn,programming,NL,2023,4
+138,DTrace,programming,NL,2023,4
 137,Visual Basic 6.0,programming,NL,2023,4
-131,VBScript,programming,NL,2023,4
-131,M,programming,NL,2023,4
-131,RobotFramework,programming,NL,2023,4
 131,CoffeeScript,programming,NL,2023,4
-129,Nim,programming,NL,2023,4
+131,RobotFramework,programming,NL,2023,4
+131,M,programming,NL,2023,4
+131,VBScript,programming,NL,2023,4
 129,AutoHotkey,programming,NL,2023,4
+129,Nim,programming,NL,2023,4
 127,Zig,programming,NL,2023,4
 125,OCaml,programming,NL,2023,4
 122,Jsonnet,programming,NL,2023,4
@@ -97523,6 +102023,22 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,AMPL,programming,NL,2023,4
 107,POV-Ray SDL,programming,NL,2023,4
 103,XS,programming,NL,2023,4
+223,Markdown,prose,NL,2023,4
+10573,HTML,markup,NO,2023,4
+9257,CSS,markup,NO,2023,4
+2264,SCSS,markup,NO,2023,4
+1961,Jupyter Notebook,markup,NO,2023,4
+675,TeX,markup,NO,2023,4
+499,Vue,markup,NO,2023,4
+490,Roff,markup,NO,2023,4
+405,Less,markup,NO,2023,4
+366,Svelte,markup,NO,2023,4
+346,Jinja,markup,NO,2023,4
+235,Handlebars,markup,NO,2023,4
+215,EJS,markup,NO,2023,4
+165,Astro,markup,NO,2023,4
+160,Mustache,markup,NO,2023,4
+111,Rich Text Format,markup,NO,2023,4
 9588,JavaScript,programming,NO,2023,4
 7498,Python,programming,NO,2023,4
 5925,Shell,programming,NO,2023,4
@@ -97577,15 +102093,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 125,Yacc,programming,NO,2023,4
 124,Bicep,programming,NO,2023,4
 122,Meson,programming,NO,2023,4
-121,VBScript,programming,NO,2023,4
 121,TSQL,programming,NO,2023,4
+121,VBScript,programming,NO,2023,4
 118,Scala,programming,NO,2023,4
 112,Pascal,programming,NO,2023,4
 111,SourcePawn,programming,NO,2023,4
 110,Starlark,programming,NO,2023,4
-108,Cython,programming,NO,2023,4
 108,Lex,programming,NO,2023,4
+108,Cython,programming,NO,2023,4
 104,Smalltalk,programming,NO,2023,4
+11799,HTML,markup,NP,2023,4
+10376,CSS,markup,NP,2023,4
+1776,SCSS,markup,NP,2023,4
+1370,Jupyter Notebook,markup,NP,2023,4
+586,Blade,markup,NP,2023,4
+332,EJS,markup,NP,2023,4
+319,Vue,markup,NP,2023,4
+210,Less,markup,NP,2023,4
+146,Roff,markup,NP,2023,4
+144,Handlebars,markup,NP,2023,4
+110,TeX,markup,NP,2023,4
 10232,JavaScript,programming,NP,2023,4
 4159,Python,programming,NP,2023,4
 2522,TypeScript,programming,NP,2023,4
@@ -97612,9 +102139,21 @@ num_pushers,language,language_type,iso2_code,year,quarter
 213,Procfile,programming,NP,2023,4
 158,Solidity,programming,NP,2023,4
 144,Assembly,programming,NP,2023,4
-132,Objective-C++,programming,NP,2023,4
 132,Perl,programming,NP,2023,4
+132,Objective-C++,programming,NP,2023,4
 101,Nix,programming,NP,2023,4
+6583,HTML,markup,NZ,2023,4
+5566,CSS,markup,NZ,2023,4
+1433,SCSS,markup,NZ,2023,4
+866,Jupyter Notebook,markup,NZ,2023,4
+318,Vue,markup,NZ,2023,4
+277,TeX,markup,NZ,2023,4
+260,Roff,markup,NZ,2023,4
+204,Svelte,markup,NZ,2023,4
+172,Handlebars,markup,NZ,2023,4
+170,EJS,markup,NZ,2023,4
+148,Less,markup,NZ,2023,4
+145,Jinja,markup,NZ,2023,4
 6199,JavaScript,programming,NZ,2023,4
 3749,Python,programming,NZ,2023,4
 3171,Shell,programming,NZ,2023,4
@@ -97659,10 +102198,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,Groovy,programming,NZ,2023,4
 119,Emacs Lisp,programming,NZ,2023,4
 109,GDScript,programming,NZ,2023,4
+591,HTML,markup,OM,2023,4
+461,CSS,markup,OM,2023,4
+104,Jupyter Notebook,markup,OM,2023,4
 426,JavaScript,programming,OM,2023,4
 271,Python,programming,OM,2023,4
 109,TypeScript,programming,OM,2023,4
 104,PHP,programming,OM,2023,4
+1026,HTML,markup,PA,2023,4
+952,CSS,markup,PA,2023,4
+179,SCSS,markup,PA,2023,4
 931,JavaScript,programming,PA,2023,4
 362,Python,programming,PA,2023,4
 294,PHP,programming,PA,2023,4
@@ -97671,6 +102216,20 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,Shell,programming,PA,2023,4
 133,Hack,programming,PA,2023,4
 127,Dockerfile,programming,PA,2023,4
+15135,HTML,markup,PE,2023,4
+13317,CSS,markup,PE,2023,4
+2999,SCSS,markup,PE,2023,4
+1539,Jupyter Notebook,markup,PE,2023,4
+1094,Blade,markup,PE,2023,4
+835,Vue,markup,PE,2023,4
+393,Less,markup,PE,2023,4
+322,Astro,markup,PE,2023,4
+266,EJS,markup,PE,2023,4
+206,Handlebars,markup,PE,2023,4
+203,TeX,markup,PE,2023,4
+153,Roff,markup,PE,2023,4
+124,Pug,markup,PE,2023,4
+103,Svelte,markup,PE,2023,4
 13361,JavaScript,programming,PE,2023,4
 4954,Java,programming,PE,2023,4
 4535,Python,programming,PE,2023,4
@@ -97701,16 +102260,32 @@ num_pushers,language,language_type,iso2_code,year,quarter
 221,R,programming,PE,2023,4
 175,Assembly,programming,PE,2023,4
 166,Perl,programming,PE,2023,4
-152,ASP.NET,programming,PE,2023,4
 152,Nix,programming,PE,2023,4
+152,ASP.NET,programming,PE,2023,4
 142,Rust,programming,PE,2023,4
-139,Smarty,programming,PE,2023,4
 139,HCL,programming,PE,2023,4
+139,Smarty,programming,PE,2023,4
 128,Objective-C++,programming,PE,2023,4
 110,Vim Script,programming,PE,2023,4
 105,PLpgSQL,programming,PE,2023,4
-102,Cython,programming,PE,2023,4
 102,XSLT,programming,PE,2023,4
+102,Cython,programming,PE,2023,4
+34662,HTML,markup,PH,2023,4
+30921,CSS,markup,PH,2023,4
+5274,SCSS,markup,PH,2023,4
+3174,Blade,markup,PH,2023,4
+1895,Vue,markup,PH,2023,4
+1822,Jupyter Notebook,markup,PH,2023,4
+631,Less,markup,PH,2023,4
+471,EJS,markup,PH,2023,4
+332,Roff,markup,PH,2023,4
+316,Handlebars,markup,PH,2023,4
+236,Svelte,markup,PH,2023,4
+230,TeX,markup,PH,2023,4
+163,Pug,markup,PH,2023,4
+144,Jinja,markup,PH,2023,4
+135,Astro,markup,PH,2023,4
+113,Sass,markup,PH,2023,4
 28107,JavaScript,programming,PH,2023,4
 8780,PHP,programming,PH,2023,4
 7920,Python,programming,PH,2023,4
@@ -97759,6 +102334,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 126,XSLT,programming,PH,2023,4
 118,M4,programming,PH,2023,4
 101,Smalltalk,programming,PH,2023,4
+39405,HTML,markup,PK,2023,4
+33552,CSS,markup,PK,2023,4
+5997,SCSS,markup,PK,2023,4
+5232,Jupyter Notebook,markup,PK,2023,4
+2240,Blade,markup,PK,2023,4
+1170,Vue,markup,PK,2023,4
+886,EJS,markup,PK,2023,4
+749,Less,markup,PK,2023,4
+473,Handlebars,markup,PK,2023,4
+384,Pug,markup,PK,2023,4
+323,Roff,markup,PK,2023,4
+292,TeX,markup,PK,2023,4
+197,Jinja,markup,PK,2023,4
+146,Rich Text Format,markup,PK,2023,4
+143,Liquid,markup,PK,2023,4
+143,Mustache,markup,PK,2023,4
+140,Svelte,markup,PK,2023,4
+138,Sass,markup,PK,2023,4
+108,Astro,markup,PK,2023,4
 36028,JavaScript,programming,PK,2023,4
 12039,Python,programming,PK,2023,4
 9238,TypeScript,programming,PK,2023,4
@@ -97815,6 +102409,26 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,Haskell,programming,PK,2023,4
 105,Mako,programming,PK,2023,4
 104,SystemVerilog,programming,PK,2023,4
+39498,HTML,markup,PL,2023,4
+32490,CSS,markup,PL,2023,4
+9577,SCSS,markup,PL,2023,4
+4662,Jupyter Notebook,markup,PL,2023,4
+2305,Vue,markup,PL,2023,4
+1202,Roff,markup,PL,2023,4
+982,TeX,markup,PL,2023,4
+869,Blade,markup,PL,2023,4
+814,Jinja,markup,PL,2023,4
+768,Less,markup,PL,2023,4
+758,Twig,markup,PL,2023,4
+746,Handlebars,markup,PL,2023,4
+703,EJS,markup,PL,2023,4
+567,Svelte,markup,PL,2023,4
+500,Mustache,markup,PL,2023,4
+345,Sass,markup,PL,2023,4
+337,Astro,markup,PL,2023,4
+307,Pug,markup,PL,2023,4
+290,Rich Text Format,markup,PL,2023,4
+108,Liquid,markup,PL,2023,4
 35513,JavaScript,programming,PL,2023,4
 23550,Python,programming,PL,2023,4
 16940,Shell,programming,PL,2023,4
@@ -97850,8 +102464,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 874,Vim Script,programming,PL,2023,4
 805,R,programming,PL,2023,4
 787,Procfile,programming,PL,2023,4
-773,Groovy,programming,PL,2023,4
 773,Gherkin,programming,PL,2023,4
+773,Groovy,programming,PL,2023,4
 642,M4,programming,PL,2023,4
 633,PLpgSQL,programming,PL,2023,4
 623,Scala,programming,PL,2023,4
@@ -97881,12 +102495,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 267,Pascal,programming,PL,2023,4
 256,SmPL,programming,PL,2023,4
 247,Scheme,programming,PL,2023,4
-242,NSIS,programming,PL,2023,4
 242,Raku,programming,PL,2023,4
+242,NSIS,programming,PL,2023,4
 241,Mathematica,programming,PL,2023,4
 239,GAP,programming,PL,2023,4
-233,Verilog,programming,PL,2023,4
 233,SourcePawn,programming,PL,2023,4
+233,Verilog,programming,PL,2023,4
 227,Forth,programming,PL,2023,4
 222,ANTLR,programming,PL,2023,4
 213,Clojure,programming,PL,2023,4
@@ -97898,8 +102512,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,QML,programming,PL,2023,4
 170,FreeMarker,programming,PL,2023,4
 169,Pawn,programming,PL,2023,4
-168,RobotFramework,programming,PL,2023,4
 168,PureBasic,programming,PL,2023,4
+168,RobotFramework,programming,PL,2023,4
 156,Inno Setup,programming,PL,2023,4
 150,F#,programming,PL,2023,4
 146,Common Lisp,programming,PL,2023,4
@@ -97913,14 +102527,16 @@ num_pushers,language,language_type,iso2_code,year,quarter
 120,VHDL,programming,PL,2023,4
 119,CoffeeScript,programming,PL,2023,4
 117,AutoHotkey,programming,PL,2023,4
-116,Bicep,programming,PL,2023,4
 116,SWIG,programming,PL,2023,4
+116,Bicep,programming,PL,2023,4
 113,Standard ML,programming,PL,2023,4
 112,AIDL,programming,PL,2023,4
 112,DIGITAL Command Language,programming,PL,2023,4
 109,AppleScript,programming,PL,2023,4
 106,LLVM,programming,PL,2023,4
 102,UnrealScript,programming,PL,2023,4
+648,HTML,markup,PR,2023,4
+575,CSS,markup,PR,2023,4
 567,JavaScript,programming,PR,2023,4
 388,Python,programming,PR,2023,4
 330,Shell,programming,PR,2023,4
@@ -97929,6 +102545,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,C++,programming,PR,2023,4
 105,Dockerfile,programming,PR,2023,4
 104,C#,programming,PR,2023,4
+1699,HTML,markup,PS,2023,4
+1513,CSS,markup,PS,2023,4
+213,SCSS,markup,PS,2023,4
+160,Blade,markup,PS,2023,4
 1534,JavaScript,programming,PS,2023,4
 486,Java,programming,PS,2023,4
 349,Python,programming,PS,2023,4
@@ -97945,6 +102565,24 @@ num_pushers,language,language_type,iso2_code,year,quarter
 149,Dockerfile,programming,PS,2023,4
 130,C#,programming,PS,2023,4
 114,Gherkin,programming,PS,2023,4
+12172,HTML,markup,PT,2023,4
+10640,CSS,markup,PT,2023,4
+2462,SCSS,markup,PT,2023,4
+2023,Jupyter Notebook,markup,PT,2023,4
+720,Vue,markup,PT,2023,4
+537,Roff,markup,PT,2023,4
+518,TeX,markup,PT,2023,4
+382,Blade,markup,PT,2023,4
+334,Handlebars,markup,PT,2023,4
+268,Less,markup,PT,2023,4
+246,Svelte,markup,PT,2023,4
+244,EJS,markup,PT,2023,4
+241,Jinja,markup,PT,2023,4
+183,Mustache,markup,PT,2023,4
+166,Sass,markup,PT,2023,4
+141,Pug,markup,PT,2023,4
+123,Astro,markup,PT,2023,4
+114,Rich Text Format,markup,PT,2023,4
 11562,JavaScript,programming,PT,2023,4
 7189,Python,programming,PT,2023,4
 5879,Shell,programming,PT,2023,4
@@ -97964,8 +102602,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 789,Rust,programming,PT,2023,4
 755,Objective-C,programming,PT,2023,4
 739,Lua,programming,PT,2023,4
-711,PowerShell,programming,PT,2023,4
 711,Swift,programming,PT,2023,4
+711,PowerShell,programming,PT,2023,4
 539,Perl,programming,PT,2023,4
 514,Assembly,programming,PT,2023,4
 417,Dart,programming,PT,2023,4
@@ -97994,26 +102632,34 @@ num_pushers,language,language_type,iso2_code,year,quarter
 175,Starlark,programming,PT,2023,4
 158,Emacs Lisp,programming,PT,2023,4
 155,Scala,programming,PT,2023,4
-142,Scheme,programming,PT,2023,4
 142,Elixir,programming,PT,2023,4
+142,Scheme,programming,PT,2023,4
 141,Yacc,programming,PT,2023,4
 120,GDScript,programming,PT,2023,4
 118,ASP.NET,programming,PT,2023,4
-111,Lex,programming,PT,2023,4
 111,Tcl,programming,PT,2023,4
+111,Lex,programming,PT,2023,4
 108,Mako,programming,PT,2023,4
 106,Mathematica,programming,PT,2023,4
+1386,HTML,markup,PY,2023,4
+1192,CSS,markup,PY,2023,4
+247,SCSS,markup,PY,2023,4
+111,Jupyter Notebook,markup,PY,2023,4
 1308,JavaScript,programming,PY,2023,4
 572,Python,programming,PY,2023,4
 354,TypeScript,programming,PY,2023,4
 323,Java,programming,PY,2023,4
 314,Shell,programming,PY,2023,4
-261,PHP,programming,PY,2023,4
 261,Dockerfile,programming,PY,2023,4
+261,PHP,programming,PY,2023,4
 145,C,programming,PY,2023,4
 122,C++,programming,PY,2023,4
 106,Ruby,programming,PY,2023,4
 102,C#,programming,PY,2023,4
+691,HTML,markup,QA,2023,4
+553,CSS,markup,QA,2023,4
+163,Jupyter Notebook,markup,QA,2023,4
+117,SCSS,markup,QA,2023,4
 580,JavaScript,programming,QA,2023,4
 431,Python,programming,QA,2023,4
 246,Shell,programming,QA,2023,4
@@ -98021,8 +102667,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 152,Dockerfile,programming,QA,2023,4
 115,Java,programming,QA,2023,4
 113,C,programming,QA,2023,4
+294,HTML,markup,RE,2023,4
+276,CSS,markup,RE,2023,4
 291,JavaScript,programming,RE,2023,4
 115,Python,programming,RE,2023,4
+12129,HTML,markup,RO,2023,4
+10306,CSS,markup,RO,2023,4
+2334,SCSS,markup,RO,2023,4
+956,Jupyter Notebook,markup,RO,2023,4
+520,Vue,markup,RO,2023,4
+352,Roff,markup,RO,2023,4
+299,Blade,markup,RO,2023,4
+256,EJS,markup,RO,2023,4
+255,Less,markup,RO,2023,4
+222,TeX,markup,RO,2023,4
+214,Handlebars,markup,RO,2023,4
+158,Jinja,markup,RO,2023,4
+148,Svelte,markup,RO,2023,4
+131,Twig,markup,RO,2023,4
+114,Rich Text Format,markup,RO,2023,4
+107,Mustache,markup,RO,2023,4
+102,Pug,markup,RO,2023,4
 10820,JavaScript,programming,RO,2023,4
 6146,Python,programming,RO,2023,4
 4616,Java,programming,RO,2023,4
@@ -98076,6 +102741,17 @@ num_pushers,language,language_type,iso2_code,year,quarter
 104,ASP.NET,programming,RO,2023,4
 103,Haskell,programming,RO,2023,4
 101,Scala,programming,RO,2023,4
+6744,HTML,markup,RS,2023,4
+5807,CSS,markup,RS,2023,4
+1559,SCSS,markup,RS,2023,4
+534,Jupyter Notebook,markup,RS,2023,4
+389,Vue,markup,RS,2023,4
+364,Blade,markup,RS,2023,4
+162,Roff,markup,RS,2023,4
+153,Less,markup,RS,2023,4
+136,TeX,markup,RS,2023,4
+122,Handlebars,markup,RS,2023,4
+102,Jinja,markup,RS,2023,4
 6200,JavaScript,programming,RS,2023,4
 2701,Python,programming,RS,2023,4
 2698,TypeScript,programming,RS,2023,4
@@ -98109,8 +102785,34 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,Objective-C++,programming,RS,2023,4
 119,ShaderLab,programming,RS,2023,4
 117,Vim Script,programming,RS,2023,4
-103,ASP.NET,programming,RS,2023,4
 103,Gherkin,programming,RS,2023,4
+103,ASP.NET,programming,RS,2023,4
+92753,HTML,markup,RU,2023,4
+71858,CSS,markup,RU,2023,4
+18664,SCSS,markup,RU,2023,4
+14370,Jupyter Notebook,markup,RU,2023,4
+6472,Vue,markup,RU,2023,4
+2585,Roff,markup,RU,2023,4
+2512,TeX,markup,RU,2023,4
+2395,Blade,markup,RU,2023,4
+2136,Less,markup,RU,2023,4
+1520,Jinja,markup,RU,2023,4
+1352,Sass,markup,RU,2023,4
+1050,Handlebars,markup,RU,2023,4
+886,Pug,markup,RU,2023,4
+774,EJS,markup,RU,2023,4
+726,Svelte,markup,RU,2023,4
+681,Rich Text Format,markup,RU,2023,4
+525,Twig,markup,RU,2023,4
+434,Mustache,markup,RU,2023,4
+276,Stylus,markup,RU,2023,4
+215,Astro,markup,RU,2023,4
+211,PostScript,markup,RU,2023,4
+153,kvlang,markup,RU,2023,4
+142,Vim Snippet,markup,RU,2023,4
+127,Liquid,markup,RU,2023,4
+120,Nunjucks,markup,RU,2023,4
+118,Slim,markup,RU,2023,4
 71880,JavaScript,programming,RU,2023,4
 70078,Python,programming,RU,2023,4
 29850,Java,programming,RU,2023,4
@@ -98148,8 +102850,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1230,M4,programming,RU,2023,4
 1229,Procfile,programming,RU,2023,4
 1083,Vim Script,programming,RU,2023,4
-1032,XSLT,programming,RU,2023,4
 1032,Nix,programming,RU,2023,4
+1032,XSLT,programming,RU,2023,4
 1016,Awk,programming,RU,2023,4
 951,Smalltalk,programming,RU,2023,4
 948,Pascal,programming,RU,2023,4
@@ -98186,8 +102888,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 382,NSIS,programming,RU,2023,4
 355,Inno Setup,programming,RU,2023,4
 339,1C Enterprise,programming,RU,2023,4
-325,Forth,programming,RU,2023,4
 325,DM,programming,RU,2023,4
+325,Forth,programming,RU,2023,4
 324,SourcePawn,programming,RU,2023,4
 315,Scheme,programming,RU,2023,4
 309,Fluent,programming,RU,2023,4
@@ -98213,25 +102915,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 180,Ren'Py,programming,RU,2023,4
 179,Elixir,programming,RU,2023,4
 178,UnrealScript,programming,RU,2023,4
-177,Standard ML,programming,RU,2023,4
 177,CoffeeScript,programming,RU,2023,4
+177,Standard ML,programming,RU,2023,4
 170,Visual Basic .NET,programming,RU,2023,4
 166,AMPL,programming,RU,2023,4
-163,OCaml,programming,RU,2023,4
 163,Jsonnet,programming,RU,2023,4
+163,OCaml,programming,RU,2023,4
 158,Erlang,programming,RU,2023,4
 155,AppleScript,programming,RU,2023,4
 146,VHDL,programming,RU,2023,4
 145,AutoHotkey,programming,RU,2023,4
-130,Module Management System,programming,RU,2023,4
 130,M,programming,RU,2023,4
+130,Module Management System,programming,RU,2023,4
 124,G-code,programming,RU,2023,4
 119,Metal,programming,RU,2023,4
 117,Processing,programming,RU,2023,4
 111,Nim,programming,RU,2023,4
-106,Ada,programming,RU,2023,4
 106,ASL,programming,RU,2023,4
+106,Ada,programming,RU,2023,4
 101,SAS,programming,RU,2023,4
+2327,HTML,markup,RW,2023,4
+2140,CSS,markup,RW,2023,4
+370,SCSS,markup,RW,2023,4
+191,Jupyter Notebook,markup,RW,2023,4
+108,Blade,markup,RW,2023,4
 2119,JavaScript,programming,RW,2023,4
 1045,Python,programming,RW,2023,4
 933,Shell,programming,RW,2023,4
@@ -98249,6 +102956,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,Hack,programming,RW,2023,4
 104,Swift,programming,RW,2023,4
 101,Batchfile,programming,RW,2023,4
+5768,HTML,markup,SA,2023,4
+4598,CSS,markup,SA,2023,4
+1246,Jupyter Notebook,markup,SA,2023,4
+815,SCSS,markup,SA,2023,4
+246,Blade,markup,SA,2023,4
+156,EJS,markup,SA,2023,4
+150,Vue,markup,SA,2023,4
+107,TeX,markup,SA,2023,4
 4295,JavaScript,programming,SA,2023,4
 2591,Python,programming,SA,2023,4
 1542,Java,programming,SA,2023,4
@@ -98273,11 +102988,33 @@ num_pushers,language,language_type,iso2_code,year,quarter
 161,Procfile,programming,SA,2023,4
 131,Lua,programming,SA,2023,4
 122,Go,programming,SA,2023,4
+304,HTML,markup,SD,2023,4
+264,CSS,markup,SD,2023,4
 268,Shell,programming,SD,2023,4
 263,JavaScript,programming,SD,2023,4
 248,C,programming,SD,2023,4
 191,Python,programming,SD,2023,4
 126,Assembly,programming,SD,2023,4
+19189,HTML,markup,SE,2023,4
+16621,CSS,markup,SE,2023,4
+4086,SCSS,markup,SE,2023,4
+2781,Jupyter Notebook,markup,SE,2023,4
+981,Vue,markup,SE,2023,4
+980,TeX,markup,SE,2023,4
+976,Roff,markup,SE,2023,4
+591,Jinja,markup,SE,2023,4
+475,Svelte,markup,SE,2023,4
+407,Handlebars,markup,SE,2023,4
+351,Less,markup,SE,2023,4
+312,Mustache,markup,SE,2023,4
+299,EJS,markup,SE,2023,4
+230,Rich Text Format,markup,SE,2023,4
+184,Twig,markup,SE,2023,4
+183,Astro,markup,SE,2023,4
+157,Blade,markup,SE,2023,4
+156,Pug,markup,SE,2023,4
+152,Sass,markup,SE,2023,4
+107,Vim Snippet,markup,SE,2023,4
 17939,JavaScript,programming,SE,2023,4
 12584,Python,programming,SE,2023,4
 10418,Shell,programming,SE,2023,4
@@ -98351,8 +103088,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 163,Prolog,programming,SE,2023,4
 162,Common Lisp,programming,SE,2023,4
 152,Raku,programming,SE,2023,4
-146,AutoHotkey,programming,SE,2023,4
 146,ASP.NET,programming,SE,2023,4
+146,AutoHotkey,programming,SE,2023,4
 145,F#,programming,SE,2023,4
 140,Solidity,programming,SE,2023,4
 132,Verilog,programming,SE,2023,4
@@ -98368,9 +103105,29 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,GAP,programming,SE,2023,4
 111,VHDL,programming,SE,2023,4
 108,DIGITAL Command Language,programming,SE,2023,4
-104,Forth,programming,SE,2023,4
 104,OCaml,programming,SE,2023,4
+104,Forth,programming,SE,2023,4
 103,CoffeeScript,programming,SE,2023,4
+27166,HTML,markup,SG,2023,4
+21095,CSS,markup,SG,2023,4
+7198,SCSS,markup,SG,2023,4
+5868,Jupyter Notebook,markup,SG,2023,4
+3349,Vue,markup,SG,2023,4
+1544,Less,markup,SG,2023,4
+1239,Roff,markup,SG,2023,4
+1143,TeX,markup,SG,2023,4
+734,EJS,markup,SG,2023,4
+630,Jinja,markup,SG,2023,4
+580,Handlebars,markup,SG,2023,4
+489,Mustache,markup,SG,2023,4
+337,Stylus,markup,SG,2023,4
+331,Pug,markup,SG,2023,4
+315,Svelte,markup,SG,2023,4
+288,Rich Text Format,markup,SG,2023,4
+240,Astro,markup,SG,2023,4
+238,Blade,markup,SG,2023,4
+159,Vim Snippet,markup,SG,2023,4
+134,Sass,markup,SG,2023,4
 24905,JavaScript,programming,SG,2023,4
 19982,Python,programming,SG,2023,4
 16246,Shell,programming,SG,2023,4
@@ -98432,12 +103189,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 237,GDB,programming,SG,2023,4
 228,QMake,programming,SG,2023,4
 226,Verilog,programming,SG,2023,4
-217,Raku,programming,SG,2023,4
 217,Fortran,programming,SG,2023,4
+217,Raku,programming,SG,2023,4
 206,Meson,programming,SG,2023,4
 205,NASL,programming,SG,2023,4
-199,NSIS,programming,SG,2023,4
 199,Pascal,programming,SG,2023,4
+199,NSIS,programming,SG,2023,4
 196,Thrift,programming,SG,2023,4
 194,SmPL,programming,SG,2023,4
 170,SWIG,programming,SG,2023,4
@@ -98448,8 +103205,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 160,GAP,programming,SG,2023,4
 159,SourcePawn,programming,SG,2023,4
 156,UnrealScript,programming,SG,2023,4
-153,PureBasic,programming,SG,2023,4
 153,CoffeeScript,programming,SG,2023,4
+153,PureBasic,programming,SG,2023,4
 151,PLSQL,programming,SG,2023,4
 141,DIGITAL Command Language,programming,SG,2023,4
 141,Julia,programming,SG,2023,4
@@ -98457,8 +103214,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,Scheme,programming,SG,2023,4
 131,Pawn,programming,SG,2023,4
 131,Jsonnet,programming,SG,2023,4
-130,Inno Setup,programming,SG,2023,4
 130,VBScript,programming,SG,2023,4
+130,Inno Setup,programming,SG,2023,4
 128,AppleScript,programming,SG,2023,4
 123,Mathematica,programming,SG,2023,4
 115,Smalltalk,programming,SG,2023,4
@@ -98467,6 +103224,12 @@ num_pushers,language,language_type,iso2_code,year,quarter
 107,Visual Basic .NET,programming,SG,2023,4
 105,VHDL,programming,SG,2023,4
 103,Common Lisp,programming,SG,2023,4
+1973,HTML,markup,SI,2023,4
+1663,CSS,markup,SI,2023,4
+430,SCSS,markup,SI,2023,4
+371,Jupyter Notebook,markup,SI,2023,4
+216,TeX,markup,SI,2023,4
+179,Vue,markup,SI,2023,4
 1853,JavaScript,programming,SI,2023,4
 1512,Python,programming,SI,2023,4
 1079,Shell,programming,SI,2023,4
@@ -98489,6 +103252,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Objective-C,programming,SI,2023,4
 117,Swift,programming,SI,2023,4
 111,PowerShell,programming,SI,2023,4
+3473,HTML,markup,SK,2023,4
+2966,CSS,markup,SK,2023,4
+792,SCSS,markup,SK,2023,4
+308,Vue,markup,SK,2023,4
+292,Jupyter Notebook,markup,SK,2023,4
+188,TeX,markup,SK,2023,4
+173,Blade,markup,SK,2023,4
+132,Roff,markup,SK,2023,4
+104,Jinja,markup,SK,2023,4
 3176,JavaScript,programming,SK,2023,4
 2051,Python,programming,SK,2023,4
 1747,Shell,programming,SK,2023,4
@@ -98517,7 +103289,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 117,Smarty,programming,SK,2023,4
 112,HLSL,programming,SK,2023,4
 107,ShaderLab,programming,SK,2023,4
+161,HTML,markup,SL,2023,4
+113,CSS,markup,SL,2023,4
 104,JavaScript,programming,SL,2023,4
+1640,HTML,markup,SN,2023,4
+1467,CSS,markup,SN,2023,4
+390,SCSS,markup,SN,2023,4
+319,Blade,markup,SN,2023,4
+121,Jupyter Notebook,markup,SN,2023,4
 1321,JavaScript,programming,SN,2023,4
 554,PHP,programming,SN,2023,4
 438,Java,programming,SN,2023,4
@@ -98530,18 +103309,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 128,C++,programming,SN,2023,4
 122,Kotlin,programming,SN,2023,4
 114,Objective-C,programming,SN,2023,4
-114,Dart,programming,SN,2023,4
 114,Swift,programming,SN,2023,4
+114,Dart,programming,SN,2023,4
 109,CMake,programming,SN,2023,4
+709,HTML,markup,SO,2023,4
+494,CSS,markup,SO,2023,4
 555,JavaScript,programming,SO,2023,4
 225,Dart,programming,SO,2023,4
-199,Kotlin,programming,SO,2023,4
 199,C,programming,SO,2023,4
+199,Kotlin,programming,SO,2023,4
 191,Swift,programming,SO,2023,4
 187,Objective-C,programming,SO,2023,4
 186,C++,programming,SO,2023,4
 173,CMake,programming,SO,2023,4
 109,Python,programming,SO,2023,4
+3044,HTML,markup,SV,2023,4
+2693,CSS,markup,SV,2023,4
+528,SCSS,markup,SV,2023,4
+388,Blade,markup,SV,2023,4
+199,Vue,markup,SV,2023,4
 2700,JavaScript,programming,SV,2023,4
 883,Java,programming,SV,2023,4
 833,PHP,programming,SV,2023,4
@@ -98561,6 +103347,10 @@ num_pushers,language,language_type,iso2_code,year,quarter
 150,Ruby,programming,SV,2023,4
 145,CMake,programming,SV,2023,4
 118,Batchfile,programming,SV,2023,4
+1246,HTML,markup,SY,2023,4
+1091,CSS,markup,SY,2023,4
+347,Blade,markup,SY,2023,4
+284,SCSS,markup,SY,2023,4
 1082,JavaScript,programming,SY,2023,4
 430,PHP,programming,SY,2023,4
 228,C++,programming,SY,2023,4
@@ -98575,12 +103365,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 146,C#,programming,SY,2023,4
 137,Java,programming,SY,2023,4
 103,Shell,programming,SY,2023,4
+528,HTML,markup,TG,2023,4
+463,CSS,markup,TG,2023,4
+137,SCSS,markup,TG,2023,4
 486,JavaScript,programming,TG,2023,4
 193,Python,programming,TG,2023,4
 150,PHP,programming,TG,2023,4
 143,TypeScript,programming,TG,2023,4
 122,Shell,programming,TG,2023,4
 104,C,programming,TG,2023,4
+18251,HTML,markup,TH,2023,4
+15144,CSS,markup,TH,2023,4
+2966,SCSS,markup,TH,2023,4
+2099,Jupyter Notebook,markup,TH,2023,4
+1777,Vue,markup,TH,2023,4
+717,Blade,markup,TH,2023,4
+549,EJS,markup,TH,2023,4
+513,Less,markup,TH,2023,4
+360,Svelte,markup,TH,2023,4
+317,Roff,markup,TH,2023,4
+235,TeX,markup,TH,2023,4
+224,Handlebars,markup,TH,2023,4
+216,Astro,markup,TH,2023,4
+164,Pug,markup,TH,2023,4
+153,Twig,markup,TH,2023,4
 16337,JavaScript,programming,TH,2023,4
 7562,Python,programming,TH,2023,4
 6042,TypeScript,programming,TH,2023,4
@@ -98603,8 +103411,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 1060,Batchfile,programming,TH,2023,4
 625,Lua,programming,TH,2023,4
 541,Rust,programming,TH,2023,4
-519,ShaderLab,programming,TH,2023,4
 519,HLSL,programming,TH,2023,4
+519,ShaderLab,programming,TH,2023,4
 518,PowerShell,programming,TH,2023,4
 380,R,programming,TH,2023,4
 367,Smarty,programming,TH,2023,4
@@ -98627,12 +103435,28 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,Mathematica,programming,TH,2023,4
 107,Cython,programming,TH,2023,4
 101,Groovy,programming,TH,2023,4
+466,HTML,markup,TJ,2023,4
+388,CSS,markup,TJ,2023,4
+108,SCSS,markup,TJ,2023,4
 377,JavaScript,programming,TJ,2023,4
 116,Python,programming,TJ,2023,4
 113,C#,programming,TJ,2023,4
 104,TypeScript,programming,TJ,2023,4
 101,PHP,programming,TJ,2023,4
+198,HTML,markup,TM,2023,4
+167,CSS,markup,TM,2023,4
 184,JavaScript,programming,TM,2023,4
+10218,HTML,markup,TN,2023,4
+8779,CSS,markup,TN,2023,4
+2293,SCSS,markup,TN,2023,4
+1080,Jupyter Notebook,markup,TN,2023,4
+740,Twig,markup,TN,2023,4
+490,Blade,markup,TN,2023,4
+276,Vue,markup,TN,2023,4
+262,Less,markup,TN,2023,4
+150,Roff,markup,TN,2023,4
+139,EJS,markup,TN,2023,4
+105,Handlebars,markup,TN,2023,4
 8451,JavaScript,programming,TN,2023,4
 5065,Java,programming,TN,2023,4
 3806,TypeScript,programming,TN,2023,4
@@ -98661,6 +103485,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 118,Gherkin,programming,TN,2023,4
 113,XSLT,programming,TN,2023,4
 111,Solidity,programming,TN,2023,4
+30337,HTML,markup,TR,2023,4
+24919,CSS,markup,TR,2023,4
+5883,SCSS,markup,TR,2023,4
+4187,Jupyter Notebook,markup,TR,2023,4
+1437,Vue,markup,TR,2023,4
+933,Less,markup,TR,2023,4
+800,Blade,markup,TR,2023,4
+670,EJS,markup,TR,2023,4
+607,Roff,markup,TR,2023,4
+436,Handlebars,markup,TR,2023,4
+434,TeX,markup,TR,2023,4
+324,Pug,markup,TR,2023,4
+270,Svelte,markup,TR,2023,4
+229,Jinja,markup,TR,2023,4
+184,Rich Text Format,markup,TR,2023,4
+173,Sass,markup,TR,2023,4
+165,Astro,markup,TR,2023,4
+159,Mustache,markup,TR,2023,4
+109,Twig,markup,TR,2023,4
 26765,JavaScript,programming,TR,2023,4
 14288,Python,programming,TR,2023,4
 10579,C#,programming,TR,2023,4
@@ -98714,14 +103557,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,Groovy,programming,TR,2023,4
 165,Meson,programming,TR,2023,4
 153,Awk,programming,TR,2023,4
-149,QMake,programming,TR,2023,4
 149,Lex,programming,TR,2023,4
+149,QMake,programming,TR,2023,4
 147,Emacs Lisp,programming,TR,2023,4
 144,Tcl,programming,TR,2023,4
 141,GDB,programming,TR,2023,4
 134,Fortran,programming,TR,2023,4
-129,Verilog,programming,TR,2023,4
 129,Scala,programming,TR,2023,4
+129,Verilog,programming,TR,2023,4
 128,Pascal,programming,TR,2023,4
 121,sed,programming,TR,2023,4
 118,Mako,programming,TR,2023,4
@@ -98731,9 +103574,30 @@ num_pushers,language,language_type,iso2_code,year,quarter
 106,NSIS,programming,TR,2023,4
 104,Haskell,programming,TR,2023,4
 104,Raku,programming,TR,2023,4
+326,HTML,markup,TT,2023,4
+241,CSS,markup,TT,2023,4
 311,JavaScript,programming,TT,2023,4
 216,Python,programming,TT,2023,4
 157,Shell,programming,TT,2023,4
+27128,HTML,markup,TW,2023,4
+20169,CSS,markup,TW,2023,4
+6171,SCSS,markup,TW,2023,4
+5315,Jupyter Notebook,markup,TW,2023,4
+3590,Vue,markup,TW,2023,4
+1051,Less,markup,TW,2023,4
+1043,TeX,markup,TW,2023,4
+954,Roff,markup,TW,2023,4
+730,EJS,markup,TW,2023,4
+508,Blade,markup,TW,2023,4
+439,Handlebars,markup,TW,2023,4
+387,Jinja,markup,TW,2023,4
+343,Pug,markup,TW,2023,4
+270,Sass,markup,TW,2023,4
+258,Mustache,markup,TW,2023,4
+256,Stylus,markup,TW,2023,4
+245,Svelte,markup,TW,2023,4
+230,Rich Text Format,markup,TW,2023,4
+199,Astro,markup,TW,2023,4
 23220,JavaScript,programming,TW,2023,4
 18424,Python,programming,TW,2023,4
 11999,Shell,programming,TW,2023,4
@@ -98786,8 +103650,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 307,Starlark,programming,TW,2023,4
 287,HCL,programming,TW,2023,4
 264,GDB,programming,TW,2023,4
-258,Pascal,programming,TW,2023,4
 258,Fortran,programming,TW,2023,4
+258,Pascal,programming,TW,2023,4
 246,Scala,programming,TW,2023,4
 236,Gherkin,programming,TW,2023,4
 235,Raku,programming,TW,2023,4
@@ -98801,8 +103665,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 182,Meson,programming,TW,2023,4
 176,SystemVerilog,programming,TW,2023,4
 175,SourcePawn,programming,TW,2023,4
-174,Forth,programming,TW,2023,4
 174,VHDL,programming,TW,2023,4
+174,Forth,programming,TW,2023,4
 170,XS,programming,TW,2023,4
 162,PLSQL,programming,TW,2023,4
 160,FreeMarker,programming,TW,2023,4
@@ -98813,19 +103677,23 @@ num_pushers,language,language_type,iso2_code,year,quarter
 156,NSIS,programming,TW,2023,4
 155,UnrealScript,programming,TW,2023,4
 148,Mako,programming,TW,2023,4
-143,Pawn,programming,TW,2023,4
 143,Haskell,programming,TW,2023,4
+143,Pawn,programming,TW,2023,4
 137,Processing,programming,TW,2023,4
 136,GAP,programming,TW,2023,4
 126,Julia,programming,TW,2023,4
 125,VBScript,programming,TW,2023,4
 117,Scheme,programming,TW,2023,4
 116,AIDL,programming,TW,2023,4
-109,QML,programming,TW,2023,4
 109,Common Lisp,programming,TW,2023,4
+109,QML,programming,TW,2023,4
 108,PureBasic,programming,TW,2023,4
 107,Ada,programming,TW,2023,4
 103,Gnuplot,programming,TW,2023,4
+1279,HTML,markup,TZ,2023,4
+1135,CSS,markup,TZ,2023,4
+321,SCSS,markup,TZ,2023,4
+175,Blade,markup,TZ,2023,4
 1146,JavaScript,programming,TZ,2023,4
 473,Python,programming,TZ,2023,4
 376,PHP,programming,TZ,2023,4
@@ -98841,6 +103709,25 @@ num_pushers,language,language_type,iso2_code,year,quarter
 143,Swift,programming,TZ,2023,4
 122,CMake,programming,TZ,2023,4
 119,Hack,programming,TZ,2023,4
+40363,HTML,markup,UA,2023,4
+32518,CSS,markup,UA,2023,4
+11186,SCSS,markup,UA,2023,4
+2134,Jupyter Notebook,markup,UA,2023,4
+2126,Vue,markup,UA,2023,4
+997,Blade,markup,UA,2023,4
+751,Handlebars,markup,UA,2023,4
+748,Less,markup,UA,2023,4
+573,Roff,markup,UA,2023,4
+530,Sass,markup,UA,2023,4
+420,EJS,markup,UA,2023,4
+380,Pug,markup,UA,2023,4
+367,Jinja,markup,UA,2023,4
+302,Twig,markup,UA,2023,4
+285,TeX,markup,UA,2023,4
+236,Mustache,markup,UA,2023,4
+215,Svelte,markup,UA,2023,4
+176,Rich Text Format,markup,UA,2023,4
+152,Liquid,markup,UA,2023,4
 34646,JavaScript,programming,UA,2023,4
 14605,Python,programming,UA,2023,4
 12666,TypeScript,programming,UA,2023,4
@@ -98890,11 +103777,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 199,Starlark,programming,UA,2023,4
 197,Yacc,programming,UA,2023,4
 182,Emacs Lisp,programming,UA,2023,4
-173,R,programming,UA,2023,4
 173,Haskell,programming,UA,2023,4
+173,R,programming,UA,2023,4
 173,Cython,programming,UA,2023,4
-164,MATLAB,programming,UA,2023,4
 164,ASP.NET,programming,UA,2023,4
+164,MATLAB,programming,UA,2023,4
 163,Lex,programming,UA,2023,4
 148,FreeMarker,programming,UA,2023,4
 134,Mathematica,programming,UA,2023,4
@@ -98908,6 +103795,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 111,Clojure,programming,UA,2023,4
 110,QML,programming,UA,2023,4
 101,GDScript,programming,UA,2023,4
+2789,HTML,markup,UG,2023,4
+2469,CSS,markup,UG,2023,4
+504,SCSS,markup,UG,2023,4
+321,Jupyter Notebook,markup,UG,2023,4
+135,Blade,markup,UG,2023,4
 2141,JavaScript,programming,UG,2023,4
 1195,Python,programming,UG,2023,4
 686,Shell,programming,UG,2023,4
@@ -98928,6 +103820,42 @@ num_pushers,language,language_type,iso2_code,year,quarter
 144,Assembly,programming,UG,2023,4
 129,Hack,programming,UG,2023,4
 118,PowerShell,programming,UG,2023,4
+752,YAML,data,US,2023,4
+616,JSON,data,US,2023,4
+114,SQL,data,US,2023,4
+428212,HTML,markup,US,2023,4
+352612,CSS,markup,US,2023,4
+105985,Jupyter Notebook,markup,US,2023,4
+87982,SCSS,markup,US,2023,4
+24996,TeX,markup,US,2023,4
+20480,Roff,markup,US,2023,4
+18098,Vue,markup,US,2023,4
+11395,Jinja,markup,US,2023,4
+11227,Less,markup,US,2023,4
+10029,Handlebars,markup,US,2023,4
+9721,EJS,markup,US,2023,4
+7589,Svelte,markup,US,2023,4
+6624,Mustache,markup,US,2023,4
+5536,Rich Text Format,markup,US,2023,4
+4573,Pug,markup,US,2023,4
+4021,Astro,markup,US,2023,4
+2933,Sass,markup,US,2023,4
+2519,Blade,markup,US,2023,4
+2042,Liquid,markup,US,2023,4
+1976,PostScript,markup,US,2023,4
+1877,Stylus,markup,US,2023,4
+1861,Nunjucks,markup,US,2023,4
+1595,Vim Snippet,markup,US,2023,4
+1475,Twig,markup,US,2023,4
+1096,Haml,markup,US,2023,4
+627,Mermaid,markup,US,2023,4
+536,YASnippet,markup,US,2023,4
+520,kvlang,markup,US,2023,4
+417,Slim,markup,US,2023,4
+271,Velocity Template Language,markup,US,2023,4
+265,StringTemplate,markup,US,2023,4
+219,Bikeshed,markup,US,2023,4
+200,RAML,markup,US,2023,4
 378906,JavaScript,programming,US,2023,4
 322098,Python,programming,US,2023,4
 226509,Shell,programming,US,2023,4
@@ -99077,8 +104005,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 644,Cap'n Proto,programming,US,2023,4
 641,Rebol,programming,US,2023,4
 639,Boogie,programming,US,2023,4
-638,Module Management System,programming,US,2023,4
 638,ReScript,programming,US,2023,4
+638,Module Management System,programming,US,2023,4
 630,Elvish,programming,US,2023,4
 584,Nextflow,programming,US,2023,4
 569,Game Maker Language,programming,US,2023,4
@@ -99102,8 +104030,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 435,V,programming,US,2023,4
 433,Ragel,programming,US,2023,4
 422,TLA,programming,US,2023,4
-409,EmberScript,programming,US,2023,4
 409,Euphoria,programming,US,2023,4
+409,EmberScript,programming,US,2023,4
 403,Limbo,programming,US,2023,4
 390,JetBrains MPS,programming,US,2023,4
 388,SMT,programming,US,2023,4
@@ -99132,8 +104060,8 @@ num_pushers,language,language_type,iso2_code,year,quarter
 262,YARA,programming,US,2023,4
 260,SaltStack,programming,US,2023,4
 258,LookML,programming,US,2023,4
-251,Move,programming,US,2023,4
 251,Clean,programming,US,2023,4
+251,Move,programming,US,2023,4
 246,Red,programming,US,2023,4
 238,Ink,programming,US,2023,4
 237,Qt Script,programming,US,2023,4
@@ -99156,13 +104084,13 @@ num_pushers,language,language_type,iso2_code,year,quarter
 181,Modula-3,programming,US,2023,4
 179,Common Workflow Language,programming,US,2023,4
 175,Monkey C,programming,US,2023,4
+174,Clarion,programming,US,2023,4
 174,GSC,programming,US,2023,4
 174,Berry,programming,US,2023,4
-174,Clarion,programming,US,2023,4
 173,AutoIt,programming,US,2023,4
 173,AngelScript,programming,US,2023,4
-172,LiveScript,programming,US,2023,4
 172,PigLatin,programming,US,2023,4
+172,LiveScript,programming,US,2023,4
 169,Nu,programming,US,2023,4
 169,REXX,programming,US,2023,4
 168,Odin,programming,US,2023,4
@@ -99178,9 +104106,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 151,Squirrel,programming,US,2023,4
 148,Smithy,programming,US,2023,4
 147,SQF,programming,US,2023,4
-146,J,programming,US,2023,4
-146,Nasal,programming,US,2023,4
 146,Hy,programming,US,2023,4
+146,Nasal,programming,US,2023,4
+146,J,programming,US,2023,4
 145,Cool,programming,US,2023,4
 145,Singularity,programming,US,2023,4
 144,Alloy,programming,US,2023,4
@@ -99200,11 +104128,11 @@ num_pushers,language,language_type,iso2_code,year,quarter
 121,Modelica,programming,US,2023,4
 121,Nearley,programming,US,2023,4
 120,Zeek,programming,US,2023,4
-120,LOLCODE,programming,US,2023,4
 120,PDDL,programming,US,2023,4
-119,GAMS,programming,US,2023,4
-119,F*,programming,US,2023,4
+120,LOLCODE,programming,US,2023,4
 119,ZAP,programming,US,2023,4
+119,F*,programming,US,2023,4
+119,GAMS,programming,US,2023,4
 117,Cairo,programming,US,2023,4
 116,Xtend,programming,US,2023,4
 115,Faust,programming,US,2023,4
@@ -99216,6 +104144,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 110,NetLogo,programming,US,2023,4
 105,Gleam,programming,US,2023,4
 101,KakouneScript,programming,US,2023,4
+1229,Markdown,prose,US,2023,4
+112,reStructuredText,prose,US,2023,4
+4166,HTML,markup,UY,2023,4
+3731,CSS,markup,UY,2023,4
+737,SCSS,markup,UY,2023,4
+283,Jupyter Notebook,markup,UY,2023,4
+142,Handlebars,markup,UY,2023,4
+110,Blade,markup,UY,2023,4
 4079,JavaScript,programming,UY,2023,4
 1105,Python,programming,UY,2023,4
 991,TypeScript,programming,UY,2023,4
@@ -99235,6 +104171,14 @@ num_pushers,language,language_type,iso2_code,year,quarter
 114,Swift,programming,UY,2023,4
 112,Hack,programming,UY,2023,4
 102,Go,programming,UY,2023,4
+10531,HTML,markup,UZ,2023,4
+8906,CSS,markup,UZ,2023,4
+2859,SCSS,markup,UZ,2023,4
+736,Vue,markup,UZ,2023,4
+369,Blade,markup,UZ,2023,4
+310,Jupyter Notebook,markup,UZ,2023,4
+183,Less,markup,UZ,2023,4
+133,Handlebars,markup,UZ,2023,4
 7826,JavaScript,programming,UZ,2023,4
 3423,Python,programming,UZ,2023,4
 1743,TypeScript,programming,UZ,2023,4
@@ -99257,6 +104201,15 @@ num_pushers,language,language_type,iso2_code,year,quarter
 302,Go,programming,UZ,2023,4
 248,Procfile,programming,UZ,2023,4
 142,Hack,programming,UZ,2023,4
+4699,HTML,markup,VE,2023,4
+4390,CSS,markup,VE,2023,4
+982,SCSS,markup,VE,2023,4
+401,Blade,markup,VE,2023,4
+320,Vue,markup,VE,2023,4
+199,Jupyter Notebook,markup,VE,2023,4
+161,EJS,markup,VE,2023,4
+118,Astro,markup,VE,2023,4
+115,Less,markup,VE,2023,4
 4778,JavaScript,programming,VE,2023,4
 1600,TypeScript,programming,VE,2023,4
 1522,Python,programming,VE,2023,4
@@ -99280,6 +104233,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 127,PowerShell,programming,VE,2023,4
 125,Go,programming,VE,2023,4
 120,Procfile,programming,VE,2023,4
+61865,HTML,markup,VN,2023,4
+57158,CSS,markup,VN,2023,4
+19975,SCSS,markup,VN,2023,4
+6114,Jupyter Notebook,markup,VN,2023,4
+4510,Less,markup,VN,2023,4
+4093,Blade,markup,VN,2023,4
+3357,Vue,markup,VN,2023,4
+2460,EJS,markup,VN,2023,4
+2188,Handlebars,markup,VN,2023,4
+830,Pug,markup,VN,2023,4
+801,Roff,markup,VN,2023,4
+782,TeX,markup,VN,2023,4
+362,Svelte,markup,VN,2023,4
+344,Jinja,markup,VN,2023,4
+298,Sass,markup,VN,2023,4
+283,Mustache,markup,VN,2023,4
+249,Rich Text Format,markup,VN,2023,4
+184,Astro,markup,VN,2023,4
+164,Twig,markup,VN,2023,4
+120,Liquid,markup,VN,2023,4
+111,PostScript,markup,VN,2023,4
 62254,JavaScript,programming,VN,2023,4
 22499,Java,programming,VN,2023,4
 19286,Python,programming,VN,2023,4
@@ -99332,9 +104306,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 201,Raku,programming,VN,2023,4
 199,Mathematica,programming,VN,2023,4
 192,NSIS,programming,VN,2023,4
-191,Scala,programming,VN,2023,4
-191,CoffeeScript,programming,VN,2023,4
 191,Awk,programming,VN,2023,4
+191,CoffeeScript,programming,VN,2023,4
+191,Scala,programming,VN,2023,4
 184,Fortran,programming,VN,2023,4
 180,Tcl,programming,VN,2023,4
 177,PureBasic,programming,VN,2023,4
@@ -99342,24 +104316,27 @@ num_pushers,language,language_type,iso2_code,year,quarter
 171,Pascal,programming,VN,2023,4
 160,Emacs Lisp,programming,VN,2023,4
 154,Meson,programming,VN,2023,4
-152,Clojure,programming,VN,2023,4
 152,GAP,programming,VN,2023,4
+152,Clojure,programming,VN,2023,4
 150,QMake,programming,VN,2023,4
-148,FreeMarker,programming,VN,2023,4
 148,Forth,programming,VN,2023,4
+148,FreeMarker,programming,VN,2023,4
 139,AIDL,programming,VN,2023,4
 137,Verilog,programming,VN,2023,4
 134,Lex,programming,VN,2023,4
 133,PLSQL,programming,VN,2023,4
-122,Elixir,programming,VN,2023,4
 122,VBScript,programming,VN,2023,4
+122,Elixir,programming,VN,2023,4
 119,sed,programming,VN,2023,4
 113,GDB,programming,VN,2023,4
-109,Visual Basic .NET,programming,VN,2023,4
-109,GDScript,programming,VN,2023,4
 109,Haskell,programming,VN,2023,4
-105,Classic ASP,programming,VN,2023,4
+109,GDScript,programming,VN,2023,4
+109,Visual Basic .NET,programming,VN,2023,4
 105,Scheme,programming,VN,2023,4
+105,Classic ASP,programming,VN,2023,4
+1526,HTML,markup,XK,2023,4
+1397,CSS,markup,XK,2023,4
+180,SCSS,markup,XK,2023,4
 1212,JavaScript,programming,XK,2023,4
 229,TypeScript,programming,XK,2023,4
 201,PHP,programming,XK,2023,4
@@ -99367,6 +104344,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 174,Python,programming,XK,2023,4
 161,Java,programming,XK,2023,4
 101,Dockerfile,programming,XK,2023,4
+960,HTML,markup,YE,2023,4
+748,CSS,markup,YE,2023,4
+164,SCSS,markup,YE,2023,4
 704,JavaScript,programming,YE,2023,4
 303,Python,programming,YE,2023,4
 244,Dart,programming,YE,2023,4
@@ -99382,6 +104362,19 @@ num_pushers,language,language_type,iso2_code,year,quarter
 133,C#,programming,YE,2023,4
 115,Dockerfile,programming,YE,2023,4
 111,TypeScript,programming,YE,2023,4
+12015,HTML,markup,ZA,2023,4
+10373,CSS,markup,ZA,2023,4
+2059,SCSS,markup,ZA,2023,4
+1371,Jupyter Notebook,markup,ZA,2023,4
+438,Vue,markup,ZA,2023,4
+275,TeX,markup,ZA,2023,4
+263,Less,markup,ZA,2023,4
+223,Roff,markup,ZA,2023,4
+201,EJS,markup,ZA,2023,4
+193,Blade,markup,ZA,2023,4
+159,Handlebars,markup,ZA,2023,4
+148,Svelte,markup,ZA,2023,4
+114,Jinja,markup,ZA,2023,4
 10554,JavaScript,programming,ZA,2023,4
 5340,Python,programming,ZA,2023,4
 4396,Shell,programming,ZA,2023,4
@@ -99427,6 +104420,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 122,GLSL,programming,ZA,2023,4
 110,Gherkin,programming,ZA,2023,4
 107,Forth,programming,ZA,2023,4
+654,HTML,markup,ZM,2023,4
+587,CSS,markup,ZM,2023,4
+108,SCSS,markup,ZM,2023,4
 610,JavaScript,programming,ZM,2023,4
 255,Python,programming,ZM,2023,4
 159,PHP,programming,ZM,2023,4
@@ -99434,6 +104430,9 @@ num_pushers,language,language_type,iso2_code,year,quarter
 145,TypeScript,programming,ZM,2023,4
 128,C,programming,ZM,2023,4
 102,Java,programming,ZM,2023,4
+819,HTML,markup,ZW,2023,4
+761,CSS,markup,ZW,2023,4
+176,SCSS,markup,ZW,2023,4
 774,JavaScript,programming,ZW,2023,4
 391,Python,programming,ZW,2023,4
 247,Shell,programming,ZW,2023,4


### PR DESCRIPTION
This pull request adds data for languages other than those of type `programming`, as those were inadvertently omitted from the dataset after Q1 2023. Thanks to @alexanderquispe for reporting!